### PR TITLE
Switch from unsafeFlags to enableExperimentalFeature to enable strict concurrency checking

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -111,7 +111,6 @@ extension Array where Element == PackageDescription.SwiftSetting {
   static var packageSettings: Self {
     [
       .unsafeFlags([
-        "-strict-concurrency=complete",
         "-require-explicit-sendable",
 
         "-Xfrontend", "-define-availability", "-Xfrontend", "_clockAPI:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0",
@@ -119,6 +118,7 @@ extension Array where Element == PackageDescription.SwiftSetting {
         "-Xfrontend", "-define-availability", "-Xfrontend", "_regexAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0",
         "-Xfrontend", "-define-availability", "-Xfrontend", "_swiftVersionAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0",
       ]),
+      .enableExperimentalFeature("StrictConcurrency"),
       .enableUpcomingFeature("ExistentialAny"),
       .define("SWT_TARGET_OS_APPLE", .when(platforms: [.macOS, .iOS, .macCatalyst, .watchOS, .tvOS, .visionOS])),
     ]


### PR DESCRIPTION
This removes one of our usages of `.unsafeFlags` in favor of `.enableExperimentalFeature`, which is helpful since `.unsafeFlags` cannot be safely used by clients (except when the package is local or using a branch for its dependency).