### PR TITLE
Do not re-add leading/trailing trivia when expanding condition macros.

### DIFF
--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -137,9 +137,9 @@ extension _ConditionMacro {
     // Construct and return the call to __check().
     let call: ExprSyntax = "Testing.\(expandedFunctionName)(\(LabeledExprListSyntax(checkArguments)))"
     if isThrowing {
-      return "\(raw: macro.leadingTrivia)\(call).__required()\(raw: macro.trailingTrivia)"
+      return "\(call).__required()"
     }
-    return "\(raw: macro.leadingTrivia)\(call).__expected()\(raw: macro.trailingTrivia)"
+    return "\(call).__expected()"
   }
 
   /// Get the complete argument list for a given macro, including any trailing


### PR DESCRIPTION
swift-syntax 5.9.0 is able to adjust leading and trailing trivia after macro expansions, so it is no longer necessary for swift-testing to do so.

Resolves rdar://113853493.