### PR TITLE
Add `borrowing` to more places that pass `Event` and `Event.Context`.

### DIFF
--- a/Sources/Testing/Events/Event.Recorder.swift
+++ b/Sources/Testing/Events/Event.Recorder.swift
@@ -435,10 +435,11 @@ extension Event.Recorder {
         testName = "\(colorDots)\(_resetANSIEscapeCode) \(testName)"
       }
     }
+    let instant = event.instant
 
     switch event.kind {
     case .runStarted:
-      $context.withLock { [instant = event.instant] context in
+      $context.withLock { context in
         context.runStartInstant = instant
       }
       let symbol = _Symbol.default.stringValue(options: options)
@@ -482,7 +483,7 @@ extension Event.Recorder {
       let testDataGraph = context.testData.subgraph(at: id.keyPathRepresentation)
       let testData = testDataGraph?.value ?? .init()
       let issues = _issueCounts(in: testDataGraph)
-      let duration = testData.startInstant.descriptionOfDuration(to: event.instant)
+      let duration = testData.startInstant.descriptionOfDuration(to: instant)
       if issues.issueCount > 0 {
         let symbol = _Symbol.fail.stringValue(options: options)
         let comments = _formattedComments(for: test, options: options).map { "\($0)\n" } ?? ""
@@ -586,12 +587,8 @@ extension Event.Recorder {
 
       let testCount = context.testCount
       let issues = _issueCounts(in: context.testData)
-      let runStartInstant = if let runStartInstant = context.runStartInstant {
-        runStartInstant
-      } else {
-        event.instant
-      }
-      let duration = runStartInstant.descriptionOfDuration(to: event.instant)
+      let runStartInstant = context.runStartInstant ?? instant
+      let duration = runStartInstant.descriptionOfDuration(to: instant)
 
       if issues.issueCount > 0 {
         let symbol = _Symbol.fail.stringValue(options: options)

--- a/Sources/Testing/Events/Event.Recorder.swift
+++ b/Sources/Testing/Events/Event.Recorder.swift
@@ -415,7 +415,7 @@ extension Event.Recorder {
   ///
   /// - Returns: A string description of the event, or `nil` if there is nothing
   ///   useful to output for this event.
-  func _record(_ event: Event, in eventContext: Event.Context) -> String? {
+  func _record(_ event: borrowing Event, in eventContext: borrowing Event.Context) -> String? {
     let test = eventContext.test
     var testName: String
     if let displayName = test?.displayName {
@@ -438,8 +438,8 @@ extension Event.Recorder {
 
     switch event.kind {
     case .runStarted:
-      $context.withLock { context in
-        context.runStartInstant = event.instant
+      $context.withLock { [instant = event.instant] context in
+        context.runStartInstant = instant
       }
       let symbol = _Symbol.default.stringValue(options: options)
       var comments: [Comment] = [
@@ -610,7 +610,7 @@ extension Event.Recorder {
   ///
   /// - Returns: Whether any output was written using the recorder's write
   ///   function.
-  @discardableResult public func record(_ event: Event, in context: Event.Context) -> Bool {
+  @discardableResult public func record(_ event: borrowing Event, in context: borrowing Event.Context) -> Bool {
     if let output = _record(event, in: context) {
       write(output)
       return true

--- a/Sources/Testing/Events/Event.Recorder.swift
+++ b/Sources/Testing/Events/Event.Recorder.swift
@@ -586,7 +586,11 @@ extension Event.Recorder {
 
       let testCount = context.testCount
       let issues = _issueCounts(in: context.testData)
-      let runStartInstant = context.runStartInstant ?? event.instant
+      let runStartInstant = if let runStartInstant = context.runStartInstant {
+        runStartInstant
+      } else {
+        event.instant
+      }
       let duration = runStartInstant.descriptionOfDuration(to: event.instant)
 
       if issues.issueCount > 0 {

--- a/Sources/Testing/Events/Event.swift
+++ b/Sources/Testing/Events/Event.swift
@@ -32,13 +32,23 @@ public struct Event: Sendable {
     case planStepStarted(_ step: Runner.Plan.Step)
 
     /// A test started.
+    ///
+    /// The test that started is contained in the ``Event/Context`` instance
+    /// that was passed to the event handler along with this event. Its ID is
+    /// available from the event's ``Event/testID`` property.
     case testStarted
 
     /// A test case started.
+    ///
+    /// The test case that started is contained in the ``Event/Context``
+    /// instance that was passed to the event handler along with this event.
     @_spi(ExperimentalParameterizedTesting)
     case testCaseStarted
 
     /// A test case ended.
+    ///
+    /// The test case that ended is contained in the ``Event/Context`` instance
+    /// that was passed to the event handler along with this event.
     @_spi(ExperimentalParameterizedTesting)
     case testCaseEnded
 
@@ -67,12 +77,20 @@ public struct Event: Sendable {
     case issueRecorded(_ issue: Issue)
 
     /// A test ended.
+    ///
+    /// The test that ended is contained in the ``Event/Context`` instance that
+    /// was passed to the event handler along with this event. Its ID is
+    /// available from the event's ``Event/testID`` property.
     case testEnded
 
     /// A test was skipped.
     ///
     /// - Parameters:
     ///   - skipInfo: A ``SkipInfo`` containing details about this skipped test.
+    ///
+    /// The test that was skipped is contained in the ``Event/Context`` instance
+    /// that was passed to the event handler along with this event. Its ID is
+    /// available from the event's ``Event/testID`` property.
     case testSkipped(_ skipInfo: SkipInfo)
 
 #if !SWIFT_PACKAGE
@@ -203,6 +221,7 @@ extension Event {
   /// Post this event to the currently-installed event handler.
   ///
   /// - Parameters:
+  ///   - context: The context associated with this event.
   ///   - configuration: The configuration whose event handler should handle
   ///     this event. If `nil` is passed, the current task's configuration is
   ///     used, if known.
@@ -214,7 +233,7 @@ extension Event {
   /// instead. If there is no current configuration, the event is posted to
   /// the event handlers of all configurations set as current across all tasks
   /// in the process.
-  private func _post(in context: Context, configuration: Configuration? = nil) {
+  private borrowing func _post(in context: borrowing Context, configuration: Configuration? = nil) {
     if let configuration = configuration ?? Configuration.current {
       // The caller specified a configuration, or the current task has an
       // associated configuration. Post to either configuration's event handler.

--- a/Sources/Testing/Events/Event.swift
+++ b/Sources/Testing/Events/Event.swift
@@ -35,7 +35,7 @@ public struct Event: Sendable {
     ///
     /// The test that started is contained in the ``Event/Context`` instance
     /// that was passed to the event handler along with this event. Its ID is
-    /// available from the event's ``Event/testID`` property.
+    /// available from this event's ``Event/testID`` property.
     case testStarted
 
     /// A test case started.

--- a/Sources/Testing/Events/Event.swift
+++ b/Sources/Testing/Events/Event.swift
@@ -80,7 +80,7 @@ public struct Event: Sendable {
     ///
     /// The test that ended is contained in the ``Event/Context`` instance that
     /// was passed to the event handler along with this event. Its ID is
-    /// available from the event's ``Event/testID`` property.
+    /// available from this event's ``Event/testID`` property.
     case testEnded
 
     /// A test was skipped.

--- a/Sources/Testing/Events/Event.swift
+++ b/Sources/Testing/Events/Event.swift
@@ -90,7 +90,7 @@ public struct Event: Sendable {
     ///
     /// The test that was skipped is contained in the ``Event/Context`` instance
     /// that was passed to the event handler along with this event. Its ID is
-    /// available from the event's ``Event/testID`` property.
+    /// available from this event's ``Event/testID`` property.
     case testSkipped(_ skipInfo: SkipInfo)
 
 #if !SWIFT_PACKAGE


### PR DESCRIPTION
This PR reduces the number of copies of `Event` and `Event.Context` that may be made when an event occurs by marking more parameters with these types as `borrowing`.

I also took a moment to update the documentation for some of the event types to explain where their associated values ended up as it may not be clear from initial inspection.