### PR TITLE
Add CI icons to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ concurrency, and parameterize test functions across wide ranges of inputs.
 The table below describes the current level of support that `swift-testing` has
 for various platforms:
 
-| **Platform** | **Status** |
-|---|---|
-| **macOS** | [![Build Status](https://ci.swift.org/buildStatus/icon?job=pr-swift-testing-macos)](https://ci.swift.org/job/pr-swift-testing-macos/) |
-| **iOS** | Supported |
-| **watchOS** | Supported |
-| **tvOS** | Supported |
-| **Ubuntu 22.04** | [![Build Status](https://ci.swift.org/buildStatus/icon?job=pr-swift-testing-linux-main)](https://ci.swift.org/job/pr-swift-testing-linux-main/) |
-| **Windows** | Pending support for macros |
+| **Platform** | **CI Status** | **Support Status** |
+|-|:-:|-|
+| **macOS** | [![Build Status](https://ci.swift.org/buildStatus/icon?job=pr-swift-testing-macos)](https://ci.swift.org/job/pr-swift-testing-macos/) | Supported |
+| **iOS** | | Supported |
+| **watchOS** | | Supported |
+| **tvOS** | | Supported |
+| **Ubuntu 22.04** | [![Build Status](https://ci.swift.org/buildStatus/icon?job=pr-swift-testing-linux-main)](https://ci.swift.org/job/pr-swift-testing-linux-main/) | Supported |
+| **Windows** | | Pending support for macros |
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ for various platforms:
 
 | **Platform** | **CI Status** | **Support Status** |
 |-|:-:|-|
-| **macOS** | [![Build Status](https://ci.swift.org/buildStatus/icon?job=pr-swift-testing-macos)](https://ci.swift.org/job/pr-swift-testing-macos/) | Supported |
+| **macOS** | [![Build Status](https://ci.swift.org/buildStatus/icon?job=swift-testing-main-swift-5.10-macos)](https://ci.swift.org/job/swift-testing-main-swift-5.10-macos/) | Supported |
 | **iOS** | | Supported |
 | **watchOS** | | Supported |
 | **tvOS** | | Supported |
-| **Ubuntu 22.04** | [![Build Status](https://ci.swift.org/buildStatus/icon?job=pr-swift-testing-linux-main)](https://ci.swift.org/job/pr-swift-testing-linux-main/) | Supported |
+| **Ubuntu 22.04** | [![Build Status](https://ci.swift.org/buildStatus/icon?job=swift-testing-main-swift-5.10-linux)](https://ci.swift.org/job/swift-testing-main-swift-5.10-linux/) | Supported |
 | **Windows** | | Pending support for macros |
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ for various platforms:
 
 | **Platform** | **Status** |
 |---|---|
-| **macOS** | Supported |
+| **macOS** | [![Build Status](https://ci.swift.org/buildStatus/icon?job=pr-swift-testing-macos)](https://ci.swift.org/job/pr-swift-testing-macos/) |
 | **iOS** | Supported |
 | **watchOS** | Supported |
 | **tvOS** | Supported |
-| **Ubuntu 22.04** | Supported |
+| **Ubuntu 22.04** | [![Build Status](https://ci.swift.org/buildStatus/icon?job=pr-swift-testing-linux-main)](https://ci.swift.org/job/pr-swift-testing-linux-main/) |
 | **Windows** | Pending support for macros |
 
 ## Documentation


### PR DESCRIPTION
Add CI icons to the readme (using PR jobs for now.)

### Motivation:

CI icons provide at-a-glance status information about supported platforms.

### Modifications:

Modifies the README file to include Jenkins CI icons for macOS and Linux jobs.

### Result:

Build icons will appear in the supported platforms table for macOS and Linux.

Looks like:

<img width="523" alt="Screenshot 2023-09-22 at 10 25 42 AM" src="https://github.com/apple/swift-testing/assets/4145863/406cc36f-e30e-4720-b897-92bc52549cb0">

Resolves rdar://115073005.
