### PR TITLE
Enable the `parameterizedConsuming()` canary test function.

### DIFF
--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -95,13 +95,11 @@ struct SendableTests: Sendable {
   @Test(.hidden, arguments: FixtureData.zeroUpTo100)
   func parameterizedBorrowingAsync(i: borrowing Int) async {}
 
-#if FIXED_112795074
   @Test(.hidden, arguments: FixtureData.zeroUpTo100)
   func parameterizedConsuming(i: consuming Int) {}
 
   @Test(.hidden, arguments: FixtureData.zeroUpTo100)
   func parameterizedConsumingAsync(i: consuming Int) async { }
-#endif
 }
 
 @Suite("Named Sendable test type", .hidden)


### PR DESCRIPTION
Enable the `parameterizedConsuming()` canary test function.

### Motivation:

The function in question was disabled due to a compiler bug tracked by rdar://112795074. That bug has been fixed, so we can reenable this function.

### Modifications:

Enables a disabled function that tests we produce valid output for a parameterized consuming test function.

### Result:

Better test coverage.