### PR TITLE
Check availability before calling `_mangledTypeName(_:)`.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -118,6 +118,7 @@ extension Array where Element == PackageDescription.SwiftSetting {
         "-Xfrontend", "-define-availability", "-Xfrontend", "_distantFuture:macOS 99.0, iOS 99.0, watchOS 99.0, tvOS 99.0",
         "-Xfrontend", "-define-availability", "-Xfrontend", "_regexAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0",
         "-Xfrontend", "-define-availability", "-Xfrontend", "_swiftVersionAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0",
+        "-Xfrontend", "-define-availability", "-Xfrontend", "_mangledTypeNameAPI:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0",
       ]),
       .enableUpcomingFeature("ExistentialAny"),
       .define("SWT_TARGET_OS_APPLE", .when(platforms: [.macOS, .iOS, .macCatalyst, .watchOS, .tvOS, .visionOS])),

--- a/Sources/Testing/SourceAttribution/CustomTestStringConvertible.swift
+++ b/Sources/Testing/SourceAttribution/CustomTestStringConvertible.swift
@@ -107,13 +107,13 @@ extension String {
       self.init(describing: value)
     } else if let value = value as? any CustomDebugStringConvertible {
       self.init(reflecting: value)
-    } else if let value = value as? any RawRepresentable, isImportedFromC(valueType) {
+    } else if #available(_mangledTypeNameAPI, *), let value = value as? any RawRepresentable, isImportedFromC(valueType) {
       // Present raw-representable C types, which we assume to be imported
       // enumerations, in a consistent fashion. The case names of C enumerations
       // are not statically visible, so instead present the enumeration type's
       // name along with the raw value of `value`.
       self = "\(valueType)(rawValue: \(String(describingForTest: value.rawValue)))"
-    } else if isSwiftEnumeration(valueType) {
+    } else if #available(_mangledTypeNameAPI, *), isSwiftEnumeration(valueType) {
       // Add a leading period to enumeration cases to more closely match their
       // source representation. SEE: _adHocPrint_unlocked() in the stdlib.
       self = ".\(value)"

--- a/Sources/Testing/Support/Additions/TypeAdditions.swift
+++ b/Sources/Testing/Support/Additions/TypeAdditions.swift
@@ -30,6 +30,7 @@ func nameComponents(of type: Any.Type) -> [String] {
 ///
 /// Per the [Swift mangling ABI](https://github.com/apple/swift/blob/main/docs/ABI/Mangling.rst),
 /// enumeration types are mangled as `"O"`.
+@available(_mangledTypeNameAPI, *)
 func isSwiftEnumeration(_ type: Any.Type) -> Bool {
   guard let mangledTypeName = _mangledTypeName(type), let lastCharacter = mangledTypeName.last else {
     return false
@@ -49,6 +50,7 @@ func isSwiftEnumeration(_ type: Any.Type) -> Bool {
 /// module. That module has a standardized mangling of `"So"`. The presence of
 /// those characters at the start of a type's mangled name indicates that it is
 /// an imported type.
+@available(_mangledTypeNameAPI, *)
 func isImportedFromC(_ type: Any.Type) -> Bool {
   guard let mangledTypeName = _mangledTypeName(type), mangledTypeName.count > 2 else {
     return false

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -1139,7 +1139,11 @@ final class IssueTests: XCTestCase {
     await fulfillment(of: [expectationFailed], timeout: 0.0)
   }
 
-  func testEnumDescription() async {
+  func testEnumDescription() async throws {
+    guard #available(_mangledTypeNameAPI, *) else {
+      throw XCTSkip("Unavailable")
+    }
+
     enum E: CaseIterable {
       case a
       case b
@@ -1198,7 +1202,11 @@ final class IssueTests: XCTestCase {
     await fulfillment(of: [expectationFailed], timeout: 0.0)
   }
 
-  func testCEnumDescription() async {
+  func testCEnumDescription() async throws {
+    guard #available(_mangledTypeNameAPI, *) else {
+      throw XCTSkip("Unavailable")
+    }
+
     let expectationFailed = expectation(description: "Expectation failed")
 
     var configuration = Configuration()


### PR DESCRIPTION
We currently call the stdlib SPI function `_mangledTypeName(_:)` in a few spots (pending availability of a more general reflection API.) This function needs availability checks to be used on Apple platforms other than macOS.