### PR TITLE
Generalize the selectedTests facility to be closure-based, to allow filtering tests via other criteria than ID

### DIFF
--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -141,6 +141,7 @@ public struct Configuration: Sendable {
   ///
   /// - Parameters:
   ///   - test: An test that needs to be filtered.
+  ///   
   /// - Returns: A Boolean value representing if the test satisfied the filter.
   public typealias TestFilter = @Sendable (Test) -> Bool
 
@@ -150,10 +151,17 @@ public struct Configuration: Sendable {
   /// The granularity to enforce test filtering.
   /// 
   /// By default, all tests are run and no filter is set.
+  /// - Parameters:
+  ///   - selection: An set of test ids to be filtered.
   public mutating func setTestFilter(toMatch selection: Set<Test.ID>?) {
-      self.setTestFilter(toMatch: selection.map({ Test.ID.Selection(testIDs: $0) }))
+      self.setTestFilter(toMatch: selection.map(Test.ID.Selection.init))
   }
-    
+  
+  /// The granularity to enforce test filtering.
+  ///
+  /// By default, all tests are run and no filter is set.
+  /// - Parameters:
+  ///   - selection: An selection of test ids to be filtered.
   mutating func setTestFilter(toMatch selection: Test.ID.Selection?) {
     guard let selectedTests = selection else {
         self.testFilter = nil

--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -137,38 +137,16 @@ public struct Configuration: Sendable {
 
   // MARK: - Test selection
 
-  /// The selected tests to run, if any.
-  ///
-  /// This property should be used for testing membership (whether a test ID has
-  /// been selected) since it is more optimized for that use case. It also
-  /// provides the backing storage for ``selectedTestIDs``.
-  ///
-  /// This property is optional and defaults to `nil` because it is possible to
-  /// select specific tests to run but not provide any tests in that list. That
-  /// is a supported use case: it results in zero tests being run and no issues
-  /// recorded.
-  ///
-  /// A practical example of when this situation can happen is when testing is
-  /// configured via an Xcode Test Plan, the "Automatically Include New Tests"
-  /// option is disabled, and zero tests are enabled.
-  var selectedTests: Test.ID.Selection?
+  // TODO: Write DocC documenting this typealias.
+  //
+  // (Note: this typealias may also be used to eventually implement a similar
+  // filter property for **skipped** tests. But that doesn't need to be
+  // mentioned in the DocC.)
+  public typealias TestPredicate = @Sendable (Test) -> Bool
 
-  /// The IDs of the selected tests to run, if any.
-  ///
-  /// This property is optional and defaults to `nil` because it is possible to
-  /// select specific tests to run but not provide any tests in that list. That
-  /// is a supported use case: it results in zero tests being run and no issues
-  /// recorded.
-  ///
-  /// A practical example of when this situation can happen is when testing is
-  /// configured via an Xcode Test Plan, the "Automatically Include New Tests"
-  /// option is disabled, and zero tests are enabled.
-  public var selectedTestIDs: Set<Test.ID>? {
-    get {
-      selectedTests?.testIDs
-    }
-    set {
-      selectedTests = newValue.map { .init(testIDs: $0) }
-    }
-  }
+  // TODO: Choose better name for this property.
+  //
+  // TODO: Write DocC documenting this property, explaining its purpose and
+  // potentially including an example of its most common usage patterns.
+  public var testSelectionFilter: TestPredicate?
 }

--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -137,16 +137,25 @@ public struct Configuration: Sendable {
 
   // MARK: - Test selection
 
-  // TODO: Write DocC documenting this typealias.
-  //
-  // (Note: this typealias may also be used to eventually implement a similar
-  // filter property for **skipped** tests. But that doesn't need to be
-  // mentioned in the DocC.)
-  public typealias TestPredicate = @Sendable (Test) -> Bool
+  /// A function that handles filtering tests.
+  ///
+  /// - Parameters:
+  ///   - test: An test that needs to be filtered.
+  /// - Returns: A Boolean value representing if the test satisfied the filter.
+  public typealias TestFilter = @Sendable (Test) -> Bool
 
-  // TODO: Choose better name for this property.
-  //
-  // TODO: Write DocC documenting this property, explaining its purpose and
-  // potentially including an example of its most common usage patterns.
-  public var testSelectionFilter: TestPredicate?
+  /// The test filter to which tests should be filtered when run.
+  public var testFilter: TestFilter?
+
+  /// The granularity to enforce test filtering.
+  /// 
+  /// By default, all tests are run and no filter is set.
+  @_spi(ExperimentalTestFilter)
+  public mutating func setTestFilter(toMatch selection: Set<Test.ID>?) {
+      if let selectedTests = selection.map({ Test.ID.Selection(testIDs: $0) }) {
+          self.testFilter = { test in
+              selectedTests.contains(test)
+          }
+      }
+  }
 }

--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -150,12 +150,17 @@ public struct Configuration: Sendable {
   /// The granularity to enforce test filtering.
   /// 
   /// By default, all tests are run and no filter is set.
-  @_spi(ExperimentalTestFilter)
   public mutating func setTestFilter(toMatch selection: Set<Test.ID>?) {
-      if let selectedTests = selection.map({ Test.ID.Selection(testIDs: $0) }) {
-          self.testFilter = { test in
-              selectedTests.contains(test)
-          }
-      }
+      self.setTestFilter(toMatch: selection.map({ Test.ID.Selection(testIDs: $0) }))
+  }
+    
+  mutating func setTestFilter(toMatch selection: Test.ID.Selection?) {
+    guard let selectedTests = selection else {
+        self.testFilter = nil
+        return
+    }
+    self.testFilter = { test in
+        selectedTests.contains(test)
+    }
   }
 }

--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -122,7 +122,6 @@ extension Runner.Plan {
     }
   }
 
-  // TODO: Update DocC
   /// Determine if a test is included in the selected test IDs, if any are
   /// configured.
   ///

--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -127,8 +127,6 @@ extension Runner.Plan {
   ///
   /// - Parameters:
   ///   - test: The test to query.
-  ///   - selectedTests: The selected test IDs to use in determining whether
-  ///     `test` is selected, if one is configured.
   ///   - filter: The filter to decide if the test is included.
   ///
   /// - Returns: Whether or not the specified test is selected. If

--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -122,6 +122,7 @@ extension Runner.Plan {
     }
   }
 
+  // TODO: Update DocC
   /// Determine if a test is included in the selected test IDs, if any are
   /// configured.
   ///
@@ -133,11 +134,11 @@ extension Runner.Plan {
   /// - Returns: Whether or not the specified test is selected. If
   ///   `selectedTests` is `nil`, `test` is considered selected if it is not
   ///   hidden.
-  private static func _isTestIncluded(_ test: Test, in selectedTests: Test.ID.Selection?) -> Bool {
-    guard let selectedTests else {
+  private static func _isTestIncluded(_ test: Test, using predicate: Configuration.TestPredicate?) -> Bool {
+    guard let predicate else {
       return !test.isHidden
     }
-    return selectedTests.contains(test)
+    return predicate(test)
   }
 
   /// Construct a graph of runner plan steps for the specified tests.
@@ -160,8 +161,7 @@ extension Runner.Plan {
     // them, in which case it will be .recordIssue().
     var testGraph = Graph<String, Test?>()
     var actionGraph = Graph<String, Action>(value: .run)
-    let selectedTests = configuration.selectedTests
-    for test in tests where _isTestIncluded(test, in: selectedTests) {
+    for test in tests where _isTestIncluded(test, using: configuration.testSelectionFilter) {
       let idComponents = test.id.keyPathRepresentation
       testGraph.insertValue(test, at: idComponents)
       actionGraph.insertValue(.run, at: idComponents, intermediateValue: .run)

--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -130,15 +130,16 @@ extension Runner.Plan {
   ///   - test: The test to query.
   ///   - selectedTests: The selected test IDs to use in determining whether
   ///     `test` is selected, if one is configured.
+  ///   - filter: The filter to decide if the test is included.
   ///
   /// - Returns: Whether or not the specified test is selected. If
   ///   `selectedTests` is `nil`, `test` is considered selected if it is not
   ///   hidden.
-  private static func _isTestIncluded(_ test: Test, using predicate: Configuration.TestFilter?) -> Bool {
-    guard let predicate else {
+  private static func _isTestIncluded(_ test: Test, using filter: Configuration.TestFilter?) -> Bool {
+    guard let filter else {
       return !test.isHidden
     }
-    return predicate(test)
+    return filter(test)
   }
 
   /// Construct a graph of runner plan steps for the specified tests.

--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -134,7 +134,7 @@ extension Runner.Plan {
   /// - Returns: Whether or not the specified test is selected. If
   ///   `selectedTests` is `nil`, `test` is considered selected if it is not
   ///   hidden.
-  private static func _isTestIncluded(_ test: Test, using predicate: Configuration.TestPredicate?) -> Bool {
+  private static func _isTestIncluded(_ test: Test, using predicate: Configuration.TestFilter?) -> Bool {
     guard let predicate else {
       return !test.isHidden
     }
@@ -161,7 +161,7 @@ extension Runner.Plan {
     // them, in which case it will be .recordIssue().
     var testGraph = Graph<String, Test?>()
     var actionGraph = Graph<String, Action>(value: .run)
-    for test in tests where _isTestIncluded(test, using: configuration.testSelectionFilter) {
+    for test in tests where _isTestIncluded(test, using: configuration.testFilter) {
       let idComponents = test.id.keyPathRepresentation
       testGraph.insertValue(test, at: idComponents)
       actionGraph.insertValue(.run, at: idComponents, intermediateValue: .run)

--- a/Tests/TestingTests/PlanTests.swift
+++ b/Tests/TestingTests/PlanTests.swift
@@ -29,9 +29,10 @@ struct PlanTests {
       testB,
     ]
 
+    let selection = Test.ID.Selection(testIDs: [innerTestType.id])
     var configuration = Configuration()
-    configuration.testSelectionFilter = { test in
-      Test.ID.Selection(testIDs: [innerTestType.id]).contains(test)
+    configuration.testFilter = { test in
+        selection.contains(test)
     }
 
     let plan = await Runner.Plan(tests: tests, configuration: configuration)
@@ -56,8 +57,9 @@ struct PlanTests {
     ]
 
     var configuration = Configuration()
-    configuration.testSelectionFilter = { test in
-      Test.ID.Selection(testIDs: [innerTestType.id, outerTestType.id]).contains(test)
+    let selection = Test.ID.Selection(testIDs: [innerTestType.id, outerTestType.id])
+    configuration.testFilter = { test in
+        selection.contains(test)
     }
 
     let plan = await Runner.Plan(tests: tests, configuration: configuration)
@@ -77,7 +79,7 @@ struct PlanTests {
     let tests = [outerTestType, deeplyNestedTest]
 
     var configuration = Configuration()
-    configuration.testSelectionFilter = { test in
+    configuration.testFilter = { test in
       Test.ID.Selection(testIDs: [outerTestType.id, deeplyNestedTest.id]).contains(test)
     }
 
@@ -97,8 +99,9 @@ struct PlanTests {
     let tests = [testSuiteA, testSuiteB, testSuiteC, testFuncX]
 
     var configuration = Configuration()
-    configuration.testSelectionFilter = { test in
-      Test.ID.Selection(testIDs: [testSuiteA.id]).contains(test)
+    let selection = Test.ID.Selection(testIDs: [testSuiteA.id])
+    configuration.testFilter = { test in
+      selection.contains(test)
     }
 
     let plan = await Runner.Plan(tests: tests, configuration: configuration)

--- a/Tests/TestingTests/PlanTests.swift
+++ b/Tests/TestingTests/PlanTests.swift
@@ -12,6 +12,9 @@
 
 @Suite("Runner.Plan Tests")
 struct PlanTests {
+  // TODO: Potentially update the names of tests below which reference "selected
+  // tests" based on naming changes elsewhere.
+
   @Test("Selected tests")
   func selectedTests() async throws {
     let outerTestType = try #require(await test(for: SendableTests.self))
@@ -27,7 +30,9 @@ struct PlanTests {
     ]
 
     var configuration = Configuration()
-    configuration.selectedTestIDs = [innerTestType.id]
+    configuration.testSelectionFilter = { test in
+      Test.ID.Selection(testIDs: [innerTestType.id]).contains(test)
+    }
 
     let plan = await Runner.Plan(tests: tests, configuration: configuration)
     #expect(plan.steps.contains(where: { $0.test == outerTestType }))
@@ -51,7 +56,9 @@ struct PlanTests {
     ]
 
     var configuration = Configuration()
-    configuration.selectedTestIDs = [innerTestType.id, outerTestType.id]
+    configuration.testSelectionFilter = { test in
+      Test.ID.Selection(testIDs: [innerTestType.id, outerTestType.id]).contains(test)
+    }
 
     let plan = await Runner.Plan(tests: tests, configuration: configuration)
     let planTests = plan.steps.map(\.test)
@@ -70,7 +77,9 @@ struct PlanTests {
     let tests = [outerTestType, deeplyNestedTest]
 
     var configuration = Configuration()
-    configuration.selectedTestIDs = [outerTestType.id, deeplyNestedTest.id]
+    configuration.testSelectionFilter = { test in
+      Test.ID.Selection(testIDs: [outerTestType.id, deeplyNestedTest.id]).contains(test)
+    }
 
     let plan = await Runner.Plan(tests: tests, configuration: configuration)
 
@@ -88,7 +97,9 @@ struct PlanTests {
     let tests = [testSuiteA, testSuiteB, testSuiteC, testFuncX]
 
     var configuration = Configuration()
-    configuration.selectedTestIDs = [testSuiteA.id]
+    configuration.testSelectionFilter = { test in
+      Test.ID.Selection(testIDs: [testSuiteA.id]).contains(test)
+    }
 
     let plan = await Runner.Plan(tests: tests, configuration: configuration)
     let testFuncXWithTraits = try #require(plan.steps.map(\.test).first { $0.name == "x()" })

--- a/Tests/TestingTests/PlanTests.swift
+++ b/Tests/TestingTests/PlanTests.swift
@@ -31,9 +31,7 @@ struct PlanTests {
 
     let selection = Test.ID.Selection(testIDs: [innerTestType.id])
     var configuration = Configuration()
-    configuration.testFilter = { test in
-        selection.contains(test)
-    }
+    configuration.setTestFilter(toMatch: selection)
 
     let plan = await Runner.Plan(tests: tests, configuration: configuration)
     #expect(plan.steps.contains(where: { $0.test == outerTestType }))
@@ -58,9 +56,7 @@ struct PlanTests {
 
     var configuration = Configuration()
     let selection = Test.ID.Selection(testIDs: [innerTestType.id, outerTestType.id])
-    configuration.testFilter = { test in
-        selection.contains(test)
-    }
+    configuration.setTestFilter(toMatch: selection)
 
     let plan = await Runner.Plan(tests: tests, configuration: configuration)
     let planTests = plan.steps.map(\.test)

--- a/Tests/TestingTests/PlanTests.swift
+++ b/Tests/TestingTests/PlanTests.swift
@@ -12,8 +12,6 @@
 
 @Suite("Runner.Plan Tests")
 struct PlanTests {
-  // TODO: Potentially update the names of tests below which reference "selected
-  // tests" based on naming changes elsewhere.
 
   @Test("Selected tests")
   func selectedTests() async throws {

--- a/Tests/TestingTests/PlanTests.swift
+++ b/Tests/TestingTests/PlanTests.swift
@@ -7,12 +7,11 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
-
+    
 @testable @_spi(ExperimentalTestRunning) import Testing
 
 @Suite("Runner.Plan Tests")
 struct PlanTests {
-
   @Test("Selected tests")
   func selectedTests() async throws {
     let outerTestType = try #require(await test(for: SendableTests.self))
@@ -73,8 +72,9 @@ struct PlanTests {
     let tests = [outerTestType, deeplyNestedTest]
 
     var configuration = Configuration()
+    let selection = Test.ID.Selection(testIDs: [outerTestType.id, deeplyNestedTest.id])
     configuration.testFilter = { test in
-      Test.ID.Selection(testIDs: [outerTestType.id, deeplyNestedTest.id]).contains(test)
+      selection.contains(test)
     }
 
     let plan = await Runner.Plan(tests: tests, configuration: configuration)

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -250,7 +250,9 @@ final class RunnerTests: XCTestCase {
     let testFunc = try #require(await testFunction(named: "duelingConditions()", in: NeverRunTests.self))
 
     var configuration = Configuration()
-    configuration.selectedTests = .init(testIDs: [testSuite.id])
+    configuration.testSelectionFilter = { test in
+      Test.ID.Selection(testIDs: [testSuite.id]).contains(test)
+    }
 
     let runner = await Runner(testing: [
       testSuite,
@@ -294,11 +296,15 @@ final class RunnerTests: XCTestCase {
       (SendableTests.self, "disabled()"),
     ]
 
-    var configuration = Configuration()
-    configuration.selectedTestIDs = Set(tests.map {
+    let selectedTestIDs = Set(tests.map {
       Test.ID(type: $0).child(named: $1)
     })
-    XCTAssertEqual(false, configuration.selectedTestIDs?.isEmpty)
+    XCTAssertFalse(selectedTestIDs.isEmpty)
+
+    var configuration = Configuration()
+    configuration.testSelectionFilter = { test in
+      Test.ID.Selection(testIDs: selectedTestIDs).contains(test)
+    }
 
     let runner = await Runner(configuration: configuration)
     let plan = runner.plan

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -250,8 +250,9 @@ final class RunnerTests: XCTestCase {
     let testFunc = try #require(await testFunction(named: "duelingConditions()", in: NeverRunTests.self))
 
     var configuration = Configuration()
-    configuration.testSelectionFilter = { test in
-      Test.ID.Selection(testIDs: [testSuite.id]).contains(test)
+    let selection = Test.ID.Selection(testIDs: [testSuite.id])
+    configuration.testFilter = { test in
+      selection.contains(test)
     }
 
     let runner = await Runner(testing: [
@@ -302,8 +303,9 @@ final class RunnerTests: XCTestCase {
     XCTAssertFalse(selectedTestIDs.isEmpty)
 
     var configuration = Configuration()
-    configuration.testSelectionFilter = { test in
-      Test.ID.Selection(testIDs: selectedTestIDs).contains(test)
+    let selection = Test.ID.Selection(testIDs: selectedTestIDs)
+    configuration.testFilter = { test in
+      selection.contains(test)
     }
 
     let runner = await Runner(configuration: configuration)

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -67,8 +67,9 @@ func runTest(for containingType: Any.Type, configuration: Configuration = .init(
 /// If no test is found representing `containingType`, nothing is run.
 func runTestFunction(named name: String, in containingType: Any.Type, configuration: Configuration = .init()) async {
   var configuration = configuration
-  configuration.testSelectionFilter = { test in
-    Test.ID.Selection(testIDs: [Test.ID(type: containingType).child(named: name)]).contains(test)
+  let testID = Test.ID.Selection(testIDs: [Test.ID(type: containingType).child(named: name)])
+  configuration.testFilter = { test in
+    testID.contains(test)
   }
 
   let runner = await Runner(configuration: configuration)
@@ -92,8 +93,9 @@ extension Runner {
     let moduleName = String(fileID[..<fileID.lastIndex(of: "/")!])
 
     var configuration = configuration
-    configuration.testSelectionFilter = { test in
-      Test.ID.Selection(testIDs: [Test.ID(moduleName: moduleName, nameComponents: [testName], sourceLocation: nil)]).contains(test)
+    let selection = Test.ID.Selection(testIDs: [Test.ID(moduleName: moduleName, nameComponents: [testName], sourceLocation: nil)])
+    configuration.testFilter = { test in
+        selection.contains(test)
     }
 
     await self.init(configuration: configuration)
@@ -108,8 +110,9 @@ extension Runner.Plan {
   ///   - configuration: The configuration to use for planning.
   init(selecting containingType: Any.Type, configuration: Configuration = .init()) async {
     var configuration = configuration
-    configuration.testSelectionFilter = { test in
-      Test.ID.Selection(testIDs: [Test.ID(type: containingType)]).contains(test)
+    let selection = Test.ID.Selection(testIDs: [Test.ID(type: containingType)])
+    configuration.testFilter = { test in
+      selection.contains(test)
     }
 
     await self.init(configuration: configuration)

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -294,10 +294,6 @@ extension Test.ID.Selection {
   }
 }
 
-// TODO: Provide some convenience utilities for our own unit tests to streamline
-// creating a `Configuration` consisting of a selected tests predicate based on
-// a `Test.ID.Selection` and eliminate boilerplate.
-
 /// Whether or not to enable "noisy" tests that produce a lot of output.
 ///
 /// This flag can be used with `.enabled(if:)` to disable noisy tests unless the

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -94,9 +94,7 @@ extension Runner {
 
     var configuration = configuration
     let selection = Test.ID.Selection(testIDs: [Test.ID(moduleName: moduleName, nameComponents: [testName], sourceLocation: nil)])
-    configuration.testFilter = { test in
-        selection.contains(test)
-    }
+    configuration.setTestFilter(toMatch: selection)
 
     await self.init(configuration: configuration)
   }


### PR DESCRIPTION
Replace `Configuration.selectedTests` with an optional closure property which acts as a predicate for choosing which tests should be selected.

### Motivation:

Currently, the testing library supports selecting specific test(s) to run based on their `Test.ID`, but we would like it to be possible to select tests based on other criteria, such as specific tag(s), or even based on arbitrary logic. Offering a closure-based predicate to filter tests would help accomplish this.

### Modifications:

- Remove the `Configuration.selectedTestIDs` and associated storage property.
- Add a closure property `Configuration.testSelectionFilter` which accepts a `Test` and returns `Bool` whether to include it in the selected tests.
- Update selection logic in `Runner.Plan` based on the above changes.
- Update unit tests.

### Result:

There is now a more flexible closure-based facility for selecting/filtering tests.
