### PR TITLE
Link to Swift issues about using `_mangledTypeName()`.

### DIFF
--- a/Sources/Testing/Support/Additions/TypeAdditions.swift
+++ b/Sources/Testing/Support/Additions/TypeAdditions.swift
@@ -30,6 +30,10 @@ func nameComponents(of type: Any.Type) -> [String] {
 ///
 /// Per the [Swift mangling ABI](https://github.com/apple/swift/blob/main/docs/ABI/Mangling.rst),
 /// enumeration types are mangled as `"O"`.
+///
+/// - Bug: We use the internal Swift standard library function
+///   `_mangledTypeName()` to derive this information. We should use supported
+///   API instead. ([swift-#69147](https://github.com/apple/swift/issues/69147))
 @available(_mangledTypeNameAPI, *)
 func isSwiftEnumeration(_ type: Any.Type) -> Bool {
   guard let mangledTypeName = _mangledTypeName(type), let lastCharacter = mangledTypeName.last else {
@@ -50,6 +54,10 @@ func isSwiftEnumeration(_ type: Any.Type) -> Bool {
 /// module. That module has a standardized mangling of `"So"`. The presence of
 /// those characters at the start of a type's mangled name indicates that it is
 /// an imported type.
+///
+/// - Bug: We use the internal Swift standard library function
+///   `_mangledTypeName()` to derive this information. We should use supported
+///   API instead. ([swift-#69146](https://github.com/apple/swift/issues/69146))
 @available(_mangledTypeNameAPI, *)
 func isImportedFromC(_ type: Any.Type) -> Bool {
   guard let mangledTypeName = _mangledTypeName(type), mangledTypeName.count > 2 else {


### PR DESCRIPTION
Adds comments linking to issues filed against the Swift repo that if resolved would help us avoid using this unsupported interface.