### PR TITLE
#expect(throws:) expression should accept non-Void return type and describe returned values

### DIFF
--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -83,7 +83,8 @@
 ///
 /// If `expression` does not throw an error, or if it throws an error that is
 /// not an instance of `errorType`, an ``Issue`` is recorded for the test that
-/// is running in the current task.
+/// is running in the current task. Any value returned by `expression` is
+/// discarded.
 ///
 /// If the thrown error need only equal another instance of [`Error`](https://developer.apple.com/documentation/swift/error),
 /// use ``expect(throws:_:performing:)-1s3lx`` instead. If `expression` should
@@ -111,7 +112,8 @@
 /// ```
 ///
 /// If `expression` throws an error, an ``Issue`` is recorded for the test that
-/// is running in the current task.
+/// is running in the current task. Any value returned by `expression` is
+/// discarded.
 ///
 /// Test functions can be annotated with `throws` and can throw errors which are
 /// then recorded as [issues](doc:Issues) when the test runs. If the intent is
@@ -156,7 +158,7 @@
 /// If `expression` does not throw an error, or if it throws an error that is
 /// not an instance of `errorType`, an ``Issue`` is recorded for the test that
 /// is running in the current task and an instance of ``ExpectationFailedError``
-/// is thrown.
+/// is thrown. Any value returned by `expression` is discarded.
 ///
 /// If the thrown error need only equal another instance of [`Error`](https://developer.apple.com/documentation/swift/error),
 /// use ``require(throws:_:performing:)-84jir`` instead.
@@ -206,7 +208,7 @@
 ///
 /// If `expression` does not throw an error, or if it throws an error that is
 /// not equal to `error`, an ``Issue`` is recorded for the test that is running
-/// in the current task.
+/// in the current task. Any value returned by `expression` is discarded.
 ///
 /// If the thrown error need only be an instance of a particular type, use
 /// ``expect(throws:_:performing:)-2j0od`` instead. If `expression` should
@@ -241,6 +243,7 @@
 /// If `expression` does not throw an error, or if it throws an error that is
 /// not equal to `error`, an ``Issue`` is recorded for the test that is running
 /// in the current task and an instance of ``ExpectationFailedError`` is thrown.
+/// Any value returned by `expression` is discarded.
 ///
 /// If the thrown error need only be an instance of a particular type, use
 /// ``require(throws:_:performing:)-8762f`` instead.
@@ -276,7 +279,8 @@
 /// If `expression` does not throw an error, if it throws an error that is
 /// not matched by `errorMatcher`, or if `errorMatcher` throws an error
 /// (including the error passed to it), an ``Issue`` is recorded for the test
-/// that is running in the current task.
+/// that is running in the current task. Any value returned by `expression` is
+/// discarded.
 ///
 /// If the thrown error need only be an instance of a particular type, use
 /// ``expect(throws:_:performing:)-2j0od`` instead. If the thrown error need
@@ -318,7 +322,8 @@
 /// not matched by `errorMatcher`, or if `errorMatcher` throws an error
 /// (including the error passed to it), an ``Issue`` is recorded for the test
 /// that is running in the current task and an instance of
-/// ``ExpectationFailedError`` is thrown.
+/// ``ExpectationFailedError`` is thrown. Any value returned by `expression` is
+/// discarded.
 ///
 /// If the thrown error need only be an instance of a particular type, use
 /// ``require(throws:_:performing:)-8762f`` instead. If the thrown error need

--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -88,10 +88,10 @@
 /// If the thrown error need only equal another instance of [`Error`](https://developer.apple.com/documentation/swift/error),
 /// use ``expect(throws:_:performing:)-1s3lx`` instead. If `expression` should
 /// _never_ throw any error, use ``expect(throws:_:performing:)-jtjw`` instead.
-@freestanding(expression) public macro expect<E>(
+@freestanding(expression) public macro expect<E, R>(
   throws errorType: E.Type,
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> Any
+  performing expression: () async throws -> R
 ) = #externalMacro(module: "TestingMacros", type: "ExpectMacro") where E: Error
 
 /// Check that an expression never throws an error.
@@ -124,10 +124,10 @@
 /// ``expect(throws:_:performing:)-2j0od`` instead. If the thrown error need
 /// only equal another instance of [`Error`](https://developer.apple.com/documentation/swift/error),
 /// use ``expect(throws:_:performing:)-1s3lx`` instead.
-@freestanding(expression) public macro expect(
+@freestanding(expression) public macro expect<R>(
   throws _: Never.Type,
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> Any
+  performing expression: () async throws -> R
 ) = #externalMacro(module: "TestingMacros", type: "ExpectMacro")
 
 /// Check that an expression always throws an error of a given type, and throw
@@ -163,10 +163,10 @@
 ///
 /// If `expression` should _never_ throw, simply invoke the code without using
 /// this macro. The test will then fail if an error is thrown.
-@freestanding(expression) public macro require<E>(
+@freestanding(expression) public macro require<E, R>(
   throws errorType: E.Type,
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> Any
+  performing expression: () async throws -> R
 ) = #externalMacro(module: "TestingMacros", type: "RequireMacro") where E: Error
 
 /// Check that an expression never throws an error, and throw an error if it
@@ -179,10 +179,10 @@
 /// - Throws: An instance of ``ExpectationFailedError`` if `expression` throws
 ///   any error. The error thrown by `expression` is not rethrown.
 @available(*, deprecated, message: "try #require(throws: Never.self) is redundant. Invoke non-throwing test code directly instead.")
-@freestanding(expression) public macro require(
+@freestanding(expression) public macro require<R>(
   throws _: Never.Type,
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> Any
+  performing expression: () async throws -> R
 ) = #externalMacro(module: "TestingMacros", type: "RequireMacro")
 
 // MARK: - Matching instances of equatable errors
@@ -211,10 +211,10 @@
 /// If the thrown error need only be an instance of a particular type, use
 /// ``expect(throws:_:performing:)-2j0od`` instead. If `expression` should
 /// _never_ throw any error, use ``expect(throws:_:performing:)-jtjw`` instead.
-@freestanding(expression) public macro expect<E>(
+@freestanding(expression) public macro expect<E, R>(
   throws error: E,
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> Any
+  performing expression: () async throws -> R
 ) = #externalMacro(module: "TestingMacros", type: "ExpectMacro") where E: Error & Equatable
 
 /// Check that an expression always throws a specific error, and throw an error
@@ -244,10 +244,10 @@
 ///
 /// If the thrown error need only be an instance of a particular type, use
 /// ``require(throws:_:performing:)-8762f`` instead.
-@freestanding(expression) public macro require<E>(
+@freestanding(expression) public macro require<E, R>(
   throws error: E,
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> Any
+  performing expression: () async throws -> R
 ) = #externalMacro(module: "TestingMacros", type: "RequireMacro") where E: Error & Equatable
 
 // MARK: - Arbitrary error matching
@@ -283,9 +283,9 @@
 /// only equal another instance of [`Error`](https://developer.apple.com/documentation/swift/error),
 /// use ``expect(throws:_:performing:)-1s3lx`` instead. If an error should
 /// _never_ be thrown, use ``expect(throws:_:performing:)-jtjw`` instead.
-@freestanding(expression) public macro expect(
+@freestanding(expression) public macro expect<R>(
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> Any,
+  performing expression: () async throws -> R,
   throws errorMatcher: (any Error) async throws -> Bool
 ) = #externalMacro(module: "TestingMacros", type: "ExpectMacro")
 
@@ -327,8 +327,8 @@
 ///
 /// If `expression` should _never_ throw, simply invoke the code without using
 /// this macro. The test will then fail if an error is thrown.
-@freestanding(expression) public macro require(
+@freestanding(expression) public macro require<R>(
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> Any,
+  performing expression: () async throws -> R,
   throws errorMatcher: (any Error) async throws -> Bool
 ) = #externalMacro(module: "TestingMacros", type: "RequireMacro")

--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -88,10 +88,10 @@
 /// If the thrown error need only equal another instance of [`Error`](https://developer.apple.com/documentation/swift/error),
 /// use ``expect(throws:_:performing:)-1s3lx`` instead. If `expression` should
 /// _never_ throw any error, use ``expect(throws:_:performing:)-jtjw`` instead.
-@freestanding(expression) public macro expect<E>(
+@freestanding(expression) public macro expect<E, T>(
   throws errorType: E.Type,
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> Void
+  performing expression: () async throws -> T
 ) = #externalMacro(module: "TestingMacros", type: "ExpectMacro") where E: Error
 
 /// Check that an expression never throws an error.
@@ -124,10 +124,10 @@
 /// ``expect(throws:_:performing:)-2j0od`` instead. If the thrown error need
 /// only equal another instance of [`Error`](https://developer.apple.com/documentation/swift/error),
 /// use ``expect(throws:_:performing:)-1s3lx`` instead.
-@freestanding(expression) public macro expect(
+@freestanding(expression) public macro expect<T>(
   throws _: Never.Type,
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> Void
+  performing expression: () async throws -> T
 ) = #externalMacro(module: "TestingMacros", type: "ExpectMacro")
 
 /// Check that an expression always throws an error of a given type, and throw
@@ -163,10 +163,10 @@
 ///
 /// If `expression` should _never_ throw, simply invoke the code without using
 /// this macro. The test will then fail if an error is thrown.
-@freestanding(expression) public macro require<E>(
+@freestanding(expression) public macro require<E, T>(
   throws errorType: E.Type,
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> Void
+  performing expression: () async throws -> T
 ) = #externalMacro(module: "TestingMacros", type: "RequireMacro") where E: Error
 
 /// Check that an expression never throws an error, and throw an error if it
@@ -179,10 +179,10 @@
 /// - Throws: An instance of ``ExpectationFailedError`` if `expression` throws
 ///   any error. The error thrown by `expression` is not rethrown.
 @available(*, deprecated, message: "try #require(throws: Never.self) is redundant. Invoke non-throwing test code directly instead.")
-@freestanding(expression) public macro require(
+@freestanding(expression) public macro require<T>(
   throws _: Never.Type,
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> Void
+  performing expression: () async throws -> T
 ) = #externalMacro(module: "TestingMacros", type: "RequireMacro")
 
 // MARK: - Matching instances of equatable errors
@@ -211,10 +211,10 @@
 /// If the thrown error need only be an instance of a particular type, use
 /// ``expect(throws:_:performing:)-2j0od`` instead. If `expression` should
 /// _never_ throw any error, use ``expect(throws:_:performing:)-jtjw`` instead.
-@freestanding(expression) public macro expect<E>(
+@freestanding(expression) public macro expect<E, T>(
   throws error: E,
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> Void
+  performing expression: () async throws -> T
 ) = #externalMacro(module: "TestingMacros", type: "ExpectMacro") where E: Error & Equatable
 
 /// Check that an expression always throws a specific error, and throw an error
@@ -244,10 +244,10 @@
 ///
 /// If the thrown error need only be an instance of a particular type, use
 /// ``require(throws:_:performing:)-8762f`` instead.
-@freestanding(expression) public macro require<E>(
+@freestanding(expression) public macro require<E, T>(
   throws error: E,
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> Void
+  performing expression: () async throws -> T
 ) = #externalMacro(module: "TestingMacros", type: "RequireMacro") where E: Error & Equatable
 
 // MARK: - Arbitrary error matching
@@ -283,9 +283,9 @@
 /// only equal another instance of [`Error`](https://developer.apple.com/documentation/swift/error),
 /// use ``expect(throws:_:performing:)-1s3lx`` instead. If an error should
 /// _never_ be thrown, use ``expect(throws:_:performing:)-jtjw`` instead.
-@freestanding(expression) public macro expect(
+@freestanding(expression) public macro expect<T>(
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> Void,
+  performing expression: () async throws -> T,
   throws errorMatcher: (any Error) async throws -> Bool
 ) = #externalMacro(module: "TestingMacros", type: "ExpectMacro")
 
@@ -327,8 +327,8 @@
 ///
 /// If `expression` should _never_ throw, simply invoke the code without using
 /// this macro. The test will then fail if an error is thrown.
-@freestanding(expression) public macro require(
+@freestanding(expression) public macro require<T>(
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> Void,
+  performing expression: () async throws -> T,
   throws errorMatcher: (any Error) async throws -> Bool
 ) = #externalMacro(module: "TestingMacros", type: "RequireMacro")

--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -88,10 +88,10 @@
 /// If the thrown error need only equal another instance of [`Error`](https://developer.apple.com/documentation/swift/error),
 /// use ``expect(throws:_:performing:)-1s3lx`` instead. If `expression` should
 /// _never_ throw any error, use ``expect(throws:_:performing:)-jtjw`` instead.
-@freestanding(expression) public macro expect<E, T>(
+@freestanding(expression) public macro expect<E>(
   throws errorType: E.Type,
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> T
+  performing expression: () async throws -> Any
 ) = #externalMacro(module: "TestingMacros", type: "ExpectMacro") where E: Error
 
 /// Check that an expression never throws an error.
@@ -124,10 +124,10 @@
 /// ``expect(throws:_:performing:)-2j0od`` instead. If the thrown error need
 /// only equal another instance of [`Error`](https://developer.apple.com/documentation/swift/error),
 /// use ``expect(throws:_:performing:)-1s3lx`` instead.
-@freestanding(expression) public macro expect<T>(
+@freestanding(expression) public macro expect(
   throws _: Never.Type,
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> T
+  performing expression: () async throws -> Any
 ) = #externalMacro(module: "TestingMacros", type: "ExpectMacro")
 
 /// Check that an expression always throws an error of a given type, and throw
@@ -163,10 +163,10 @@
 ///
 /// If `expression` should _never_ throw, simply invoke the code without using
 /// this macro. The test will then fail if an error is thrown.
-@freestanding(expression) public macro require<E, T>(
+@freestanding(expression) public macro require<E>(
   throws errorType: E.Type,
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> T
+  performing expression: () async throws -> Any
 ) = #externalMacro(module: "TestingMacros", type: "RequireMacro") where E: Error
 
 /// Check that an expression never throws an error, and throw an error if it
@@ -179,10 +179,10 @@
 /// - Throws: An instance of ``ExpectationFailedError`` if `expression` throws
 ///   any error. The error thrown by `expression` is not rethrown.
 @available(*, deprecated, message: "try #require(throws: Never.self) is redundant. Invoke non-throwing test code directly instead.")
-@freestanding(expression) public macro require<T>(
+@freestanding(expression) public macro require(
   throws _: Never.Type,
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> T
+  performing expression: () async throws -> Any
 ) = #externalMacro(module: "TestingMacros", type: "RequireMacro")
 
 // MARK: - Matching instances of equatable errors
@@ -211,10 +211,10 @@
 /// If the thrown error need only be an instance of a particular type, use
 /// ``expect(throws:_:performing:)-2j0od`` instead. If `expression` should
 /// _never_ throw any error, use ``expect(throws:_:performing:)-jtjw`` instead.
-@freestanding(expression) public macro expect<E, T>(
+@freestanding(expression) public macro expect<E>(
   throws error: E,
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> T
+  performing expression: () async throws -> Any
 ) = #externalMacro(module: "TestingMacros", type: "ExpectMacro") where E: Error & Equatable
 
 /// Check that an expression always throws a specific error, and throw an error
@@ -244,10 +244,10 @@
 ///
 /// If the thrown error need only be an instance of a particular type, use
 /// ``require(throws:_:performing:)-8762f`` instead.
-@freestanding(expression) public macro require<E, T>(
+@freestanding(expression) public macro require<E>(
   throws error: E,
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> T
+  performing expression: () async throws -> Any
 ) = #externalMacro(module: "TestingMacros", type: "RequireMacro") where E: Error & Equatable
 
 // MARK: - Arbitrary error matching
@@ -283,9 +283,9 @@
 /// only equal another instance of [`Error`](https://developer.apple.com/documentation/swift/error),
 /// use ``expect(throws:_:performing:)-1s3lx`` instead. If an error should
 /// _never_ be thrown, use ``expect(throws:_:performing:)-jtjw`` instead.
-@freestanding(expression) public macro expect<T>(
+@freestanding(expression) public macro expect(
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> T,
+  performing expression: () async throws -> Any,
   throws errorMatcher: (any Error) async throws -> Bool
 ) = #externalMacro(module: "TestingMacros", type: "ExpectMacro")
 
@@ -327,8 +327,8 @@
 ///
 /// If `expression` should _never_ throw, simply invoke the code without using
 /// this macro. The test will then fail if an error is thrown.
-@freestanding(expression) public macro require<T>(
+@freestanding(expression) public macro require(
   _ comment: @autoclosure () -> Comment? = nil,
-  performing expression: () async throws -> T,
+  performing expression: () async throws -> Any,
   throws errorMatcher: (any Error) async throws -> Bool
 ) = #externalMacro(module: "TestingMacros", type: "RequireMacro")

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -482,9 +482,9 @@ public func __checkCast<V, T>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall<E, T>(
+public func __checkClosureCall<E>(
   throws errorType: E.Type,
-  performing expression: () throws -> T,
+  performing expression: () throws -> Any,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -519,9 +519,9 @@ public func __checkClosureCall<E, T>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall<E, T>(
+public func __checkClosureCall<E>(
   throws errorType: E.Type,
-  performing expression: () async throws -> T,
+  performing expression: () async throws -> Any,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -559,9 +559,9 @@ public func __checkClosureCall<E, T>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall<T>(
+public func __checkClosureCall(
   throws _: Never.Type,
-  performing expression: () throws -> T,
+  performing expression: () throws -> Any,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -595,9 +595,9 @@ public func __checkClosureCall<T>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall<T>(
+public func __checkClosureCall(
   throws _: Never.Type,
-  performing expression: () async throws -> T,
+  performing expression: () async throws -> Any,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -631,9 +631,9 @@ public func __checkClosureCall<T>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall<E, T>(
+public func __checkClosureCall<E>(
   throws error: E,
-  performing expression: () throws -> T,
+  performing expression: () throws -> Any,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -657,9 +657,9 @@ public func __checkClosureCall<E, T>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall<E, T>(
+public func __checkClosureCall<E>(
   throws error: E,
-  performing expression: () async throws -> T,
+  performing expression: () async throws -> Any,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -684,8 +684,8 @@ public func __checkClosureCall<E, T>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall<T>(
-  performing expression: () throws -> T,
+public func __checkClosureCall(
+  performing expression: () throws -> Any,
   throws errorMatcher: (any Error) throws -> Bool,
   mismatchExplanation: ((any Error) -> String)? = nil,
   sourceCode: SourceCode,
@@ -731,8 +731,8 @@ public func __checkClosureCall<T>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall<T>(
-  performing expression: () async throws -> T,
+public func __checkClosureCall(
+  performing expression: () async throws -> Any,
   throws errorMatcher: (any Error) async throws -> Bool,
   mismatchExplanation: ((any Error) -> String)? = nil,
   sourceCode: SourceCode,

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -482,9 +482,9 @@ public func __checkCast<V, T>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall<E>(
+public func __checkClosureCall<E, T>(
   throws errorType: E.Type,
-  performing expression: () throws -> Void,
+  performing expression: () throws -> T,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -519,9 +519,9 @@ public func __checkClosureCall<E>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall<E>(
+public func __checkClosureCall<E, T>(
   throws errorType: E.Type,
-  performing expression: () async throws -> Void,
+  performing expression: () async throws -> T,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -559,9 +559,9 @@ public func __checkClosureCall<E>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall(
+public func __checkClosureCall<T>(
   throws _: Never.Type,
-  performing expression: () throws -> Void,
+  performing expression: () throws -> T,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -570,7 +570,7 @@ public func __checkClosureCall(
   var success = true
   var mismatchExplanationValue: String? = nil
   do {
-    try expression()
+    _ = try expression()
   } catch {
     success = false
     mismatchExplanationValue = "an error was thrown when none was expected: \(_description(of: error))"
@@ -595,9 +595,9 @@ public func __checkClosureCall(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall(
+public func __checkClosureCall<T>(
   throws _: Never.Type,
-  performing expression: () async throws -> Void,
+  performing expression: () async throws -> T,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -606,7 +606,7 @@ public func __checkClosureCall(
   var success = true
   var mismatchExplanationValue: String? = nil
   do {
-    try await expression()
+    _ = try await expression()
   } catch {
     success = false
     mismatchExplanationValue = "an error was thrown when none was expected: \(_description(of: error))"
@@ -631,9 +631,9 @@ public func __checkClosureCall(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall<E>(
+public func __checkClosureCall<E, T>(
   throws error: E,
-  performing expression: () throws -> Void,
+  performing expression: () throws -> T,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -657,9 +657,9 @@ public func __checkClosureCall<E>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall<E>(
+public func __checkClosureCall<E, T>(
   throws error: E,
-  performing expression: () async throws -> Void,
+  performing expression: () async throws -> T,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -684,8 +684,8 @@ public func __checkClosureCall<E>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall(
-  performing expression: () throws -> Void,
+public func __checkClosureCall<T>(
+  performing expression: () throws -> T,
   throws errorMatcher: (any Error) throws -> Bool,
   mismatchExplanation: ((any Error) -> String)? = nil,
   sourceCode: SourceCode,
@@ -696,8 +696,13 @@ public func __checkClosureCall(
   var errorMatches = false
   var mismatchExplanationValue: String? = nil
   do {
-    try expression()
-    mismatchExplanationValue = "an error was expected but none was thrown"
+    let result = try expression()
+
+    var explanation = "an error was expected but none was thrown"
+    if type(of: result) != Void.self {
+      explanation += " and \"\(result)\" was returned"
+    }
+    mismatchExplanationValue = explanation
   } catch {
     do {
       errorMatches = try errorMatcher(error)
@@ -726,8 +731,8 @@ public func __checkClosureCall(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall(
-  performing expression: () async throws -> Void,
+public func __checkClosureCall<T>(
+  performing expression: () async throws -> T,
   throws errorMatcher: (any Error) async throws -> Bool,
   mismatchExplanation: ((any Error) -> String)? = nil,
   sourceCode: SourceCode,
@@ -738,8 +743,13 @@ public func __checkClosureCall(
   var errorMatches = false
   var mismatchExplanationValue: String? = nil
   do {
-    try await expression()
-    mismatchExplanationValue = "an error was expected but none was thrown"
+    let result = try await expression()
+
+    var explanation = "an error was expected but none was thrown"
+    if type(of: result) != Void.self {
+      explanation += " and \"\(result)\" was returned"
+    }
+    mismatchExplanationValue = explanation
   } catch {
     do {
       errorMatches = try await errorMatcher(error)

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -482,9 +482,9 @@ public func __checkCast<V, T>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall<E, R>(
+public func __checkClosureCall<E>(
   throws errorType: E.Type,
-  performing expression: () throws -> R,
+  performing expression: () throws -> some Any,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -519,9 +519,9 @@ public func __checkClosureCall<E, R>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall<E, R>(
+public func __checkClosureCall<E>(
   throws errorType: E.Type,
-  performing expression: () async throws -> R,
+  performing expression: () async throws -> some Any,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -559,9 +559,9 @@ public func __checkClosureCall<E, R>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall<R>(
+public func __checkClosureCall(
   throws _: Never.Type,
-  performing expression: () throws -> R,
+  performing expression: () throws -> some Any,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -595,9 +595,9 @@ public func __checkClosureCall<R>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall<R>(
+public func __checkClosureCall(
   throws _: Never.Type,
-  performing expression: () async throws -> R,
+  performing expression: () async throws -> some Any,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -631,9 +631,9 @@ public func __checkClosureCall<R>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall<E, R>(
+public func __checkClosureCall<E>(
   throws error: E,
-  performing expression: () throws -> R,
+  performing expression: () throws -> some Any,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -657,9 +657,9 @@ public func __checkClosureCall<E, R>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall<E, R>(
+public func __checkClosureCall<E>(
   throws error: E,
-  performing expression: () async throws -> R,
+  performing expression: () async throws -> some Any,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -482,9 +482,9 @@ public func __checkCast<V, T>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall<E>(
+public func __checkClosureCall<E, R>(
   throws errorType: E.Type,
-  performing expression: () throws -> Any,
+  performing expression: () throws -> R,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -519,9 +519,9 @@ public func __checkClosureCall<E>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall<E>(
+public func __checkClosureCall<E, R>(
   throws errorType: E.Type,
-  performing expression: () async throws -> Any,
+  performing expression: () async throws -> R,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -559,9 +559,9 @@ public func __checkClosureCall<E>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall(
+public func __checkClosureCall<R>(
   throws _: Never.Type,
-  performing expression: () throws -> Any,
+  performing expression: () throws -> R,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -595,9 +595,9 @@ public func __checkClosureCall(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall(
+public func __checkClosureCall<R>(
   throws _: Never.Type,
-  performing expression: () async throws -> Any,
+  performing expression: () async throws -> R,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -631,9 +631,9 @@ public func __checkClosureCall(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall<E>(
+public func __checkClosureCall<E, R>(
   throws error: E,
-  performing expression: () throws -> Any,
+  performing expression: () throws -> R,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -657,9 +657,9 @@ public func __checkClosureCall<E>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall<E>(
+public func __checkClosureCall<E, R>(
   throws error: E,
-  performing expression: () async throws -> Any,
+  performing expression: () async throws -> R,
   sourceCode: SourceCode,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -684,8 +684,8 @@ public func __checkClosureCall<E>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall(
-  performing expression: () throws -> Any,
+public func __checkClosureCall<R>(
+  performing expression: () throws -> R,
   throws errorMatcher: (any Error) throws -> Bool,
   mismatchExplanation: ((any Error) -> String)? = nil,
   sourceCode: SourceCode,
@@ -699,7 +699,7 @@ public func __checkClosureCall(
     let result = try expression()
 
     var explanation = "an error was expected but none was thrown"
-    if type(of: result) != Void.self {
+    if R.self != Void.self {
       explanation += " and \"\(result)\" was returned"
     }
     mismatchExplanationValue = explanation
@@ -731,8 +731,8 @@ public func __checkClosureCall(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkClosureCall(
-  performing expression: () async throws -> Any,
+public func __checkClosureCall<R>(
+  performing expression: () async throws -> R,
   throws errorMatcher: (any Error) async throws -> Bool,
   mismatchExplanation: ((any Error) -> String)? = nil,
   sourceCode: SourceCode,
@@ -746,7 +746,7 @@ public func __checkClosureCall(
     let result = try await expression()
 
     var explanation = "an error was expected but none was thrown"
-    if type(of: result) != Void.self {
+    if R.self != Void.self {
       explanation += " and \"\(result)\" was returned"
     }
     mismatchExplanationValue = explanation

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -431,6 +431,10 @@ final class IssueTests: XCTestCase {
         #expect(throws: type) {}
       }
       genericExpectThrows(Never.self)
+      func zero() throws -> Int { throw MyError() }
+      #expect(throws: MyError.self) {
+        try zero()
+      }
     }.run(configuration: configuration)
 
     await fulfillment(of: [expectationFailed], timeout: 0.0)
@@ -438,7 +442,7 @@ final class IssueTests: XCTestCase {
 
   func testErrorCheckingWithExpect_Mismatching() async throws {
     let expectationFailed = expectation(description: "Expectation failed")
-    expectationFailed.expectedFulfillmentCount = 10
+    expectationFailed.expectedFulfillmentCount = 11
 
     var configuration = Configuration()
     configuration.eventHandler = { event in
@@ -493,6 +497,10 @@ final class IssueTests: XCTestCase {
         }
       }
       genericExpectThrows(Never.self)
+      func zero() throws -> Int { 0 }
+      #expect(throws: MyError.self) {
+        try zero()
+      }
     }.run(configuration: configuration)
 
     await fulfillment(of: [expectationFailed], timeout: 0.0)


### PR DESCRIPTION
This changes `#expect(throws:)` and similar macros so that their closure parameters accept any type instead of `Void` specifically.

### Motivation:

This makes testing trivial throwing expressions of non-`Void` types easier, by not requiring syntax to discard the return value. For example:

```swift
func mightThrowXOrReturnY() throws -> Y { ... }
#expect(throws: X.self) {
  try mightThrowXOrReturnY() // ⚠️ Result of call to 'mightThrowXOrReturnY()' is unused
}
```

### Modifications:

- Change closure parameters of relevant macro-related declarations to use generic `R` type instead of `Void`.
- Change implementation of relevant `__check...` functions to include a description of return value.
- Add new unit tests.
- Update documentation to mention that return values are always discarded.

### Result:

The changes in this PR mean the warning above will no longer be emitted by the compiler. These changes also allow printing a description of the return value if the expectation fails and the expression does not throw an error, providing a more detailed and actionable failure message.
