### PR TITLE
Silence warnings on the latest toolchain.

### DIFF
--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -389,19 +389,6 @@ struct MiscellaneousTests {
     #expect(tests.map(\.displayName) == ["A", "B", "C", "D", "E", "F", "G"])
   }
 
-  @Test("Parameterizing using lazy collections",
-    .disabled("Lazy collections are not sendable, so are not selected during overload resolution (favoring arrays instead.)"),
-    .bug("rdar://104169208")
-  )
-  func testParameterizedOverLazyCollection() async throws {
-    // Test that functional transformations on the collection are supported.
-    let range = 1 ... 100
-    let test = Test(arguments: range.lazy.map(-)) { i in
-      #expect(i < 0)
-    }
-    await test.run()
-  }
-
   @Test("Parameterizing over a collection with a poor underestimatedCount property")
   func testParameterizedOverCollectionWithBadUnderestimatedCount() async throws {
     struct PoorlyEstimatedCollection<C>: Collection where C: Collection & Sendable {
@@ -487,7 +474,7 @@ struct MiscellaneousTests {
     let line = 12345
     let column = 67890
     let sourceLocation = SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column)
-    let testFunction = await Test.__function(named: "myTestFunction()", in: nil, xcTestCompatibleSelector: nil, displayName: nil, traits: [], sourceLocation: sourceLocation) {}
+    let testFunction = Test.__function(named: "myTestFunction()", in: nil, xcTestCompatibleSelector: nil, displayName: nil, traits: [], sourceLocation: sourceLocation) {}
     #expect(String(describing: testFunction.id) == "Module/myTestFunction()/Y.swift:12345:67890")
   }
 


### PR DESCRIPTION
This PR resolves these recent warnings:

```
/Volumes/Dev/Source/swift-testing/Tests/TestingTests/MiscellaneousTests.swift:399:16: warning: type 'LazyMapSequence<LazySequence<ClosedRange<Int>>.Elements, Int>' (aka 'LazyMapSequence<ClosedRange<Int>, Int>') does not conform to the 'Sendable' protocol
    let test = Test(arguments: range.lazy.map(-)) { i in
               ^
Swift.LazyMapSequence:1:23: note: generic struct 'LazyMapSequence' does not conform to the 'Sendable' protocol
@frozen public struct LazyMapSequence<Base, Element> where Base : Sequence {
                      ^
/Volumes/Dev/Source/swift-testing/Tests/TestingTests/MiscellaneousTests.swift:490:24: warning: no 'async' operations occur within 'await' expression
    let testFunction = await Test.__function(named: "myTestFunction()", in: nil, xcTestCompatibleSelector: nil, displayName: nil, traits: [], sourceLocation: sourceLocation) {}
                       ^
```