### PR TITLE
Use `CodeBlockItemListSyntax` instead of `ExprSyntax` when constructing a test function thunk.

### DIFF
--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -308,11 +308,7 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
     }
 
     // Generate a thunk function that invokes the actual function.
-    // NOTE: `thunkBody` is not actually an expression. It's better-represented
-    // as an instance of CodeBlockItemListSyntax, but due to its size it is
-    // easier to express using string interpolation than by directly creating an
-    // instance of CodeBlockItemListSyntax.
-    var thunkBody: ExprSyntax
+    var thunkBody: CodeBlockItemListSyntax
     if functionDecl.availability(when: .unavailable).first != nil {
       thunkBody = ""
     } else if let typeName {


### PR DESCRIPTION
This PR corrects a technical defect in `TestDeclarationMacro`. There should be no developer- or user-facing impact.

Previously, `CodeBlockItemListSyntax` didn't conform to `SyntaxExpressibleByStringInterpolation` so we would have had to manually construct it. Instead, we just substituted `ExprSyntax` which is wrong, but allows string interpolation. This was corrected with https://github.com/apple/swift-syntax/pull/1946, so we can use the right type now.