### PR TITLE
Allow specifying the source location of `#expect()` and `#require()`.

### DIFF
--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -15,12 +15,15 @@
 /// - Parameters:
 ///   - condition: The condition to be evaluated.
 ///   - comment: A comment describing the expectation.
+///   - sourceLocation: The source location to which recorded expectations and
+///     issues should be attributed.
 ///
 /// If `condition` evaluates to `false`, an ``Issue`` is recorded for the test
 /// that is running in the current task.
 @freestanding(expression) public macro expect(
   _ condition: Bool,
-  _ comment: @autoclosure () -> Comment? = nil
+  _ comment: @autoclosure () -> Comment? = nil,
+  sourceLocation: SourceLocation = SourceLocation()
 ) = #externalMacro(module: "TestingMacros", type: "ExpectMacro")
 
 /// Check that an expectation has passed after a condition has been evaluated
@@ -29,6 +32,8 @@
 /// - Parameters:
 ///   - condition: The condition to be evaluated.
 ///   - comment: A comment describing the expectation.
+///   - sourceLocation: The source location to which recorded expectations and
+///     issues should be attributed.
 ///
 /// - Throws: An instance of ``ExpectationFailedError`` if `condition` evaluates
 ///   to `false`.
@@ -38,7 +43,8 @@
 /// ``ExpectationFailedError`` is thrown.
 @freestanding(expression) public macro require(
   _ condition: Bool,
-  _ comment: @autoclosure () -> Comment? = nil
+  _ comment: @autoclosure () -> Comment? = nil,
+  sourceLocation: SourceLocation = SourceLocation()
 ) = #externalMacro(module: "TestingMacros", type: "RequireMacro")
 
 // MARK: - Optional checking
@@ -48,6 +54,8 @@
 /// - Parameters:
 ///   - optionalValue: The optional value to be unwrapped.
 ///   - comment: A comment describing the expectation.
+///   - sourceLocation: The source location to which recorded expectations and
+///     issues should be attributed.
 ///
 /// - Returns: The unwrapped value of `value`.
 ///
@@ -57,7 +65,8 @@
 /// in the current task and an instance of ``ExpectationFailedError`` is thrown.
 @freestanding(expression) public macro require<T>(
   _ optionalValue: T?,
-  _ comment: @autoclosure () -> Comment? = nil
+  _ comment: @autoclosure () -> Comment? = nil,
+  sourceLocation: SourceLocation = SourceLocation()
 ) -> T = #externalMacro(module: "TestingMacros", type: "RequireMacro")
 
 // MARK: - Matching errors by type
@@ -69,6 +78,8 @@
 ///     `expression` could throw _any_ error, or the specific type of thrown
 ///     error is unimportant, pass `any Error.self`.
 ///   - comment: A comment describing the expectation.
+///   - sourceLocation: The source location to which recorded expectations and
+///     issues should be attributed.
 ///   - expression: The expression to be evaluated.
 ///
 /// Use this overload of `#expect()` when the expression `expression` _should_
@@ -87,11 +98,13 @@
 /// discarded.
 ///
 /// If the thrown error need only equal another instance of [`Error`](https://developer.apple.com/documentation/swift/error),
-/// use ``expect(throws:_:performing:)-1s3lx`` instead. If `expression` should
-/// _never_ throw any error, use ``expect(throws:_:performing:)-jtjw`` instead.
+/// use ``expect(throws:_:sourceLocation:performing:)-1xr34`` instead. If
+/// `expression` should _never_ throw any error, use
+/// ``expect(throws:_:sourceLocation:performing:)-5lzjz`` instead.
 @freestanding(expression) public macro expect<E, R>(
   throws errorType: E.Type,
   _ comment: @autoclosure () -> Comment? = nil,
+  sourceLocation: SourceLocation = SourceLocation(),
   performing expression: () async throws -> R
 ) = #externalMacro(module: "TestingMacros", type: "ExpectMacro") where E: Error
 
@@ -99,6 +112,8 @@
 ///
 /// - Parameters:
 ///   - comment: A comment describing the expectation.
+///   - sourceLocation: The source location to which recorded expectations and
+///     issues should be attributed.
 ///   - expression: The expression to be evaluated.
 ///
 /// Use this overload of `#expect()` when the expression `expression` should
@@ -123,12 +138,13 @@
 /// naturally.
 ///
 /// If the thrown error need only be an instance of a particular type, use
-/// ``expect(throws:_:performing:)-2j0od`` instead. If the thrown error need
-/// only equal another instance of [`Error`](https://developer.apple.com/documentation/swift/error),
-/// use ``expect(throws:_:performing:)-1s3lx`` instead.
+/// ``expect(throws:_:sourceLocation:performing:)-79piu`` instead. If the thrown
+/// error need only equal another instance of [`Error`](https://developer.apple.com/documentation/swift/error),
+/// use ``expect(throws:_:sourceLocation:performing:)-1xr34`` instead.
 @freestanding(expression) public macro expect<R>(
   throws _: Never.Type,
   _ comment: @autoclosure () -> Comment? = nil,
+  sourceLocation: SourceLocation = SourceLocation(),
   performing expression: () async throws -> R
 ) = #externalMacro(module: "TestingMacros", type: "ExpectMacro")
 
@@ -140,6 +156,8 @@
 ///     `expression` could throw _any_ error, or the specific type of thrown
 ///     error is unimportant, pass `any Error.self`.
 ///   - comment: A comment describing the expectation.
+///   - sourceLocation: The source location to which recorded expectations and
+///     issues should be attributed.
 ///   - expression: The expression to be evaluated.
 ///
 /// - Throws: An instance of ``ExpectationFailedError`` if `expression` does not
@@ -161,13 +179,14 @@
 /// is thrown. Any value returned by `expression` is discarded.
 ///
 /// If the thrown error need only equal another instance of [`Error`](https://developer.apple.com/documentation/swift/error),
-/// use ``require(throws:_:performing:)-84jir`` instead.
+/// use ``require(throws:_:sourceLocation:performing:)-7v83e`` instead.
 ///
 /// If `expression` should _never_ throw, simply invoke the code without using
 /// this macro. The test will then fail if an error is thrown.
 @freestanding(expression) public macro require<E, R>(
   throws errorType: E.Type,
   _ comment: @autoclosure () -> Comment? = nil,
+  sourceLocation: SourceLocation = SourceLocation(),
   performing expression: () async throws -> R
 ) = #externalMacro(module: "TestingMacros", type: "RequireMacro") where E: Error
 
@@ -176,6 +195,8 @@
 ///
 /// - Parameters:
 ///   - comment: A comment describing the expectation.
+///   - sourceLocation: The source location to which recorded expectations and
+///     issues should be attributed.
 ///   - expression: The expression to be evaluated.
 ///
 /// - Throws: An instance of ``ExpectationFailedError`` if `expression` throws
@@ -184,6 +205,7 @@
 @freestanding(expression) public macro require<R>(
   throws _: Never.Type,
   _ comment: @autoclosure () -> Comment? = nil,
+  sourceLocation: SourceLocation = SourceLocation(),
   performing expression: () async throws -> R
 ) = #externalMacro(module: "TestingMacros", type: "RequireMacro")
 
@@ -194,6 +216,8 @@
 /// - Parameters:
 ///   - error: The error that is expected to be thrown.
 ///   - comment: A comment describing the expectation.
+///   - sourceLocation: The source location to which recorded expectations and
+///     issues should be attributed.
 ///   - expression: The expression to be evaluated.
 ///
 /// Use this overload of `#expect()` when the expression `expression` _should_
@@ -211,11 +235,13 @@
 /// in the current task. Any value returned by `expression` is discarded.
 ///
 /// If the thrown error need only be an instance of a particular type, use
-/// ``expect(throws:_:performing:)-2j0od`` instead. If `expression` should
-/// _never_ throw any error, use ``expect(throws:_:performing:)-jtjw`` instead.
+/// ``expect(throws:_:sourceLocation:performing:)-79piu`` instead. If
+/// `expression` should _never_ throw any error, use
+/// ``expect(throws:_:sourceLocation:performing:)-5lzjz`` instead.
 @freestanding(expression) public macro expect<E, R>(
   throws error: E,
   _ comment: @autoclosure () -> Comment? = nil,
+  sourceLocation: SourceLocation = SourceLocation(),
   performing expression: () async throws -> R
 ) = #externalMacro(module: "TestingMacros", type: "ExpectMacro") where E: Error & Equatable
 
@@ -225,6 +251,8 @@
 /// - Parameters:
 ///   - error: The error that is expected to be thrown.
 ///   - comment: A comment describing the expectation.
+///   - sourceLocation: The source location to which recorded expectations and
+///     issues should be attributed.
 ///   - expression: The expression to be evaluated.
 ///
 /// - Throws: An instance of ``ExpectationFailedError`` if `expression` does not
@@ -246,10 +274,11 @@
 /// Any value returned by `expression` is discarded.
 ///
 /// If the thrown error need only be an instance of a particular type, use
-/// ``require(throws:_:performing:)-8762f`` instead.
+/// ``require(throws:_:sourceLocation:performing:)-76bjn`` instead.
 @freestanding(expression) public macro require<E, R>(
   throws error: E,
   _ comment: @autoclosure () -> Comment? = nil,
+  sourceLocation: SourceLocation = SourceLocation(),
   performing expression: () async throws -> R
 ) = #externalMacro(module: "TestingMacros", type: "RequireMacro") where E: Error & Equatable
 
@@ -259,6 +288,8 @@
 ///
 /// - Parameters:
 ///   - comment: A comment describing the expectation.
+///   - sourceLocation: The source location to which recorded expectations and
+///     issues should be attributed.
 ///   - expression: The expression to be evaluated.
 ///   - errorMatcher: A closure to invoke when `expression` throws an error that
 ///     indicates if it matched or not.
@@ -283,12 +314,14 @@
 /// discarded.
 ///
 /// If the thrown error need only be an instance of a particular type, use
-/// ``expect(throws:_:performing:)-2j0od`` instead. If the thrown error need
-/// only equal another instance of [`Error`](https://developer.apple.com/documentation/swift/error),
-/// use ``expect(throws:_:performing:)-1s3lx`` instead. If an error should
-/// _never_ be thrown, use ``expect(throws:_:performing:)-jtjw`` instead.
+/// ``expect(throws:_:sourceLocation:performing:)-79piu`` instead. If the thrown
+/// error need only equal another instance of [`Error`](https://developer.apple.com/documentation/swift/error),
+/// use ``expect(throws:_:sourceLocation:performing:)-1xr34`` instead. If an
+/// error should _never_ be thrown, use
+/// ``expect(throws:_:sourceLocation:performing:)-5lzjz`` instead.
 @freestanding(expression) public macro expect<R>(
   _ comment: @autoclosure () -> Comment? = nil,
+  sourceLocation: SourceLocation = SourceLocation(),
   performing expression: () async throws -> R,
   throws errorMatcher: (any Error) async throws -> Bool
 ) = #externalMacro(module: "TestingMacros", type: "ExpectMacro")
@@ -298,6 +331,8 @@
 ///
 /// - Parameters:
 ///   - comment: A comment describing the expectation.
+///   - sourceLocation: The source location to which recorded expectations and
+///     issues should be attributed.
 ///   - expression: The expression to be evaluated.
 ///   - errorMatcher: A closure to invoke when `expression` throws an error that
 ///     indicates if it matched or not.
@@ -326,14 +361,15 @@
 /// discarded.
 ///
 /// If the thrown error need only be an instance of a particular type, use
-/// ``require(throws:_:performing:)-8762f`` instead. If the thrown error need
+/// ``require(throws:_:sourceLocation:performing:)-76bjn`` instead. If the thrown error need
 /// only equal another instance of [`Error`](https://developer.apple.com/documentation/swift/error),
-/// use ``require(throws:_:performing:)-84jir`` instead.
+/// use ``require(throws:_:sourceLocation:performing:)-7v83e`` instead.
 ///
 /// If `expression` should _never_ throw, simply invoke the code without using
 /// this macro. The test will then fail if an error is thrown.
 @freestanding(expression) public macro require<R>(
   _ comment: @autoclosure () -> Comment? = nil,
+  sourceLocation: SourceLocation = SourceLocation(),
   performing expression: () async throws -> R,
   throws errorMatcher: (any Error) async throws -> Bool
 ) = #externalMacro(module: "TestingMacros", type: "RequireMacro")

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -82,7 +82,7 @@ extension Issue {
   ///
   /// Use this function if, while running a test, an issue occurs that cannot be
   /// represented as an expectation (using the ``expect(_:_:sourceLocation:)``
-  /// or ``require(_:_:sourceLocation:)-6lago`` macros.)
+  /// or ``require(_:_:sourceLocation:)-5l63q`` macros.)
   @discardableResult public static func record(
     _ comment: Comment? = nil,
     fileID: String = #fileID,

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -81,8 +81,8 @@ extension Issue {
   /// - Returns: The issue that was recorded.
   ///
   /// Use this function if, while running a test, an issue occurs that cannot be
-  /// represented as an expectation (using the ``expect(_:_:)`` or
-  /// ``require(_:_:)-6lago`` macros.)
+  /// represented as an expectation (using the ``expect(_:_:sourceLocation:)``
+  /// or ``require(_:_:sourceLocation:)-6lago`` macros.)
   @discardableResult public static func record(
     _ comment: Comment? = nil,
     fileID: String = #fileID,

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -17,7 +17,7 @@ public struct Issue: Sendable {
     case unconditional
 
     /// An issue due to a failed expectation, such as those produced by
-    /// ``expect(_:_:)``.
+    /// ``expect(_:_:sourceLocation:)``.
     ///
     /// - Parameters:
     ///   - expectation: The expectation that failed.

--- a/Sources/Testing/Testing.docc/ExpectThrows.md
+++ b/Sources/Testing/Testing.docc/ExpectThrows.md
@@ -29,17 +29,17 @@ runtime not to mark the test as failing when those issues occur.
 
 ### Validating that errors are thrown
 
-- ``expect(throws:_:performing:)-2j0od``
-- ``expect(throws:_:performing:)-1s3lx``
-- ``expect(_:performing:throws:)``
-- ``require(throws:_:performing:)-8762f``
-- ``require(throws:_:performing:)-84jir``
-- ``require(_:performing:throws:)``
+- ``expect(throws:_:sourceLocation:performing:)-79piu``
+- ``expect(throws:_:sourceLocation:performing:)-1xr34``
+- ``expect(_:sourceLocation:performing:throws:)``
+- ``require(throws:_:sourceLocation:performing:)-76bjn``
+- ``require(throws:_:sourceLocation:performing:)-7v83e``
+- ``require(_:sourceLocation:performing:throws:)``
 
 ### Validating that errors are not thrown
 
-- ``expect(throws:_:performing:)-jtjw``
-- ``require(throws:_:performing:)-4a80i``
+- ``expect(throws:_:sourceLocation:performing:)-5lzjz``
+- ``require(throws:_:sourceLocation:performing:)-36uzc``
 
 ### Recording known issues in tests
 

--- a/Sources/Testing/Testing.docc/Expectations.md
+++ b/Sources/Testing/Testing.docc/Expectations.md
@@ -21,9 +21,9 @@ built-in expectation APIs.
 
 ### Validating behavior using expectations
 
-- ``expect(_:_:)``
-- ``require(_:_:)-6lago``
-- ``require(_:_:)-3wq2g``
+- ``expect(_:_:sourceLocation:)``
+- ``require(_:_:sourceLocation:)-6lago``
+- ``require(_:_:sourceLocation:)-3wq2g``
 
 ### Validating asynchronous behavior using confirmations
 

--- a/Sources/Testing/Testing.docc/Expectations.md
+++ b/Sources/Testing/Testing.docc/Expectations.md
@@ -22,8 +22,8 @@ built-in expectation APIs.
 ### Validating behavior using expectations
 
 - ``expect(_:_:sourceLocation:)``
-- ``require(_:_:sourceLocation:)-6lago``
-- ``require(_:_:sourceLocation:)-3wq2g``
+- ``require(_:_:sourceLocation:)-5l63q``
+- ``require(_:_:sourceLocation:)-6w9oo``
 
 ### Validating asynchronous behavior using confirmations
 

--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -193,9 +193,10 @@ see <doc:DefiningTests>.
 XCTest uses a family of approximately 40 functions to assert test requirements.
 These functions are collectively referred to as
 [`XCTAssert()`](https://developer.apple.com/documentation/xctest/1500669-xctassert).
-The testing library has two replacements, ``expect(_:_:)`` and
-``require(_:_:)-6lago``. They both behave similarly to `XCTAssert()` except that
-``require(_:_:)-6lago`` will throw an error if its condition is not met:
+The testing library has two replacements, ``expect(_:_:sourceLocation:)`` and
+``require(_:_:sourceLocation:)-6lago``. They both behave similarly to
+`XCTAssert()` except that ``require(_:_:sourceLocation:)-6lago`` will throw an
+error if its condition is not met:
 
 @Row {
   @Column {
@@ -232,8 +233,8 @@ The testing library has two replacements, ``expect(_:_:)`` and
 
 XCTest also has a function, [`XCTUnwrap()`](https://developer.apple.com/documentation/xctest/3380195-xctunwrap),
 that tests if an optional value is `nil` and throws an error if it is. When
-using the testing library, you can use ``require(_:_:)-3wq2g`` with optional
-expressions to unwrap them:
+using the testing library, you can use ``require(_:_:sourceLocation:)-3wq2g``
+with optional expressions to unwrap them:
 
 @Row {
   @Column {

--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -194,8 +194,8 @@ XCTest uses a family of approximately 40 functions to assert test requirements.
 These functions are collectively referred to as
 [`XCTAssert()`](https://developer.apple.com/documentation/xctest/1500669-xctassert).
 The testing library has two replacements, ``expect(_:_:sourceLocation:)`` and
-``require(_:_:sourceLocation:)-6lago``. They both behave similarly to
-`XCTAssert()` except that ``require(_:_:sourceLocation:)-6lago`` will throw an
+``require(_:_:sourceLocation:)-5l63q``. They both behave similarly to
+`XCTAssert()` except that ``require(_:_:sourceLocation:)-5l63q`` will throw an
 error if its condition is not met:
 
 @Row {
@@ -233,7 +233,7 @@ error if its condition is not met:
 
 XCTest also has a function, [`XCTUnwrap()`](https://developer.apple.com/documentation/xctest/3380195-xctunwrap),
 that tests if an optional value is `nil` and throws an error if it is. When
-using the testing library, you can use ``require(_:_:sourceLocation:)-3wq2g``
+using the testing library, you can use ``require(_:_:sourceLocation:)-6w9oo``
 with optional expressions to unwrap them:
 
 @Row {

--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -19,10 +19,11 @@ import SwiftSyntaxMacros
 ///
 /// ## Macro arguments
 ///
-/// Overloads of these macros that evaluate an expression take exactly two
-/// arguments, a "condition" argument and a `Comment?`-typed argument. The
-/// "condition" argument may be expanded into additional arguments based on its
-/// representation in the syntax tree.
+/// Overloads of these macros that evaluate an expression take exactly three
+/// arguments: a "condition" argument, a `Comment?`-typed argument with no
+/// label, and an optional `SourceLocation`-typed argument with the label
+/// `sourceLocation`. The "condition" argument may be expanded into additional
+/// arguments based on its representation in the syntax tree.
 ///
 /// ## Macro arguments with trailing closures
 ///

--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -80,7 +80,8 @@ extension _ConditionMacro {
     do {
       if let trailingClosureIndex {
 
-        // Include all arguments other than the "comment" argument here.
+        // Include all arguments other than the "comment" and "sourceLocation"
+        // arguments here.
         checkArguments += macroArguments.indices.lazy
           .filter { $0 != commentIndex }
           .filter { $0 != sourceLocationArgumentIndex }
@@ -99,8 +100,8 @@ extension _ConditionMacro {
         let conditionArgument = parseCondition(from: macroArguments.first!.expression, for: macro, in: context)
         checkArguments += conditionArgument.arguments
 
-        // Include all arguments other than the "condition" and "comment"
-        // arguments here.
+        // Include all arguments other than the "condition", "comment", and
+        // "sourceLocation" arguments here.
         checkArguments += macroArguments.dropFirst().indices.lazy
           .filter { $0 != commentIndex }
           .filter { $0 != sourceLocationArgumentIndex }

--- a/Sources/TestingMacros/Support/SourceLocationGeneration.swift
+++ b/Sources/TestingMacros/Support/SourceLocationGeneration.swift
@@ -22,6 +22,13 @@ import SwiftSyntaxMacros
 /// - Returns: An expression value that initializes an instance of
 ///   ``SourceLocation`` for `expr`.
 func createSourceLocationExpr(of expr: some SyntaxProtocol, context: some MacroExpansionContext) -> ExprSyntax {
+  if expr.isProtocol((any FreestandingMacroExpansionSyntax).self) {
+    // Freestanding macro expressions can just use Testing.SourceLocation()
+    // directly and do not need to talk to the macro context to get source
+    // location info.
+    return "Testing.SourceLocation()"
+  }
+
   // Get the equivalent source location in both `#fileID` and `#filePath` modes
   guard let fileIDSourceLoc: AbstractSourceLocation = context.location(of: expr),
         let filePathSourceLoc: AbstractSourceLocation = context.location(of: expr, at: .afterLeadingTrivia, filePathMode: .filePath)

--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -72,6 +72,8 @@ struct ConditionMacroTests {
         ##"Testing.__checkFunctionCall(a.self, calling: { $0.b(c: $1) }, d, sourceCode: .__functionCall("a", "b", ("c", "d")), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(a.b { c })"##:
         ##"Testing.__checkValue(a.b { c }, sourceCode: .__fromComponents("a.b { c }"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+      ##"#expect(a, sourceLocation: someValue)"##:
+        ##"Testing.__checkValue(a, sourceCode: .__fromComponents("a"), comments: [], isRequired: false, sourceLocation: someValue).__expected()"##,
     ]
   )
   func expectMacro(input: String, expectedOutput: String) throws {
@@ -132,6 +134,8 @@ struct ConditionMacroTests {
         ##"Testing.__checkFunctionCall(a.self, calling: { $0.b(c: $1) }, d, sourceCode: .__functionCall("a", "b", ("c", "d")), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(a.b { c })"##:
         ##"Testing.__checkValue(a.b { c }, sourceCode: .__fromComponents("a.b { c }"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+      ##"#require(a, sourceLocation: someValue)"##:
+        ##"Testing.__checkValue(a, sourceCode: .__fromComponents("a"), comments: [], isRequired: true, sourceLocation: someValue).__required()"##,
     ]
   )
   func requireMacro(input: String, expectedOutput: String) throws {


### PR DESCRIPTION
This PR adds an additional argument to the `#expect()` and `#require()` macros that, if specified, replaces the source location derived at macro expansion time and passed to `__check()`. This change is ABI-safe for anyone who has already adopted swift-testing because it does not affect the emitted code or symbols. It is source-safe.

In the typical use case, the existing/old code path is taken at compile time and this PR has no effect. If a developer wants to specify a precise source location, they can do so.

This PR also changes the default behaviour of `#expect()` to generate an instance of `SourceLocation` using default arguments rather than by asking the macro context to provide all info. This is a little bit faster and is more accurate when a freestanding macro expression is embedded in another macro expression, such as:

```swift
#expect(throws: FooError.self) {
  #expect(try foo())
}
```

> [!NOTE]
> The arguments to `SourceLocation.init()` all currently have default values. We might want to change that in the future so that a developer cannot accidentally underspecify an instance. Where a default value is truly required, we can offer a `.here()` factory function that explicitly indicates intent.

Resolves rdar://112974442.
Resolves #15.