### PR TITLE
Refactor platforms from Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -120,7 +120,7 @@ extension Array where Element == PackageDescription.SwiftSetting {
         "-Xfrontend", "-define-availability", "-Xfrontend", "_swiftVersionAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0",
       ]),
       .enableUpcomingFeature("ExistentialAny"),
-      .define("SWT_TARGET_OS_APPLE", .when(platforms: [.macOS, .iOS, .macCatalyst, .watchOS, .tvOS, .custom("visionos")])),
+      .define("SWT_TARGET_OS_APPLE", .when(platforms: [.macOS, .iOS, .macCatalyst, .watchOS, .tvOS, .visionOS])),
     ]
   }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -17,11 +17,11 @@ let package = Package(
   name: "swift-testing",
 
   platforms: [
-    .macOS("13.0"),
-    .iOS("16.0"),
-    .watchOS("9.0"),
-    .tvOS("16.0"),
-    .custom("visionos", versionString: "1.0"),
+    .macOS(.v13),
+    .iOS(.v16),
+    .watchOS(.v9),
+    .tvOS(.v16),
+    .visionOS(.v1),
   ],
 
   products: [

--- a/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
+++ b/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
@@ -55,7 +55,7 @@ can be used with):
 
 ```swift
 platforms: [
-  .macOS("13.0"), .iOS("16.0"), .watchOS("9.0"), .tvOS("16.0"), .visionOS("1.0")
+  .macOS(.v13), .iOS(.v16), .watchOS(.v9), .tvOS(.v16), .visionOS(.v1)
 ],
 ```
 


### PR DESCRIPTION
### Motivation:

Basically, enums and static variables should be preferred over strings because they are type-safe.
Since the apple org repository serves as an example for everyone, there is a risk of being imitated because people think it is correct to use string-based.

### Modifications:

Specify version type-safe.

### Result:

Refactoring