### PR TITLE
Rename `swt_isFIFO()` to match the macro it shadows.

### DIFF
--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -242,7 +242,7 @@ extension [Event.Recorder.Option] {
     // invokes the testing library, for example.
 #if SWT_TARGET_OS_APPLE || os(Linux)
     var statStruct = stat()
-    if 0 == fstat(STDERR_FILENO, &statStruct) && swt_isFIFO(statStruct.st_mode) {
+    if 0 == fstat(STDERR_FILENO, &statStruct) && swt_S_ISFIFO(statStruct.st_mode) {
       return true
     }
 #elseif os(Windows)

--- a/Sources/TestingInternals/include/Stubs.h
+++ b/Sources/TestingInternals/include/Stubs.h
@@ -28,9 +28,10 @@ static FILE *swt_stderr(void) {
 #if __has_include(<sys/stat.h>) && defined(S_ISFIFO)
 /// Check if a given `mode_t` value indicates that a file is a pipe (FIFO.)
 ///
-/// This function is necessary because the mode flag macros are not all
-/// imported into Swift.
-static bool swt_isFIFO(mode_t mode) {
+/// This function is exactly equivalent to the `S_ISFIFO()` macro. It is
+/// necessary because the mode flag macros are not imported into Swift
+/// consistently across platforms.
+static bool swt_S_ISFIFO(mode_t mode) {
   return S_ISFIFO(mode);
 }
 #endif


### PR DESCRIPTION
This PR is just a stylistic change so that `swt_isFIFO()`'s name directly matches the shadowed `S_ISFIFO()` macro.