### PR TITLE
Rethink tag colors as secondary package data.

### DIFF
--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -230,6 +230,9 @@ extension [Event.Recorder.Option] {
     }
 #endif
 
+    // Load tag colors from user/package preferences on disk.
+    result += tagColorOptions()
+
     return result
   }
 

--- a/Sources/Testing/Testing.docc/AddingTags.md
+++ b/Sources/Testing/Testing.docc/AddingTags.md
@@ -46,6 +46,42 @@ func licenseValid() { ... }
 The testing library does not assign any semantic meaning to any tags, nor does
 the presence or absence of tags affect how the testing library runs tests.
 
+## Customizing a tag's appearance
+
+By default, a tag does not appear in a test's output when the test is run. It is
+possible to assign colors to tags defined in a package so that when the test is
+run, the tag is visible in its output.
+
+To add colors to tags, create a directory at the root of your package named
+`".swift-testing"` and add a file named `"tag-colors.json"` to it. This file
+should contain a JSON object (a dictionary) whose keys are strings representing
+tags and whose values represent tag colors. Tag colors can be represented using
+several formats:
+
+- The strings `"red"`, `"orange"`, `"yellow"`, `"green"`, `"blue"`, or
+  `"purple"`, representing corresponding predefined instances of ``Tag``, i.e.
+  ``Tag/red``, ``Tag/orange``, ``Tag/yellow``, ``Tag/green``, ``Tag/blue``, and
+  ``Tag/purple``;
+- A string of the form `"#RRGGBB"`, containing a hexadecimal representation of
+  the color in a device-independent RGB color space; or
+- The `null` literal value, representing "no color."
+
+For example, to set the color of the tag `"critical"` to orange and the color of
+the tag `.legallyRequired` to teal, the contents of `"tag-colors.json"` can
+be set to:
+
+```json
+{
+  "critical": "red",
+  ".legallyRequired": "#66FFCC"
+}
+```
+
+- Note: Where possible, use the raw values of tags (from their ``Tag/rawValue``
+  properties) as the keys in this object rather than using Swift source
+  expressions like `".legallyRequired"` to ensure that tag colors are applied
+  everywhere a tag is used.
+
 ## Topics
 
 - ``Trait/tags(_:)-yg0i``

--- a/Sources/Testing/Testing.docc/AddingTags.md
+++ b/Sources/Testing/Testing.docc/AddingTags.md
@@ -52,11 +52,16 @@ By default, a tag does not appear in a test's output when the test is run. It is
 possible to assign colors to tags defined in a package so that when the test is
 run, the tag is visible in its output.
 
-To add colors to tags, create a directory at the root of your package named
+To add colors to tags, create a directory in your home directory named
 `".swift-testing"` and add a file named `"tag-colors.json"` to it. This file
 should contain a JSON object (a dictionary) whose keys are strings representing
-tags and whose values represent tag colors. Tag colors can be represented using
-several formats:
+tags and whose values represent tag colors.
+
+- Note: On Windows, create the `".swift-testing"` directory in the
+  `"AppData\Local"` directory inside your home directory instead of directly
+  inside it.
+
+Tag colors can be represented using several formats:
 
 - The strings `"red"`, `"orange"`, `"yellow"`, `"green"`, `"blue"`, or
   `"purple"`, representing corresponding predefined instances of ``Tag``, i.e.

--- a/Sources/Testing/Traits/Tag.Color+Loading.swift
+++ b/Sources/Testing/Traits/Tag.Color+Loading.swift
@@ -1,0 +1,125 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+private import TestingInternals
+
+// We do not want to link to Foundation normally, but this file already links to
+// XCTest which links to Foundation, so the dependency already exists and we can
+// make use of it here to support JSON decoding.
+#if canImport(Foundation)
+import Foundation
+#endif
+
+#if !SWT_NO_TAG_COLORS
+#if os(macOS) || (os(iOS) && targetEnvironment(macCatalyst)) || os(Linux)
+/// The path to the current user's home directory, if known.
+private var _homeDirectoryPath: String? {
+#if canImport(Foundation)
+  NSHomeDirectory()
+#else
+  if let homeVariable = Environment.variable(named: "HOME") {
+    homeVariable
+  } else if let pwd = getpwuid(geteuid()) {
+    String(validatingUTF8: pwd.pointee.pw_dir)
+  } else {
+    nil
+  }
+#endif
+}
+#endif
+
+#if os(Windows)
+/// The path to the current user's App Data directory, if known.
+private var _appDataDirectoryPath: String? {
+  var appDataDirectoryPath: PWSTR? = nil
+  if S_OK == SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, NULL, &appDataDirectoryPath), let appDataDirectoryPath {
+    defer {
+      CoTaskMemFree(appDataDirectoryPath)
+    }
+    return String.decodeCString(appDataDirectoryPath, as: UTF16.self)?.result
+  }
+  return nil
+}
+#endif
+
+/// The path to the user-specific `".swift-testing"` directory.
+///
+/// On Apple platforms and on Linux, this path is equivalent to
+/// `"~/.swift-testing"`. On Windows, it is equivalent to
+/// `"%HOMEPATH%\AppData\Local\.swift-testing"`.
+///
+/// The value of this property can be overridden by setting the
+/// `"SWT_SWIFT_TESTING_DIRECTORY_PATH"` environment variable.
+var swiftTestingDirectoryPath: String {
+  if let pathVariable = Environment.variable(named: "SWT_SWIFT_TESTING_DIRECTORY_PATH") {
+    return pathVariable
+  }
+
+  // The (default) name of the .swift-testing directory.
+  let swiftTestingDirectoryName = ".swift-testing"
+
+#if os(macOS) || (os(iOS) && targetEnvironment(macCatalyst)) || os(Linux)
+  if let homeDirectoryPath = _homeDirectoryPath {
+    return "\(homeDirectoryPath)/\(swiftTestingDirectoryName)"
+  }
+#elseif os(Windows)
+  if let appDataDirectoryPath = _appDataDirectoryPath {
+    return "\(appDataDirectoryPath)\\\(swiftTestingDirectoryName)"
+  }
+#else
+#warning("Platform-specific implementation missing: swift-testing directory location unavailable")
+#endif
+  return ""
+}
+#endif
+
+/// Read tag colors out of the file `"tag-colors.json"` in a given directory.
+///
+/// - Parameters:
+///   - swiftTestingDirectoryPath: The `".swift-testing"` directory from which
+///     tag color data should be read.
+///
+/// - Returns: A sequence of zero or more ``Event/Recorder/Option`` values
+///   representing the tag colors read from the file.
+///
+/// This function attempts to read the contents of the file
+/// `"tag-colors.json"` in the directory specified by
+/// `swiftTestingDirectoryPath`. The file is assumed to contain a JSON object (a
+/// dictionary) where the keys are tags' string values and the values represent
+/// tag colors. For a list of the supported formats for tag colors in this
+/// dictionary, see <doc:AddingTags>.
+func tagColorOptions(fromFileInDirectoryAtPath swiftTestingDirectoryPath: String = swiftTestingDirectoryPath) -> some Collection<Event.Recorder.Option> {
+#if !SWT_NO_TAG_COLORS
+  // Find the path to the tag-colors.json file.
+  let tagColorsURL = URL(fileURLWithPath: swiftTestingDirectoryPath, isDirectory: true)
+    .appendingPathComponent("tag-colors.json", isDirectory: false)
+
+  // Try to read from the JSON file. If we can't, ignore the error and just
+  // don't load any tag colors.
+  guard let tagColorsData = try? Data(contentsOf: tagColorsURL, options: [.mappedIfSafe]) else {
+    return []
+  }
+
+  // By default, a dictionary with non-string keys is encoded to and decoded
+  // from JSON as an array, so we decode the dictionary as if its keys are plain
+  // strings, then map them to tags.
+  //
+  // nil is a valid decoded color value (representing "no color") that we can
+  // use for merging tag color data from multiple sources, but it is not valid
+  // as an actual tag color, so we have a step here that filters it.
+  return (try? JSONDecoder().decode([String: Tag.Color?].self, from: tagColorsData))
+    .map { $0.map { (Tag(rawValue: $0), $1) } }
+    .map { Dictionary(uniqueKeysWithValues: $0) }
+    .map { $0.compactMapValues { $0 } }
+    .map { [.useTagColors($0)] } ?? []
+#else
+  []
+#endif
+}

--- a/Sources/Testing/Traits/Tag.Color+Loading.swift
+++ b/Sources/Testing/Traits/Tag.Color+Loading.swift
@@ -10,11 +10,8 @@
 
 private import TestingInternals
 
-// We do not want to link to Foundation normally, but this file already links to
-// XCTest which links to Foundation, so the dependency already exists and we can
-// make use of it here to support JSON decoding.
 #if canImport(Foundation)
-import Foundation
+private import Foundation
 #endif
 
 #if !SWT_NO_TAG_COLORS
@@ -54,14 +51,7 @@ private var _appDataDirectoryPath: String? {
 /// On Apple platforms and on Linux, this path is equivalent to
 /// `"~/.swift-testing"`. On Windows, it is equivalent to
 /// `"%HOMEPATH%\AppData\Local\.swift-testing"`.
-///
-/// The value of this property can be overridden by setting the
-/// `"SWT_SWIFT_TESTING_DIRECTORY_PATH"` environment variable.
 var swiftTestingDirectoryPath: String {
-  if let pathVariable = Environment.variable(named: "SWT_SWIFT_TESTING_DIRECTORY_PATH") {
-    return pathVariable
-  }
-
   // The (default) name of the .swift-testing directory.
   let swiftTestingDirectoryName = ".swift-testing"
 
@@ -95,8 +85,8 @@ var swiftTestingDirectoryPath: String {
 /// dictionary) where the keys are tags' string values and the values represent
 /// tag colors. For a list of the supported formats for tag colors in this
 /// dictionary, see <doc:AddingTags>.
-func tagColorOptions(fromFileInDirectoryAtPath swiftTestingDirectoryPath: String = swiftTestingDirectoryPath) -> some Collection<Event.Recorder.Option> {
-#if !SWT_NO_TAG_COLORS
+func tagColorOptions(fromFileInDirectoryAtPath swiftTestingDirectoryPath: String = swiftTestingDirectoryPath) -> [Event.Recorder.Option] {
+#if !SWT_NO_TAG_COLORS && canImport(Foundation)
   // Find the path to the tag-colors.json file.
   let tagColorsURL = URL(fileURLWithPath: swiftTestingDirectoryPath, isDirectory: true)
     .appendingPathComponent("tag-colors.json", isDirectory: false)

--- a/Sources/Testing/Traits/Tag.Color.swift
+++ b/Sources/Testing/Traits/Tag.Color.swift
@@ -1,0 +1,174 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+extension Tag {
+  /// An enumeration describing colors that can be applied to tests' tags.
+  ///
+  /// ## See Also
+  ///
+  /// - <doc:AddingTags>
+  @_spi(ExperimentalEventHandling)
+  public struct Color: Sendable {
+    /// The red component of the color.
+    ///
+    /// This property is not part of the public interface of the testing
+    /// library as we may wish to support non-RGB color spaces in the future.
+    var redComponent: UInt8
+
+    /// The green component of the color.
+    ///
+    /// This property is not part of the public interface of the testing
+    /// library as we may wish to support non-RGB color spaces in the future.
+    var greenComponent: UInt8
+
+    /// The blue component of the color.
+    ///
+    /// This property is not part of the public interface of the testing
+    /// library as we may wish to support non-RGB color spaces in the future.
+    var blueComponent: UInt8
+
+    /// The color red.
+    public static var red: Self { .rgb(255, 0, 0) }
+
+    /// The color orange.
+    public static var orange: Self { .rgb(255, 128, 0) }
+
+    /// The color yellow.
+    public static var yellow: Self { .rgb(255, 255, 0) }
+
+    /// The color green.
+    public static var green: Self { .rgb(0, 255, 0) }
+
+    /// The color blue.
+    public static var blue: Self { .rgb(0, 0, 255) }
+
+    /// The color purple.
+    public static var purple: Self { .rgb(192, 0, 224) }
+
+    /// Get an instance of this type representing a custom color in the RGB
+    /// color space.
+    ///
+    /// - Parameters:
+    ///   - redComponent: The red component of the color.
+    ///   - greenComponent: The green component of the color.
+    ///   - blueComponent: The blue component of the color.
+    ///
+    /// - Returns: An instance of this type representing the specified color.
+    ///
+    /// If a tag with an RGB color is output to a terminal that does not support
+    /// 256-color (or better) output, the color will not be displayed.
+    public static func rgb(_ redComponent: UInt8, _ greenComponent: UInt8, _ blueComponent: UInt8) -> Self {
+      self.init(redComponent: redComponent, greenComponent: greenComponent, blueComponent: blueComponent)
+    }
+  }
+}
+
+// MARK: - Equatable, Hashable
+
+extension Tag.Color: Equatable, Hashable {}
+
+// MARK: - Comparable
+
+extension Tag.Color: Comparable {
+  /// The index of this color, relative to other colors.
+  ///
+  /// The value of this property can be used for sorting color tags distinctly
+  /// from other (string-based) tags.
+  private var _colorIndex: UInt32 {
+    // Sort RGB colors such that bluer values are ordered after redder ones.
+    // (We might want to change this logic to sort by computed hue.)
+    (UInt32(blueComponent) << 16) | (UInt32(greenComponent) << 8) | UInt32(redComponent)
+  }
+
+  public static func <(lhs: Self, rhs: Self) -> Bool {
+    lhs._colorIndex < rhs._colorIndex
+  }
+}
+
+// MARK: - Comparable
+
+extension Tag.Color: Decodable {
+  public init(from decoder: any Decoder) throws {
+    let stringValue = try String(from: decoder)
+    switch stringValue {
+    case "red":
+      self = .red
+    case "orange":
+      self = .orange
+    case "yellow":
+      self = .yellow
+    case "green":
+      self = .green
+    case "blue":
+      self = .blue
+    case "purple":
+      self = .purple
+    case _ where stringValue.count == 7 && stringValue.first == "#":
+      guard let rgbValue = UInt32(stringValue.dropFirst(), radix: 16) else {
+        fallthrough
+      }
+      self = .rgb(
+        UInt8((rgbValue & 0x00FF0000) >> 16),
+        UInt8((rgbValue & 0x0000FF00) >> 8),
+        UInt8((rgbValue & 0x000000FF) >> 0)
+      )
+    default:
+      throw DecodingError.dataCorrupted(
+        DecodingError.Context(
+          codingPath: decoder.codingPath,
+          debugDescription: "Unsupported tag color constant \"\(stringValue)\"."
+        )
+      )
+    }
+  }
+}
+
+// MARK: - Predefined color tags
+
+extension Tag {
+  /// A tag representing the color red.
+  public static var red: Self { "red" }
+
+  /// A tag representing the color orange.
+  public static var orange: Self { "orange" }
+
+  /// A tag representing the color yellow.
+  public static var yellow: Self { "yellow" }
+
+  /// A tag representing the color green.
+  public static var green: Self { "green" }
+
+  /// A tag representing the color blue.
+  public static var blue: Self { "blue" }
+
+  /// A tag representing the color purple.
+  public static var purple: Self { "purple" }
+
+  /// Whether or not this tag represents a color predefined by the testing
+  /// library.
+  ///
+  /// Predefined color tags are any of these values:
+  ///
+  /// - ``Tag/red``
+  /// - ``Tag/orange``
+  /// - ``Tag/yellow``
+  /// - ``Tag/green``
+  /// - ``Tag/blue``
+  /// - ``Tag/purple``
+  public var isPredefinedColor: Bool {
+    switch self {
+    case .red, .orange, .yellow, .green, .blue, .purple:
+      return true
+    default:
+      return false
+    }
+  }
+}
+

--- a/Sources/Testing/Traits/Tag.List.swift
+++ b/Sources/Testing/Traits/Tag.List.swift
@@ -45,7 +45,7 @@ extension Tag.List: CustomStringConvertible {
     tags.lazy.map { tag in
       if let sourceCode = tag.sourceCode {
         return String(describing: sourceCode)
-      } else if tag.isColor {
+      } else if tag.isPredefinedColor {
         return ".\(tag.rawValue)"
       }
       return "\"\(tag.rawValue)\""

--- a/Sources/Testing/Traits/Tag.swift
+++ b/Sources/Testing/Traits/Tag.swift
@@ -26,48 +26,6 @@ public struct Tag: RawRepresentable, Sendable {
   }
 }
 
-// MARK: - Color tags
-
-extension Tag {
-  /// A tag representing the color red.
-  public static var red: Self { "red" }
-
-  /// A tag representing the color orange.
-  public static var orange: Self { "orange" }
-
-  /// A tag representing the color yellow.
-  public static var yellow: Self { "yellow" }
-
-  /// A tag representing the color green.
-  public static var green: Self { "green" }
-
-  /// A tag representing the color blue.
-  public static var blue: Self { "blue" }
-
-  /// A tag representing the color purple.
-  public static var purple: Self { "purple" }
-
-  /// Whether or not this tag represents a color predefined by the testing
-  /// library.
-  ///
-  /// Color tags are any of these values:
-  ///
-  /// - ``Tag/red``
-  /// - ``Tag/orange``
-  /// - ``Tag/yellow``
-  /// - ``Tag/green``
-  /// - ``Tag/blue``
-  /// - ``Tag/purple``
-  public var isColor: Bool {
-    switch self {
-    case .red, .orange, .yellow, .green, .blue, .purple:
-      return true
-    default:
-      return false
-    }
-  }
-}
-
 // MARK: - ExpressibleByStringLiteral
 
 extension Tag: ExpressibleByStringLiteral, CustomStringConvertible {
@@ -91,40 +49,20 @@ extension Tag: Equatable, Hashable, Comparable {
     hasher.combine(rawValue)
   }
 
-  /// The index of this color, relative to other colors.
-  ///
-  /// The value of this property can be used for sorting color tags distinctly
-  /// from other (string-based) tags.
-  private var _colorIndex: Int? {
-    switch self {
-    case .red:
-      return 0
-    case .orange:
-      return 1
-    case .yellow:
-      return 2
-    case .green:
-      return 3
-    case .blue:
-      return 4
-    case .purple:
-      return 5
-    default:
-      return nil
-    }
+  public static func <(lhs: Tag, rhs: Tag) -> Bool {
+    lhs.rawValue < rhs.rawValue
+  }
+}
+
+// MARK: - Codable
+
+extension Tag: Codable {
+  public func encode(to encoder: any Encoder) throws {
+    try rawValue.encode(to: encoder)
   }
 
-  public static func <(lhs: Tag, rhs: Tag) -> Bool {
-    switch (lhs._colorIndex, rhs._colorIndex) {
-    case let (.some(lhs), .some(rhs)):
-      return lhs < rhs
-    case (.some, .none):
-      return true
-    case (.none, .some):
-      return false
-    default:
-      return lhs.rawValue < rhs.rawValue
-    }
+  public init(from decoder: any Decoder) throws {
+    try self.init(rawValue: String(from: decoder))
   }
 }
 


### PR DESCRIPTION
This PR migrates tag colors from being specific instances of `Tag` to being out-of-band data contained in a package. We define a new folder in the user's home folder named `".swift-testing"` that contains out-of-band data specific to that user. In particular, we store tag colors in a file named `"tag-colors.json"` as a JSON object (dictionary.)

Note that we use `JSONDecoder` from Foundation to implement decoding. Although we do not want to add dependencies to Foundation (as it could prevent that package from someday adopting swift-testing), this code is contained in `XCTestScaffold` which already uses XCTest and, indirectly, Foundation, so this does not constitute a new dependency.

This path does not necessarily represent a final home for this data. We may instead want to put the file in the package folder or manifest, or in some location important to Xcode or other IDEs.

Example JSON:

```json
{
  "alpha": "red",
  "beta": "#00CCFF",
  "gamma": "#AABBCC",
  "delta": null
}
```

Example output (macOS Terminal.app):

<img width="331" alt="Screenshot showing colorized tags on a test in CLI (macOS)." src="https://github.com/apple/swift-testing/assets/4145863/2ca2a9b3-0d73-4147-b920-f00e08ba2691">

Example output (Ubuntu 22 Terminal):

<img width="318" alt="Screenshot showing colorized tags on a test in CLI (Linux)." src="https://github.com/apple/swift-testing/assets/4145863/11a2511c-9052-422c-8be5-d1b3d8acfa16">