### PR TITLE
Add support for the `SWT_SF_SYMBOLS_ENABLED` envvar.

### DIFF
--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -192,11 +192,18 @@ extension [Event.Recorder.Option] {
     // On macOS, if we are writing to a TTY (i.e. Terminal.app) and the SF Pro
     // font is installed, we can use SF Symbols characters in place of Unicode
     // pictographs. Other platforms do not generally have this font installed.
-    if useANSIEscapeCodes {
+    // In case rendering with SF Symbols is causing problems (e.g. a third-party
+    // terminal app is being used that doesn't support them), allow explicitly
+    // toggling them with an environment variable.
+    var useSFSymbols = false
+    if let environmentVariable = Environment.flag(named: "SWT_SF_SYMBOLS_ENABLED") {
+      useSFSymbols = environmentVariable
+    } else if useANSIEscapeCodes {
       var statStruct = stat()
-      if 0 == stat("/Library/Fonts/SF-Pro.ttf", &statStruct) {
-        result.append(.useSFSymbols)
-      }
+      useSFSymbols = (0 == stat("/Library/Fonts/SF-Pro.ttf", &statStruct))
+    }
+    if useSFSymbols {
+      result.append(.useSFSymbols)
     }
 #endif
 


### PR DESCRIPTION
On macOS, if we detect the presence of the SF Pro font, we enable SF Symbols output. This is the wrong behaviour if using a third-party terminal app that doesn't support it, or if writing to a file or pipe that we've misdetected as being a TTY.

This environment variable provides an opt-out (or explicit opt-in) for SF Symbols support on macOS. It is already documented and was meant to be supported.