### PR TITLE
Fix Syntax Error: Remove Trailing Comma from Code Snippet

### DIFF
--- a/Sources/Testing/Testing.docc/EnablingAndDisabling.md
+++ b/Sources/Testing/Testing.docc/EnablingAndDisabling.md
@@ -112,7 +112,7 @@ func allIngredientsAvailable(for food: Food) -> Bool { ... }
 @Test(
   "Can make sundaes",
   .enabled(if: Season.current == .summer),
-  .enabled(if: allIngredientsAvailable(for: .sundae)),
+  .enabled(if: allIngredientsAvailable(for: .sundae))
 )
 func makeSundae() async throws { ... }
 ```


### PR DESCRIPTION
Remove trailing comma for syntax correctness

### Motivation:
The trailing comma in the code snippet is a syntax error in Swift.

### Modifications:
Removed the trailing comma from the `@Test` macro in the code snippet.

### Result:
The code snippet is now syntactically correct and consistent with Swift standards.
