### PR TITLE
Update link to `#fileID` documentation that has moved to the stdlib.

### DIFF
--- a/Sources/Testing/SourceAttribution/SourceLocation.swift
+++ b/Sources/Testing/SourceAttribution/SourceLocation.swift
@@ -16,7 +16,6 @@ public struct SourceLocation: Sendable {
   ///
   /// - ``moduleName``
   /// - ``fileName``
-  /// - [The Swift Programming Language &mdash; Literal Expressions](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/expressions/#Literal-Expression)
   public var fileID: String {
     didSet {
       precondition(!fileID.isEmpty)
@@ -32,11 +31,14 @@ public struct SourceLocation: Sendable {
   /// instance's ``fileID`` property is `"FoodTruck/WheelTests.swift"`, the
   /// file name is `"WheelTests.swift"`.
   ///
+  /// The structure of file IDs is described in the documentation for the
+  /// [`#fileID`](https://developer.apple.com/documentation/swift/fileID())
+  /// macro in the Swift standard library.
+  ///
   /// ## See Also
   ///
   /// - ``fileID``
   /// - ``moduleName``
-  /// - [The Swift Programming Language &mdash; Literal Expressions](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/expressions/#Literal-Expression)
   public var fileName: String {
     let lastSlash = fileID.lastIndex(of: "/")!
     return String(fileID[fileID.index(after: lastSlash)...])
@@ -50,11 +52,15 @@ public struct SourceLocation: Sendable {
   /// instance's ``fileID`` property is `"FoodTruck/WheelTests.swift"`, the
   /// module name is `"FoodTruck"`.
   ///
+  /// The structure of file IDs is described in the documentation for the
+  /// [`#fileID`](https://developer.apple.com/documentation/swift/fileID())
+  /// macro in the Swift standard library.
+  ///
   /// ## See Also
   ///
   /// - ``fileID``
   /// - ``fileName``
-  /// - [The Swift Programming Language &mdash; Literal Expressions](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/expressions/#Literal-Expression)
+  /// - [`#fileID`](https://developer.apple.com/documentation/swift/fileID())
   public var moduleName: String {
     let firstSlash = fileID.firstIndex(of: "/")!
     return String(fileID[..<firstSlash])

--- a/Sources/Testing/SourceAttribution/SourceLocation.swift
+++ b/Sources/Testing/SourceAttribution/SourceLocation.swift
@@ -31,9 +31,9 @@ public struct SourceLocation: Sendable {
   /// instance's ``fileID`` property is `"FoodTruck/WheelTests.swift"`, the
   /// file name is `"WheelTests.swift"`.
   ///
-  /// The structure of file IDs is described in the documentation for the
+  /// The structure of file IDs is described in the documentation for
   /// [`#fileID`](https://developer.apple.com/documentation/swift/fileID())
-  /// macro in the Swift standard library.
+  /// in the Swift standard library.
   ///
   /// ## See Also
   ///


### PR DESCRIPTION
`#fileID` is no longer a literal but is now a macro in the stdlib, so its documentation has moved. Update our documentation to match.