### PR TITLE
Fix miscounting the number of parameters when an issue is recorded.

### DIFF
--- a/Sources/Testing/Events/Event.Recorder.swift
+++ b/Sources/Testing/Events/Event.Recorder.swift
@@ -530,6 +530,11 @@ extension Event.Recorder {
           context.testData.insertValue(testData, at: id)
         }
       }
+      let parameterCount = if let parameters = event.test?.parameters {
+        parameters.count
+      } else {
+        0
+      }
       let labeledArguments = if let testCase = event.testCase, let parameters = event.test?.parameters {
         testCase.labeledArguments(using: parameters)
       } else {
@@ -557,10 +562,10 @@ extension Event.Recorder {
       }
 
       let atSourceLocation = issue.sourceLocation.map { " at \($0)" } ?? ""
-      if labeledArguments.isEmpty {
+      if parameterCount == 0 {
         return "\(symbol) Test \(testName) recorded a\(known) issue\(atSourceLocation): \(issue.kind)\(difference)\(issueComments)\n"
       } else {
-        return "\(symbol) Test \(testName) recorded a\(known) issue with \(labeledArguments.count.counting("argument")) \(labeledArguments)\(atSourceLocation): \(issue.kind)\(difference)\(issueComments)\n"
+        return "\(symbol) Test \(testName) recorded a\(known) issue with \(parameterCount.counting("argument")) \(labeledArguments)\(atSourceLocation): \(issue.kind)\(difference)\(issueComments)\n"
       }
 
     case .testCaseStarted:


### PR DESCRIPTION
We're accidentally reporting the number of characters in the string representation of each argument as the number of arguments.

For example, with a 1-arg function, we're currently emitting something like:

```
✘ Test f(i:) recorded an issue with 6 arguments i → 10 at fooTests.swift:13:3: Expectation failed: (i → 10) < 10
```

When we should be emitting:

```
✘ Test f(i:) recorded an issue with 1 argument i → 10 at fooTests.swift:13:3: Expectation failed: (i → 10) < 10
```