### PR TITLE
Make `Backtrace` conform to `Codable`.

### DIFF
--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -15,9 +15,7 @@ import XCTest
 #if SWT_TARGET_OS_APPLE
 extension XCTSourceCodeContext {
   convenience init(_ sourceContext: SourceContext) {
-    let addresses = sourceContext.backtrace?.addresses.map { address in
-      UInt(bitPattern: address) as NSNumber
-    } ?? []
+    let addresses = sourceContext.backtrace?.addresses.map { $0 as NSNumber } ?? []
     let sourceLocation = sourceContext.sourceLocation.map { sourceLocation in
       XCTSourceCodeLocation(
         filePath: String(describing: sourceLocation._filePath),

--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -33,7 +33,7 @@ public struct Backtrace: Sendable {
   /// - Parameters:
   ///   - addresses: The addresses in the backtrace.
   ///
-  /// The pointers in `addresses` are converted to instances of `Address`. Any
+  /// The pointers in `addresses` are converted to instances of ``Address``. Any
   /// `nil` addresses are represented as `0`.
   public init(addresses: some Sequence<UnsafeRawPointer?>) {
     self.init(

--- a/Tests/TestingTests/BacktraceTests.swift
+++ b/Tests/TestingTests/BacktraceTests.swift
@@ -9,6 +9,7 @@
 //
 
 @testable @_spi(ExperimentalEventHandling) @_spi(ExperimentalTestRunning) import Testing
+import Foundation
 
 struct BacktracedError: Error {}
 
@@ -42,5 +43,13 @@ struct BacktraceTests {
   @Test("An unthrown error has no backtrace")
   func noBacktraceForNewError() throws {
     #expect(Backtrace(forFirstThrowOf: BacktracedError()) == nil)
+  }
+
+  @Test("Encoding/decoding")
+  func encodingAndDecoding() throws {
+    let original = Backtrace.current()
+    let data = try JSONEncoder().encode(original)
+    let copy = try JSONDecoder().decode(Backtrace.self, from: data)
+    #expect(original == copy)
   }
 }


### PR DESCRIPTION
`Backtrace` can trivially conform to `Codable` except that if pointers are encoded on a 64-bit platform and decoded on a 32-bit platform, decoding will fail. Store addresses as `UInt64` instead (with a `typealias` for general niceness.)