### PR TITLE
Fix the 256-color terminal check so it doesn't require `_StringProcessing`.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -114,11 +114,13 @@ extension Array where Element == PackageDescription.SwiftSetting {
         "-strict-concurrency=complete",
         "-require-explicit-sendable",
 
+        "-Xfrontend", "-define-availability", "-Xfrontend", "_mangledTypeNameAPI:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0",
+        "-Xfrontend", "-define-availability", "-Xfrontend", "_backtraceAsyncAPI:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0",
         "-Xfrontend", "-define-availability", "-Xfrontend", "_clockAPI:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0",
-        "-Xfrontend", "-define-availability", "-Xfrontend", "_distantFuture:macOS 99.0, iOS 99.0, watchOS 99.0, tvOS 99.0",
         "-Xfrontend", "-define-availability", "-Xfrontend", "_regexAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0",
         "-Xfrontend", "-define-availability", "-Xfrontend", "_swiftVersionAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0",
-        "-Xfrontend", "-define-availability", "-Xfrontend", "_mangledTypeNameAPI:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0",
+
+        "-Xfrontend", "-define-availability", "-Xfrontend", "_distantFuture:macOS 99.0, iOS 99.0, watchOS 99.0, tvOS 99.0",
       ]),
       .enableUpcomingFeature("ExistentialAny"),
       .define("SWT_TARGET_OS_APPLE", .when(platforms: [.macOS, .iOS, .macCatalyst, .watchOS, .tvOS, .visionOS])),

--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -258,11 +258,8 @@ extension [Event.Recorder.Option] {
   /// codes.
   private static var _standardErrorSupports256ColorANSIEscapeCodes: Bool {
 #if SWT_TARGET_OS_APPLE || os(Linux)
-    // The `contains(_:)` overload used here comes from _StringProcessing module
-    // instead of the stdlib. This may be lowered in the future, but for now,
-    // simply limit the check for 256 colors to these newer OSes.
-    if #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) {
-      return Environment.variable(named: "TERM")?.contains("256") == true
+    if let termVariable = Environment.variable(named: "TERM") {
+      return strstr(termVariable, "256") != nil
     }
     return false
 #elseif os(Windows)

--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -63,7 +63,7 @@ public struct Backtrace: Sendable {
     let addresses = [UnsafeRawPointer?](unsafeUninitializedCapacity: addressCount) { addresses, initializedCount in
       addresses.withMemoryRebound(to: UnsafeMutableRawPointer?.self) { addresses in
 #if SWT_TARGET_OS_APPLE
-        if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
+        if #available(_backtraceAsyncAPI, *) {
           initializedCount = backtrace_async(addresses.baseAddress!, addresses.count, nil)
         } else {
           initializedCount = .init(backtrace(addresses.baseAddress!, .init(addresses.count)))


### PR DESCRIPTION
Use `strstr()` so that we can detect 256-color terminal support on older macOS versions or with older toolchains that don't have the `_StringProcessing` module.

I did _not_ change another use of `contains()` in ExpectationChecking+Macro.swift because it may be sensitive to Unicode nuances whereas a search for the ASCII string ``"256"` isn't.

I also took the opportunity to replace one other usage of `#available(explicit_versions_here)` with an availability define. I sorted the availability defines in the package manifest too.