### PR TITLE
Support setting a debugger breakpoint to pause when a test fails

### DIFF
--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -141,14 +141,14 @@ extension Issue {
 /// the testing library calls this function synchronously. This facilitates
 /// interactive debugging of test failures by allowing a symbolic breakpoint to
 /// be added specifying the symbol name of this function
-/// (`SWTFailureBreakpoint`), so that the debugger may pause execution and allow
-/// a user to inspect the process state. This function performs no action of its
-/// own.
+/// (`swt_failureBreakpoint`), so that the debugger may pause execution and
+/// allow a user to inspect the process state. This function performs no action
+/// of its own.
 ///
 /// This function is not part of the public interface of the testing library,
 /// but it is exported and its symbol name must remain stable.
-@_cdecl("SWTFailureBreakpoint")
-@inline(never)
+@_cdecl("swt_failureBreakpoint")
+@inline(never) @_optimize(none)
 @usableFromInline
 func failureBreakpoint() {
   // Empty.

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -71,6 +71,15 @@ extension Issue {
     }
 
     Event.post(.issueRecorded(self), configuration: configuration)
+
+    if !isKnown {
+      // Since this is not a known issue, invoke the failure breakpoint.
+      //
+      // Do this after posting the event above, to allow the issue to be printed
+      // to the console first (assuming the event handler does this), since that
+      // can help explain the failure.
+      failureBreakpoint()
+    }
   }
 
   /// Record an issue when a running test fails unexpectedly.
@@ -124,4 +133,23 @@ extension Issue {
     issue.record()
     return issue
   }
+}
+
+/// A function called by the testing library when a failure occurs.
+///
+/// Whenever a test failure (specifically, a non-known ``Issue``) is recorded,
+/// the testing library calls this function synchronously. This facilitates
+/// interactive debugging of test failures by allowing a symbolic breakpoint to
+/// be added specifying the symbol name of this function
+/// (`SWTFailureBreakpoint`), so that the debugger may pause execution and allow
+/// a user to inspect the process state. This function performs no action of its
+/// own.
+///
+/// This function is not part of the public interface of the testing library,
+/// but it is exported and its symbol name must remain stable.
+@_cdecl("SWTFailureBreakpoint")
+@inline(never)
+@usableFromInline
+func failureBreakpoint() {
+  // Empty.
 }

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -139,15 +139,22 @@ extension Issue {
 ///
 /// Whenever a test failure (specifically, a non-known ``Issue``) is recorded,
 /// the testing library calls this function synchronously. This facilitates
-/// interactive debugging of test failures by allowing a symbolic breakpoint to
-/// be added specifying the symbol name of this function
-/// (`swt_failureBreakpoint`), so that the debugger may pause execution and
-/// allow a user to inspect the process state. This function performs no action
-/// of its own.
+/// interactive debugging of test failures: If you add a symbolic breakpoint
+/// specifying the name of this function, the debugger will pause execution and
+/// allow you to inspect the process state.
 ///
-/// This function is not part of the public interface of the testing library,
-/// but it is exported and its symbol name must remain stable.
-@_cdecl("swt_failureBreakpoint")
+/// When creating a symbolic breakpoint for this function, it is recommended
+/// that you constrain it to the `Testing` module to avoid collisions with
+/// similarly-named functions in other modules. If you are using LLDB, you can
+/// use the following command to create the breakpoint:
+///
+/// ```lldb
+/// (lldb) breakpoint set -s Testing -n "failureBreakpoint()"
+/// ```
+///
+/// This function performs no action of its own. It is not part of the public
+/// interface of the testing library, but it is exported and its symbol name
+/// must remain stable.
 @inline(never) @_optimize(none)
 @usableFromInline
 func failureBreakpoint() {

--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -15,12 +15,16 @@ public struct Configuration: Sendable {
   /// configuration.
   public init() {}
 
+  // MARK: - Parallelization
+
   /// Whether or not to parallelize the execution of tests and test cases (by
   /// default.)
   static var isParallelizationEnabledByDefault: Bool { Environment.flag(named: "SWT_ENABLE_PARALLELIZATION") ?? true }
 
   /// Whether or not to parallelize the execution of tests and test cases.
   public var isParallelizationEnabled = Self.isParallelizationEnabledByDefault
+
+  // MARK: - Main actor isolation
 
 #if !SWT_NO_GLOBAL_ACTORS
   /// Whether or not synchronous test functions need to run on the main actor


### PR DESCRIPTION
Add a function with a well-defined symbol that gets invoked whenever a failure occurs. This allows an attached debugger to place a breakpoint on that symbol and pause execution whenever a test failure is recorded.

### Motivation:

It's often helpful when investigating a test failure to attach using a debugger and place a breakpoint to step through the code. And sometimes, you want to pause exactly at the spot where a test failure occurs, instead of at the beginning of a particular test. This makes that workflow possible by establishing a function for which you can create a symbolic breakpoint, so that execution will pause whenever a test failure occurs.

### Modifications:

- Introduce a new function which is called whenever a test failure is recorded. Open to naming improvement suggestions!
- Allow configuring this "failure breakpoint" in `Configuration` to facilitate unit testing.
- Add new unit tests.

### Result:

It is possible to set a symbolic breakpoint on this new function and pause upon failure.

Resolves rdar://116948062