### PR TITLE
Refactor `SourceCode` factory functions a bit.

### DIFF
--- a/Sources/Testing/SourceAttribution/SourceCode+Macro.swift
+++ b/Sources/Testing/SourceAttribution/SourceCode+Macro.swift
@@ -8,10 +8,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-// NOTE: the overloads of `__fromComponents()` in this file all use the same
-// function name and unlabelled parameters so that the macro expansion code in
-// SourceCodeCapturing.swift does not need to be aware of different functions.
-
 extension SourceCode {
   /// Create an instance of ``SourceCode`` representing a complete syntax node.
   ///
@@ -20,7 +16,7 @@ extension SourceCode {
   ///     statement, etc.)
   ///
   /// - Returns: A new instance of ``SourceCode``.
-  public static func __fromComponents(_ syntaxNode: String) -> Self {
+  public static func __fromSyntaxNode(_ syntaxNode: String) -> Self {
     Self(kind: .syntaxNode(syntaxNode))
   }
 
@@ -32,7 +28,7 @@ extension SourceCode {
   ///   - rhs: The right-hand operand.
   ///
   /// - Returns: A new instance of ``SourceCode``.
-  public static func __fromComponents(_ lhs: String, _ op: String, _ rhs: String) -> Self {
+  public static func __fromBinaryOperation(_ lhs: String, _ op: String, _ rhs: String) -> Self {
     Self(kind: .binaryOperation(lhs: lhs, operator: op, rhs: rhs))
   }
 

--- a/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
+++ b/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
@@ -147,7 +147,7 @@ private func _parseCondition(from expr: ExprSyntax, leftOperand lhs: ExprSyntax,
       Argument(expression: "{ $0 \(op.trimmed) $1() }"),
       Argument(expression: "{ \(rhs.trimmed) }")
     ],
-    sourceCode: createSourceCodeExpr(from: lhs, op, rhs)
+    sourceCode: createSourceCodeExprForBinaryOperation(lhs, op, rhs)
   )
 }
 
@@ -169,7 +169,7 @@ private func _parseCondition(from expr: IsExprSyntax, for macro: some Freestandi
       Argument(expression: expression),
       Argument(label: .identifier("is"), expression: "\(type.trimmed).self")
     ],
-    sourceCode: createSourceCodeExpr(from: expression, expr.isKeyword, type)
+    sourceCode: createSourceCodeExprForBinaryOperation(expression, expr.isKeyword, type)
   )
 }
 
@@ -193,7 +193,7 @@ private func _parseCondition(from expr: AsExprSyntax, for macro: some Freestandi
         Argument(expression: expression),
         Argument(label: .identifier("as"), expression: "\(type.trimmed).self")
       ],
-      sourceCode: createSourceCodeExpr(from: expression, TokenSyntax.unknown("as?"), type)
+      sourceCode: createSourceCodeExprForBinaryOperation(expression, TokenSyntax.unknown("as?"), type)
     )
 
   case .exclamationMark where !type.isNamed("Bool", inModuleNamed: "Swift") && !type.isOptional:
@@ -345,7 +345,7 @@ private func _parseCondition(from expr: FunctionCallExprSyntax, for macro: some 
   return Condition(
     expandedFunctionName,
     arguments: conditionArguments,
-    sourceCode: createSourceCodeExprForMemberFunctionCall(memberAccessExpr?.base, functionName, argumentList)
+    sourceCode: createSourceCodeExprForFunctionCall(memberAccessExpr?.base, functionName, argumentList)
   )
 }
 

--- a/Sources/TestingMacros/Support/SourceCodeCapturing.swift
+++ b/Sources/TestingMacros/Support/SourceCodeCapturing.swift
@@ -11,40 +11,49 @@
 import SwiftSyntax
 
 /// Get an expression initializing an instance of ``SourceCode`` from an
-/// arbitrary sequence of syntax nodes.
+/// arbitrary syntax node.
 ///
 /// - Parameters:
-///   - nodes: One or more syntax nodes from which to construct an instance of
-///     ``SourceCode``. If an element in this sequence is `nil`, a `nil` literal
-///     is passed instead of a string literal.
+///   - node: A syntax node from which to construct an instance of
+///     ``SourceCode``.
 ///
 /// - Returns: An expression value that initializes an instance of
-///   ``SourceCode`` for the syntax nodes in `nodes`.
-func createSourceCodeExpr(from nodes: (any SyntaxProtocol)?...) -> ExprSyntax {
-  let arguments = LabeledExprListSyntax {
-    for node in nodes {
-      if let node {
-        LabeledExprSyntax(expression: StringLiteralExprSyntax(content: node.trimmedDescription))
-      } else {
-        LabeledExprSyntax(expression: NilLiteralExprSyntax())
-      }
-    }
-  }
-
-  return ".__fromComponents(\(arguments))"
+///   ``SourceCode`` for the specified syntax node.
+func createSourceCodeExpr(from node: any SyntaxProtocol) -> ExprSyntax {
+  ".__fromSyntaxNode(\(literal: node.trimmedDescription))"
 }
 
 /// Get an expression initializing an instance of ``SourceCode`` from an
-/// arbitrary sequence of syntax nodes.
+/// arbitrary sequence of syntax nodes representing a binary operation.
 ///
 /// - Parameters:
-///   - value: The value on which the member function is being called.
+///   - lhs: The left-hand operand.
+///   - operator: The operator.
+///   - rhs: The right-hand operand.
+///
+/// - Returns: An expression value that initializes an instance of
+///   ``SourceCode`` for the specified syntax nodes.
+func createSourceCodeExprForBinaryOperation(_ lhs: some SyntaxProtocol, _ `operator`: some SyntaxProtocol, _ rhs: some SyntaxProtocol) -> ExprSyntax {
+  let arguments = LabeledExprListSyntax {
+    LabeledExprSyntax(expression: StringLiteralExprSyntax(content: lhs.trimmedDescription))
+    LabeledExprSyntax(expression: StringLiteralExprSyntax(content: `operator`.trimmedDescription))
+    LabeledExprSyntax(expression: StringLiteralExprSyntax(content: rhs.trimmedDescription))
+  }
+
+  return ".__fromBinaryOperation(\(arguments))"
+}
+
+/// Get an expression initializing an instance of ``SourceCode`` from an
+/// arbitrary sequence of syntax nodes representing a function call.
+///
+/// - Parameters:
+///   - value: The value on which the member function is being called, if any.
 ///   - functionName: The name of the member function being called.
 ///   - arguments: The arguments to the member function.
 ///
 /// - Returns: An expression value that initializes an instance of
 ///   ``SourceCode`` for the specified syntax nodes.
-func createSourceCodeExprForMemberFunctionCall(_ value: (some SyntaxProtocol)?, _ functionName: some SyntaxProtocol, _ arguments: some Sequence<Argument>) -> ExprSyntax {
+func createSourceCodeExprForFunctionCall(_ value: (some SyntaxProtocol)?, _ functionName: some SyntaxProtocol, _ arguments: some Sequence<Argument>) -> ExprSyntax {
   let arguments = LabeledExprListSyntax {
     if let value {
       LabeledExprSyntax(expression: StringLiteralExprSyntax(content: value.trimmedDescription))

--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -23,33 +23,33 @@ struct ConditionMacroTests {
   @Test("#expect() macro",
     arguments: [
       ##"#expect(true)"##:
-        ##"Testing.__checkValue(true, sourceCode: .__fromComponents("true"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkValue(true, sourceCode: .__fromSyntaxNode("true"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(false)"##:
-        ##"Testing.__checkValue(false, sourceCode: .__fromComponents("false"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkValue(false, sourceCode: .__fromSyntaxNode("false"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(false, "Custom message")"##:
-        ##"Testing.__checkValue(false, sourceCode: .__fromComponents("false"), comments: ["Custom message"], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkValue(false, sourceCode: .__fromSyntaxNode("false"), comments: ["Custom message"], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(2 > 1)"##:
-        ##"Testing.__checkBinaryOperation(2, { $0 > $1() }, { 1 }, sourceCode: .__fromComponents("2", ">", "1"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkBinaryOperation(2, { $0 > $1() }, { 1 }, sourceCode: .__fromBinaryOperation("2", ">", "1"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(((true || false) && true) || Bool.random())"##:
-        ##"Testing.__checkBinaryOperation(((true || false) && true), { $0 || $1() }, { Bool.random() }, sourceCode: .__fromComponents("((true || false) && true)", "||", "Bool.random()"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkBinaryOperation(((true || false) && true), { $0 || $1() }, { Bool.random() }, sourceCode: .__fromBinaryOperation("((true || false) && true)", "||", "Bool.random()"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(9 > 8 && 7 > 6, "Some comment")"##:
-        ##"Testing.__checkBinaryOperation(9 > 8, { $0 && $1() }, { 7 > 6 }, sourceCode: .__fromComponents("9 > 8", "&&", "7 > 6"), comments: ["Some comment"], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkBinaryOperation(9 > 8, { $0 && $1() }, { 7 > 6 }, sourceCode: .__fromBinaryOperation("9 > 8", "&&", "7 > 6"), comments: ["Some comment"], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(!Bool.random())"##:
-        ##"Testing.__checkValue(!Bool.random(), sourceCode: .__fromComponents("!Bool.random()"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkValue(!Bool.random(), sourceCode: .__fromSyntaxNode("!Bool.random()"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect((true && false))"##:
-        ##"Testing.__checkBinaryOperation(true, { $0 && $1() }, { false }, sourceCode: .__fromComponents("true", "&&", "false"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkBinaryOperation(true, { $0 && $1() }, { false }, sourceCode: .__fromBinaryOperation("true", "&&", "false"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(try x())"##:
-        ##"Testing.__checkValue(try x(), sourceCode: .__fromComponents("try x()"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkValue(try x(), sourceCode: .__fromSyntaxNode("try x()"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(1 is Int)"##:
-        ##"Testing.__checkCast(1, is: Int.self, sourceCode: .__fromComponents("1", "is", "Int"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkCast(1, is: Int.self, sourceCode: .__fromBinaryOperation("1", "is", "Int"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect("123") { 1 == 2 } then: { foo() }"##:
-        ##"Testing.__checkClosureCall(performing: { 1 == 2 }, then: { foo() }, sourceCode: .__fromComponents("1", "==", "2"), comments: ["123"], isRequired: false, sourceLocation:Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkClosureCall(performing: { 1 == 2 }, then: { foo() }, sourceCode: .__fromBinaryOperation("1", "==", "2"), comments: ["123"], isRequired: false, sourceLocation:Testing.SourceLocation()).__expected()"##,
       ##"#expect("123") { let x = 0 }"##:
-        ##"Testing.__checkClosureCall(performing: { let x = 0 }, sourceCode: .__fromComponents("let x = 0"), comments: ["123"], isRequired: false, sourceLocation:Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkClosureCall(performing: { let x = 0 }, sourceCode: .__fromSyntaxNode("let x = 0"), comments: ["123"], isRequired: false, sourceLocation:Testing.SourceLocation()).__expected()"##,
       ##"#expect("123") { let x = 0; return x == 0 }"##:
-        ##"Testing.__checkClosureCall(performing: { let x = 0; return x == 0 }, sourceCode: .__fromComponents("{ let x = 0; return x == 0 }"), comments: ["123"], isRequired: false, sourceLocation:Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkClosureCall(performing: { let x = 0; return x == 0 }, sourceCode: .__fromSyntaxNode("{ let x = 0; return x == 0 }"), comments: ["123"], isRequired: false, sourceLocation:Testing.SourceLocation()).__expected()"##,
       ##"#expect(a, "b", c: c)"##:
-        ##"Testing.__checkValue(a, c: c, sourceCode: .__fromComponents("a"), comments: ["b"], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkValue(a, c: c, sourceCode: .__fromSyntaxNode("a"), comments: ["b"], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(a())"##:
         ##"Testing.__checkFunctionCall((), calling: { _ in a() }, sourceCode: .__functionCall(nil, "a"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(b(c))"##:
@@ -61,19 +61,19 @@ struct ConditionMacroTests {
       ##"#expect(a.b(&c))"##:
         ##"Testing.__checkInoutFunctionCall(a.self, calling: { $0.b(&$1) }, &c, sourceCode: .__functionCall("a", "b", (nil, "&c")), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(a.b(&c, &d))"##:
-        ##"Testing.__checkValue(a.b(&c, &d), sourceCode: .__fromComponents("a.b(&c, &d)"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkValue(a.b(&c, &d), sourceCode: .__fromSyntaxNode("a.b(&c, &d)"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(a.b(&c, d))"##:
-        ##"Testing.__checkValue(a.b(&c, d), sourceCode: .__fromComponents("a.b(&c, d)"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkValue(a.b(&c, d), sourceCode: .__fromSyntaxNode("a.b(&c, d)"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(a.b(try c()))"##:
-        ##"Testing.__checkValue(a.b(try c()), sourceCode: .__fromComponents("a.b(try c())"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkValue(a.b(try c()), sourceCode: .__fromSyntaxNode("a.b(try c())"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect({}())"##:
-        ##"Testing.__checkValue({}(), sourceCode: .__fromComponents("{}()"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkValue({}(), sourceCode: .__fromSyntaxNode("{}()"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(a.b(c: d))"##:
         ##"Testing.__checkFunctionCall(a.self, calling: { $0.b(c: $1) }, d, sourceCode: .__functionCall("a", "b", ("c", "d")), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(a.b { c })"##:
-        ##"Testing.__checkValue(a.b { c }, sourceCode: .__fromComponents("a.b { c }"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkValue(a.b { c }, sourceCode: .__fromSyntaxNode("a.b { c }"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(a, sourceLocation: someValue)"##:
-        ##"Testing.__checkValue(a, sourceCode: .__fromComponents("a"), comments: [], isRequired: false, sourceLocation: someValue).__expected()"##,
+        ##"Testing.__checkValue(a, sourceCode: .__fromSyntaxNode("a"), comments: [], isRequired: false, sourceLocation: someValue).__expected()"##,
     ]
   )
   func expectMacro(input: String, expectedOutput: String) throws {
@@ -85,33 +85,33 @@ struct ConditionMacroTests {
   @Test("#require() macro",
     arguments: [
       ##"#require(true)"##:
-        ##"Testing.__checkValue(true, sourceCode: .__fromComponents("true"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkValue(true, sourceCode: .__fromSyntaxNode("true"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(false)"##:
-        ##"Testing.__checkValue(false, sourceCode: .__fromComponents("false"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkValue(false, sourceCode: .__fromSyntaxNode("false"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(false, "Custom message")"##:
-        ##"Testing.__checkValue(false, sourceCode: .__fromComponents("false"), comments: ["Custom message"], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkValue(false, sourceCode: .__fromSyntaxNode("false"), comments: ["Custom message"], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(2 > 1)"##:
-        ##"Testing.__checkBinaryOperation(2, { $0 > $1() }, { 1 }, sourceCode: .__fromComponents("2", ">", "1"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkBinaryOperation(2, { $0 > $1() }, { 1 }, sourceCode: .__fromBinaryOperation("2", ">", "1"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(((true || false) && true) || Bool.random())"##:
-        ##"Testing.__checkBinaryOperation(((true || false) && true), { $0 || $1() }, { Bool.random() }, sourceCode: .__fromComponents("((true || false) && true)", "||", "Bool.random()"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkBinaryOperation(((true || false) && true), { $0 || $1() }, { Bool.random() }, sourceCode: .__fromBinaryOperation("((true || false) && true)", "||", "Bool.random()"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(9 > 8 && 7 > 6, "Some comment")"##:
-        ##"Testing.__checkBinaryOperation(9 > 8, { $0 && $1() }, { 7 > 6 }, sourceCode: .__fromComponents("9 > 8", "&&", "7 > 6"), comments: ["Some comment"], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkBinaryOperation(9 > 8, { $0 && $1() }, { 7 > 6 }, sourceCode: .__fromBinaryOperation("9 > 8", "&&", "7 > 6"), comments: ["Some comment"], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(!Bool.random())"##:
-        ##"Testing.__checkValue(!Bool.random(), sourceCode: .__fromComponents("!Bool.random()"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkValue(!Bool.random(), sourceCode: .__fromSyntaxNode("!Bool.random()"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require((true && false))"##:
-        ##"Testing.__checkBinaryOperation(true, { $0 && $1() }, { false }, sourceCode: .__fromComponents("true", "&&", "false"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkBinaryOperation(true, { $0 && $1() }, { false }, sourceCode: .__fromBinaryOperation("true", "&&", "false"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(try x())"##:
-        ##"Testing.__checkValue(try x(), sourceCode: .__fromComponents("try x()"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkValue(try x(), sourceCode: .__fromSyntaxNode("try x()"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(1 is Int)"##:
-        ##"Testing.__checkCast(1, is: Int.self, sourceCode: .__fromComponents("1", "is", "Int"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkCast(1, is: Int.self, sourceCode: .__fromBinaryOperation("1", "is", "Int"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require("123") { 1 == 2 } then: { foo() }"##:
-        ##"Testing.__checkClosureCall(performing: { 1 == 2 }, then: { foo() }, sourceCode: .__fromComponents("1", "==", "2"), comments: ["123"], isRequired: true, sourceLocation:Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkClosureCall(performing: { 1 == 2 }, then: { foo() }, sourceCode: .__fromBinaryOperation("1", "==", "2"), comments: ["123"], isRequired: true, sourceLocation:Testing.SourceLocation()).__required()"##,
       ##"#require("123") { let x = 0 }"##:
-        ##"Testing.__checkClosureCall(performing: { let x = 0 }, sourceCode: .__fromComponents("let x = 0"), comments: ["123"], isRequired: true, sourceLocation:Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkClosureCall(performing: { let x = 0 }, sourceCode: .__fromSyntaxNode("let x = 0"), comments: ["123"], isRequired: true, sourceLocation:Testing.SourceLocation()).__required()"##,
       ##"#require("123") { let x = 0; return x == 0 }"##:
-        ##"Testing.__checkClosureCall(performing: { let x = 0; return x == 0 }, sourceCode: .__fromComponents("{ let x = 0; return x == 0 }"), comments: ["123"], isRequired: true, sourceLocation:Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkClosureCall(performing: { let x = 0; return x == 0 }, sourceCode: .__fromSyntaxNode("{ let x = 0; return x == 0 }"), comments: ["123"], isRequired: true, sourceLocation:Testing.SourceLocation()).__required()"##,
       ##"#require(a, "b", c: c)"##:
-        ##"Testing.__checkValue(a, c: c, sourceCode: .__fromComponents("a"), comments: ["b"], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkValue(a, c: c, sourceCode: .__fromSyntaxNode("a"), comments: ["b"], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(a())"##:
         ##"Testing.__checkFunctionCall((), calling: { _ in a() }, sourceCode: .__functionCall(nil, "a"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(b(c))"##:
@@ -123,19 +123,19 @@ struct ConditionMacroTests {
       ##"#require(a.b(&c))"##:
         ##"Testing.__checkInoutFunctionCall(a.self, calling: { $0.b(&$1) }, &c, sourceCode: .__functionCall("a", "b", (nil, "&c")), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(a.b(&c, &d))"##:
-        ##"Testing.__checkValue(a.b(&c, &d), sourceCode: .__fromComponents("a.b(&c, &d)"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkValue(a.b(&c, &d), sourceCode: .__fromSyntaxNode("a.b(&c, &d)"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(a.b(&c, d))"##:
-        ##"Testing.__checkValue(a.b(&c, d), sourceCode: .__fromComponents("a.b(&c, d)"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkValue(a.b(&c, d), sourceCode: .__fromSyntaxNode("a.b(&c, d)"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(a.b(try c()))"##:
-        ##"Testing.__checkValue(a.b(try c()), sourceCode: .__fromComponents("a.b(try c())"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkValue(a.b(try c()), sourceCode: .__fromSyntaxNode("a.b(try c())"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require({}())"##:
-        ##"Testing.__checkValue({}(), sourceCode: .__fromComponents("{}()"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkValue({}(), sourceCode: .__fromSyntaxNode("{}()"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(a.b(c: d))"##:
         ##"Testing.__checkFunctionCall(a.self, calling: { $0.b(c: $1) }, d, sourceCode: .__functionCall("a", "b", ("c", "d")), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(a.b { c })"##:
-        ##"Testing.__checkValue(a.b { c }, sourceCode: .__fromComponents("a.b { c }"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkValue(a.b { c }, sourceCode: .__fromSyntaxNode("a.b { c }"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(a, sourceLocation: someValue)"##:
-        ##"Testing.__checkValue(a, sourceCode: .__fromComponents("a"), comments: [], isRequired: true, sourceLocation: someValue).__required()"##,
+        ##"Testing.__checkValue(a, sourceCode: .__fromSyntaxNode("a"), comments: [], isRequired: true, sourceLocation: someValue).__required()"##,
     ]
   )
   func requireMacro(input: String, expectedOutput: String) throws {
@@ -147,17 +147,17 @@ struct ConditionMacroTests {
   @Test("Unwrapping #require() macro",
     arguments: [
       ##"#require(Optional<Int>.none)"##:
-        ##"Testing.__checkValue(Optional<Int>.none, sourceCode: .__fromComponents("Optional<Int>.none"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkValue(Optional<Int>.none, sourceCode: .__fromSyntaxNode("Optional<Int>.none"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(nil ?? 123)"##:
-        ##"Testing.__checkBinaryOperation(nil, { $0 ?? $1() }, { 123 }, sourceCode: .__fromComponents("nil", "??", "123"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkBinaryOperation(nil, { $0 ?? $1() }, { 123 }, sourceCode: .__fromBinaryOperation("nil", "??", "123"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(123 ?? nil)"##:
-        ##"Testing.__checkBinaryOperation(123, { $0 ?? $1() }, { nil }, sourceCode: .__fromComponents("123", "??", "nil"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkBinaryOperation(123, { $0 ?? $1() }, { nil }, sourceCode: .__fromBinaryOperation("123", "??", "nil"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(123 as? Double)"##:
-        ##"Testing.__checkCast(123,as: Double.self, sourceCode: .__fromComponents("123", "as?", "Double"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkCast(123,as: Double.self, sourceCode: .__fromBinaryOperation("123", "as?", "Double"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(123 as Double)"##:
-        ##"Testing.__checkValue(123 as Double, sourceCode: .__fromComponents("123 as Double"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkValue(123 as Double, sourceCode: .__fromSyntaxNode("123 as Double"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(123 as! Double)"##:
-        ##"Testing.__checkValue(123 as! Double, sourceCode: .__fromComponents("123 as! Double"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkValue(123 as! Double, sourceCode: .__fromSyntaxNode("123 as! Double"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
     ]
   )
   func unwrappingRequireMacro(input: String, expectedOutput: String) throws {
@@ -176,7 +176,7 @@ struct ConditionMacroTests {
       """
       // Source comment
       /** Doc comment */
-      Testing.__checkValue(try x(), sourceCode: .__fromComponents("try x()"), comments: [.__line("// Source comment"),.__documentationBlock("/** Doc comment */"),"Argument comment"], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()
+      Testing.__checkValue(try x(), sourceCode: .__fromSyntaxNode("try x()"), comments: [.__line("// Source comment"),.__documentationBlock("/** Doc comment */"),"Argument comment"], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()
       """,
 
       """
@@ -189,7 +189,7 @@ struct ConditionMacroTests {
       // Ignore me
 
       // Capture me
-      Testing.__checkValue(try x(), sourceCode: .__fromComponents("try x()"), comments: [.__line("// Capture me")], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()
+      Testing.__checkValue(try x(), sourceCode: .__fromSyntaxNode("try x()"), comments: [.__line("// Capture me")], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()
       """,
 
       """
@@ -202,7 +202,7 @@ struct ConditionMacroTests {
       // Ignore me
       \t
       // Capture me
-      Testing.__checkValue(try x(), sourceCode: .__fromComponents("try x()"), comments: [.__line("// Capture me")], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()
+      Testing.__checkValue(try x(), sourceCode: .__fromSyntaxNode("try x()"), comments: [.__line("// Capture me")], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()
       """,
     ]
   )
@@ -276,7 +276,7 @@ struct ConditionMacroTests {
     let rawExpectedOutput = ##"""
       @Test("Random number generation") func rng() {
         let number = Int.random(in: 1 ..< .max)
-        Testing.__checkBinaryOperation((number > 0 && foo() != bar(at: 9)), { $0 != $1() }, { !true }, sourceCode: .__fromComponents("(number > 0 && foo() != bar(at: 9))", "!=", "!true"), comments: ["\(number) must be greater than 0"], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()
+        Testing.__checkBinaryOperation((number > 0 && foo() != bar(at: 9)), { $0 != $1() }, { !true }, sourceCode: .__fromBinaryOperation("(number > 0 && foo() != bar(at: 9))", "!=", "!true"), comments: ["\(number) must be greater than 0"], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()
       }
     """##
 

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -267,7 +267,7 @@ struct TestDeclarationMacroTests {
     let (output, _) = try parse("@Test(.tags(\"1\", .x), .tags([\"ABC\"]), .unrelated) func f() {}")
     #expect(output.contains("\"1\""))
     #expect(!output.contains("Testing.Tag.__tag(\"1\", sourceCode: "))
-    #expect(output.contains("Testing.Tag.__tag(.x, sourceCode: .__fromComponents(\".x\"))"))
+    #expect(output.contains("Testing.Tag.__tag(.x, sourceCode: .__fromSyntaxNode(\".x\"))"))
     #expect(output.contains("\"ABC\""))
     #expect(!output.contains("Testing.Tag.__tag(\"ABC\", sourceCode: "))
     #expect(output.contains(".unrelated"))


### PR DESCRIPTION
Right now, we have two overloads of `__fromComponents()` that really should be separate functions entirely. Refactor/rename to eliminate ambiguity during macro expansion.