### PR TITLE
Allow `async` traits on suites.

### DIFF
--- a/Sources/TestingMacros/SuiteDeclarationMacro.swift
+++ b/Sources/TestingMacros/SuiteDeclarationMacro.swift
@@ -159,12 +159,14 @@ public struct SuiteDeclarationMacro: MemberMacro, PeerMacro, Sendable {
       @available(*, unavailable, message: "This type is an implementation detail of the testing library. It cannot be used directly.")
       @available(*, deprecated)
       @frozen public enum \(enumName): Testing.__TestContainer {
-        public static var __tests: [Testing.Test] {[
-          .__type(
-            \(declaration.type.trimmed).self,
-            \(raw: attributeInfo.functionArgumentList(in: context))
-          )
-        ]}
+        public static var __tests: [Testing.Test] {
+          get async {[
+            .__type(
+              \(declaration.type.trimmed).self,
+              \(raw: attributeInfo.functionArgumentList(in: context))
+            )
+          ]}
+        }
       }
       """
     )

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -172,11 +172,15 @@ struct TestsWithStaticMemberAccessBySelfKeyword {
 @Test(.hidden, arguments: [0]) func A(🙃: Int) {}
 @Test(.hidden, arguments: [0]) func A(🙂: Int) {}
 
-@Suite(.hidden)
+func asyncTrait() async -> some SuiteTrait & TestTrait {
+  .comment("")
+}
+
+@Suite(.hidden, await asyncTrait())
 struct TestsWithAsyncArguments {
   static func asyncCollection() async -> [Int] { [] }
 
-  @Test(.hidden, arguments: await asyncCollection()) func f(i: Int) {}
+  @Test(.hidden, await asyncTrait(), arguments: await asyncCollection()) func f(i: Int) {}
 }
 
 @Suite("Miscellaneous tests")


### PR DESCRIPTION
As a small follow-up to #32, ensure callers can specify `async` traits on suites too.