### PR TITLE
Add Link to Detailed Documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,5 +65,6 @@ Here, you can delve into comprehensive guides, tutorials, and API references to 
 
 `swift-testing` is under active development. We are working to integrate it with
 the rest of the Swift ecosystem, but you can try it out today by following the
-steps in our [Getting Started](Sources/Testing/Testing.docc/TemporaryGettingStarted.md)
+steps in our
+[Getting Started](https://swiftpackageindex.com/apple/swift-testing/main/documentation/testing/temporarygettingstarted)
 article.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ for various platforms:
 | **Ubuntu 22.04** | Supported |
 | **Windows** | Pending support for macros |
 
+## Documentation
+
+The detailed documentation for `swift-testing` can be found on the [Swift Package Index](https://swiftpackageindex.com/apple/swift-testing/main/documentation/testing).
+
+Here, you can delve into comprehensive guides, tutorials, and API references to make the most out of `swift-testing`.
+
 ## Getting started
 
 `swift-testing` is under active development. We are working to integrate it with

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ for various platforms:
 
 ## Documentation
 
-The detailed documentation for `swift-testing` can be found on the [Swift Package Index](https://swiftpackageindex.com/apple/swift-testing/main/documentation/testing).
+The detailed documentation for `swift-testing` can be found on the
+[Swift Package Index](https://swiftpackageindex.com/apple/swift-testing/main/documentation/testing).
 
 Here, you can delve into comprehensive guides, tutorials, and API references to make the most out of `swift-testing`.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ for various platforms:
 The detailed documentation for `swift-testing` can be found on the
 [Swift Package Index](https://swiftpackageindex.com/apple/swift-testing/main/documentation/testing).
 
-Here, you can delve into comprehensive guides, tutorials, and API references to make the most out of `swift-testing`.
+Here, you can delve into comprehensive guides, tutorials, and API references to
+make the most out of `swift-testing`.
 
 ## Getting started
 


### PR DESCRIPTION
Add Documentation Link to README

### Motivation:

To improve documentation accessibility and aid new contributors, a direct link to the detailed documentation is added to the README.

### Modifications:

- Added a `Documentation` section to the README.
- Included a link to the detailed documentation on the Swift Package Index.

### Result:

With this change, developers and contributors will have a direct link to the detailed documentation from the README. This makes it easier to find important guides, tutorials, and API references, helping developers to utilize `swift-testing` to its fullest potential.
