### PR TITLE
Update .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -4,3 +4,4 @@ metadata:
 builder:
   configs:
     - documentation_targets: [Testing]
+      swift_version: 5.9


### PR DESCRIPTION
This opts doc generation in to running with 5.9. We're building with the latest release (at the moment still 5.8 - until next week), which fails for this package since it's 5.9+.

The `swift_version` can be removed after we update to 5.9 as the latest release.