### PR TITLE
Make sure the nesting level of sections in "Migrating from XCTest" is consistent.

### DIFF
--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -453,7 +453,7 @@ recorded otherwise:
   }
 }
 
-### Converting XCTSkip(), XCTSkipIf(), and XCTSkipUnless() calls
+#### Converting XCTSkip(), XCTSkipIf(), and XCTSkipUnless() calls
 
 When using XCTest, the [`XCTSkip`](https://developer.apple.com/documentation/xctest/xctskip)
 error type can be thrown to bypass the remainder of a test function. As well,
@@ -493,7 +493,7 @@ test function with an instance of this trait type to control whether it runs:
   }
 }
 
-### Converting XCTExpectFailure() calls
+#### Converting XCTExpectFailure() calls
 
 A test may have a known issue that sometimes or always prevents it from passing.
 When written using XCTest, such tests can call


### PR DESCRIPTION
This PR adjusts the header level of some of the sections of MigratingFromXCTest.md so that they are consistent. Namely, those sections that deal with converting specific "gadgets" within a test method/function are meant to be nested under the section about converting test methods/functions.