### PR TITLE
Use `@autoclosure` in `__checkBinaryOperation()`.

### DIFF
--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -109,7 +109,7 @@ public func __checkValue(
 private func _callBinaryOperator<T, U, R>(
   _ lhs: T,
   _ op: (T, () -> U) -> R,
-  _ rhs: @autoclosure () -> U
+  _ rhs: () -> U
 ) -> (result: R, rhs: U?) {
   // The compiler normally doesn't allow a nonescaping closure to call another
   // nonescaping closure, but our use cases are safe (e.g. `true && false`) and
@@ -146,7 +146,7 @@ public func __checkBinaryOperation<T, U>(
   isRequired: Bool,
   sourceLocation: SourceLocation
 ) -> Result<Void, any Error> {
-  let (condition, rhs) = _callBinaryOperator(lhs, op, rhs())
+  let (condition, rhs) = _callBinaryOperator(lhs, op, rhs)
   return __checkValue(
     condition,
     sourceCode: sourceCode,
@@ -294,7 +294,7 @@ public func __checkBinaryOperation<T>(
   isRequired: Bool,
   sourceLocation: SourceLocation
 ) -> Result<Void, any Error> where T: BidirectionalCollection, T.Element: Equatable {
-  let (condition, rhs) = _callBinaryOperator(lhs, op, rhs())
+  let (condition, rhs) = _callBinaryOperator(lhs, op, rhs)
   func difference() -> String? {
     guard let rhs else {
       return nil
@@ -341,7 +341,7 @@ public func __checkBinaryOperation(
   isRequired: Bool,
   sourceLocation: SourceLocation
 ) -> Result<Void, any Error> {
-  let (condition, rhs) = _callBinaryOperator(lhs, op, rhs())
+  let (condition, rhs) = _callBinaryOperator(lhs, op, rhs)
   return __checkValue(
     condition,
     sourceCode: sourceCode,
@@ -434,7 +434,7 @@ public func __checkBinaryOperation<T>(
   isRequired: Bool,
   sourceLocation: SourceLocation
 ) -> Result<T, any Error> {
-  let (optionalValue, rhs) = _callBinaryOperator(lhs, op, rhs())
+  let (optionalValue, rhs) = _callBinaryOperator(lhs, op, rhs)
   return __checkValue(
     optionalValue != nil,
     sourceCode: sourceCode,

--- a/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
+++ b/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
@@ -145,7 +145,7 @@ private func _parseCondition(from expr: ExprSyntax, leftOperand lhs: ExprSyntax,
     arguments: [
       Argument(expression: lhs),
       Argument(expression: "{ $0 \(op.trimmed) $1() }"),
-      Argument(expression: "{ \(rhs.trimmed) }")
+      Argument(expression: rhs)
     ],
     sourceCode: createSourceCodeExprForBinaryOperation(lhs, op, rhs)
   )

--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -29,15 +29,15 @@ struct ConditionMacroTests {
       ##"#expect(false, "Custom message")"##:
         ##"Testing.__checkValue(false, sourceCode: .__fromSyntaxNode("false"), comments: ["Custom message"], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(2 > 1)"##:
-        ##"Testing.__checkBinaryOperation(2, { $0 > $1() }, { 1 }, sourceCode: .__fromBinaryOperation("2", ">", "1"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkBinaryOperation(2, { $0 > $1() }, 1, sourceCode: .__fromBinaryOperation("2", ">", "1"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(((true || false) && true) || Bool.random())"##:
-        ##"Testing.__checkBinaryOperation(((true || false) && true), { $0 || $1() }, { Bool.random() }, sourceCode: .__fromBinaryOperation("((true || false) && true)", "||", "Bool.random()"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkBinaryOperation(((true || false) && true), { $0 || $1() }, Bool.random(), sourceCode: .__fromBinaryOperation("((true || false) && true)", "||", "Bool.random()"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(9 > 8 && 7 > 6, "Some comment")"##:
-        ##"Testing.__checkBinaryOperation(9 > 8, { $0 && $1() }, { 7 > 6 }, sourceCode: .__fromBinaryOperation("9 > 8", "&&", "7 > 6"), comments: ["Some comment"], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkBinaryOperation(9 > 8, { $0 && $1() }, 7 > 6, sourceCode: .__fromBinaryOperation("9 > 8", "&&", "7 > 6"), comments: ["Some comment"], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(!Bool.random())"##:
         ##"Testing.__checkValue(!Bool.random(), sourceCode: .__fromSyntaxNode("!Bool.random()"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect((true && false))"##:
-        ##"Testing.__checkBinaryOperation(true, { $0 && $1() }, { false }, sourceCode: .__fromBinaryOperation("true", "&&", "false"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkBinaryOperation(true, { $0 && $1() }, false, sourceCode: .__fromBinaryOperation("true", "&&", "false"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(try x())"##:
         ##"Testing.__checkValue(try x(), sourceCode: .__fromSyntaxNode("try x()"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(1 is Int)"##:
@@ -91,15 +91,15 @@ struct ConditionMacroTests {
       ##"#require(false, "Custom message")"##:
         ##"Testing.__checkValue(false, sourceCode: .__fromSyntaxNode("false"), comments: ["Custom message"], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(2 > 1)"##:
-        ##"Testing.__checkBinaryOperation(2, { $0 > $1() }, { 1 }, sourceCode: .__fromBinaryOperation("2", ">", "1"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkBinaryOperation(2, { $0 > $1() }, 1, sourceCode: .__fromBinaryOperation("2", ">", "1"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(((true || false) && true) || Bool.random())"##:
-        ##"Testing.__checkBinaryOperation(((true || false) && true), { $0 || $1() }, { Bool.random() }, sourceCode: .__fromBinaryOperation("((true || false) && true)", "||", "Bool.random()"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkBinaryOperation(((true || false) && true), { $0 || $1() }, Bool.random(), sourceCode: .__fromBinaryOperation("((true || false) && true)", "||", "Bool.random()"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(9 > 8 && 7 > 6, "Some comment")"##:
-        ##"Testing.__checkBinaryOperation(9 > 8, { $0 && $1() }, { 7 > 6 }, sourceCode: .__fromBinaryOperation("9 > 8", "&&", "7 > 6"), comments: ["Some comment"], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkBinaryOperation(9 > 8, { $0 && $1() }, 7 > 6, sourceCode: .__fromBinaryOperation("9 > 8", "&&", "7 > 6"), comments: ["Some comment"], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(!Bool.random())"##:
         ##"Testing.__checkValue(!Bool.random(), sourceCode: .__fromSyntaxNode("!Bool.random()"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require((true && false))"##:
-        ##"Testing.__checkBinaryOperation(true, { $0 && $1() }, { false }, sourceCode: .__fromBinaryOperation("true", "&&", "false"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkBinaryOperation(true, { $0 && $1() }, false, sourceCode: .__fromBinaryOperation("true", "&&", "false"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(try x())"##:
         ##"Testing.__checkValue(try x(), sourceCode: .__fromSyntaxNode("try x()"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(1 is Int)"##:
@@ -149,9 +149,9 @@ struct ConditionMacroTests {
       ##"#require(Optional<Int>.none)"##:
         ##"Testing.__checkValue(Optional<Int>.none, sourceCode: .__fromSyntaxNode("Optional<Int>.none"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(nil ?? 123)"##:
-        ##"Testing.__checkBinaryOperation(nil, { $0 ?? $1() }, { 123 }, sourceCode: .__fromBinaryOperation("nil", "??", "123"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkBinaryOperation(nil, { $0 ?? $1() }, 123, sourceCode: .__fromBinaryOperation("nil", "??", "123"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(123 ?? nil)"##:
-        ##"Testing.__checkBinaryOperation(123, { $0 ?? $1() }, { nil }, sourceCode: .__fromBinaryOperation("123", "??", "nil"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkBinaryOperation(123, { $0 ?? $1() }, nil, sourceCode: .__fromBinaryOperation("123", "??", "nil"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(123 as? Double)"##:
         ##"Testing.__checkCast(123,as: Double.self, sourceCode: .__fromBinaryOperation("123", "as?", "Double"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(123 as Double)"##:
@@ -276,7 +276,7 @@ struct ConditionMacroTests {
     let rawExpectedOutput = ##"""
       @Test("Random number generation") func rng() {
         let number = Int.random(in: 1 ..< .max)
-        Testing.__checkBinaryOperation((number > 0 && foo() != bar(at: 9)), { $0 != $1() }, { !true }, sourceCode: .__fromBinaryOperation("(number > 0 && foo() != bar(at: 9))", "!=", "!true"), comments: ["\(number) must be greater than 0"], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()
+        Testing.__checkBinaryOperation((number > 0 && foo() != bar(at: 9)), { $0 != $1() }, !true, sourceCode: .__fromBinaryOperation("(number > 0 && foo() != bar(at: 9))", "!=", "!true"), comments: ["\(number) must be greater than 0"], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()
       }
     """##
 


### PR DESCRIPTION
This change simplifies the macro expansions of `#expect()` and `#require()` when they are passed binary operation expressions. In prerelease versions of the Swift 5.9 toolchain, we ran into issues with autoclosures and worked around them by capturing right-hand operands in full closures. Those issues have been resolved. By switching to autoclosures we can solve some grammatical issues that crop up with explicit closures, such as:

```swift
@Test func foo() {
  let x = [2, 4, 6]
  x.forEach {
    #expect(0 == $0 % 2) // 🛑 Contextual closure type '() -> Int' expects 0
                         // arguments, but 1 was used in closure body
  }
}
```

Partially resolves rdar://114275884.