### PR TITLE
Preserve the old signature of `__TestContainer.__tests` temporarily.

### DIFF
--- a/Sources/Testing/Test+Macro.swift
+++ b/Sources/Testing/Test+Macro.swift
@@ -542,7 +542,29 @@ public func __invokeXCTestCaseMethod<T>(
 @_alwaysEmitConformanceMetadata
 public protocol __TestContainer {
   /// The set of tests contained by this type.
-  static var __tests: [Test] { get async }
+  ///
+  /// - Note: This property will be removed in a future update to the testing
+  ///   library. It remains here for binary compatibility with recently-compiled
+  ///   test targets.
+  static var __tests: [Test] { get }
+
+  /// Get the set of tests contained by this type.
+  ///
+  /// - Returns: An array of ``Test`` instances.
+  ///
+  /// - Warning: This method is used to implement the `@Test` macro. Do not use
+  ///   it directly.
+  static func __tests() async -> [Test]
+}
+
+extension __TestContainer {
+  public static var __tests: [Test] {
+    []
+  }
+
+  public static func __tests() async -> [Test] {
+    []
+  }
 }
 
 extension Test {
@@ -582,7 +604,7 @@ extension Test {
           if let type = unsafeBitCast(type, to: Any.Type.self) as? any __TestContainer.Type {
             let taskGroup = context!.assumingMemoryBound(to: TaskGroup<[Self]>.self)
             taskGroup.pointee.addTask {
-              await type.__tests
+              await type.__tests() + type.__tests
             }
           }
         }, &taskGroup)

--- a/Sources/TestingMacros/SuiteDeclarationMacro.swift
+++ b/Sources/TestingMacros/SuiteDeclarationMacro.swift
@@ -159,13 +159,13 @@ public struct SuiteDeclarationMacro: MemberMacro, PeerMacro, Sendable {
       @available(*, unavailable, message: "This type is an implementation detail of the testing library. It cannot be used directly.")
       @available(*, deprecated)
       @frozen public enum \(enumName): Testing.__TestContainer {
-        public static var __tests: [Testing.Test] {
-          get async {[
+        public static func __tests() async -> [Testing.Test] {
+          [
             .__type(
               \(declaration.type.trimmed).self,
               \(raw: attributeInfo.functionArgumentList(in: context))
             )
-          ]}
+          ]
         }
       }
       """

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -476,8 +476,8 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
       @available(*, unavailable, message: "This type is an implementation detail of the testing library. It cannot be used directly.")
       @available(*, deprecated)
       @frozen public enum \(enumName): Testing.__TestContainer {
-        public static var __tests: [Testing.Test] {
-          get async {[
+        public static func __tests() async -> [Testing.Test] {
+          [
             .__function(
               named: \(literal: functionDecl.completeName),
               in: \(typealiasExpr),
@@ -486,7 +486,7 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
               parameters: \(raw: functionDecl.testFunctionParameterList),
               testFunction: \(thunkDecl.name)
             )
-          ]}
+          ]
         }
       }
       """


### PR DESCRIPTION
We have some precompiled test targets that used the previous definition of `__tests` which we can't recompile just yet. Preserve the previous protocol requirement temporarily until we have a chance to update everything.

We'll revert (most of) this change in a couple of weeks.