### PR TITLE
Fixed 404 Error: Updated Link to `CONTRIBUTING.md` in `TemporaryGettingStarted.md`

### DIFF
--- a/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
+++ b/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
@@ -26,7 +26,7 @@ their Swift packages.
   removed in a future release.
 
 To learn how to contribute to the testing library itself, see
-[Contributing to `swift-testing`](https://github.com/apple/swift-testing/CONTRIBUTING.md).
+[Contributing to `swift-testing`](https://github.com/apple/swift-testing/blob/main/CONTRIBUTING.md).
 
 ### Downloading a development toolchain
 


### PR DESCRIPTION
Fix broken link to `CONTRIBUTING.md` in `TemporaryGettingStarted.md`

### Motivation:

The link to the `CONTRIBUTING.md` file in the `TemporaryGettingStarted.md` document is incorrect, which leads to a 404 Not Found error when attempted to access. 

### Modifications:

Updated the incorrect link from `https://github.com/apple/swift-testing/CONTRIBUTING.md` to `https://github.com/apple/swift-testing/blob/main/CONTRIBUTING.md` in the `TemporaryGettingStarted.md` document.

### Result:

With this change, users will be directed to the correct `CONTRIBUTING.md` file when they click the link in T`emporaryGettingStarted.md`, ensuring they have access to the necessary contributing guidelines.

