### PR TITLE
Fix single typo in markdown

### DIFF
--- a/Sources/Testing/Testing.docc/OrganizingTests.md
+++ b/Sources/Testing/Testing.docc/OrganizingTests.md
@@ -79,7 +79,7 @@ Are equivalent to:
 }
 ```
 
-## Constraits on test suite types
+## Constraints on test suite types
 
 If a type is used as a test suite, it is subject to some constraints that are
 not otherwise applied to Swift types.


### PR DESCRIPTION
Fix single typo in markdown

### Motivation:

We dislike typos.

### Modifications:

Change `"Constraits"` -> `"Constraints"`

### Result:

Not a single typo in the project (I've checked all files).
