### PR TITLE
[DO NOT MERGE] Check environment variables in Swift-CI

### DIFF
--- a/Tests/TestingTests/ZipTests.swift
+++ b/Tests/TestingTests/ZipTests.swift
@@ -25,3 +25,9 @@ struct ZipTests {
     #expect(i == j)
   }
 }
+
+import Foundation
+
+@Test func whatEnvironmentVariablesAreAvailableInSwiftCI() {
+  dump(ProcessInfo.processInfo.environment)
+}


### PR DESCRIPTION
Checking the configuration of Swift-CI to make sure it's compatible with `XCTestScaffold`.