### PR TITLE
Improve diffing of collections and structured values.

### DIFF
--- a/Sources/Testing/Events/Event.Recorder.swift
+++ b/Sources/Testing/Events/Event.Recorder.swift
@@ -344,6 +344,37 @@ extension Event.Recorder {
   }
 }
 
+// MARK: -
+
+extension Difference {
+  /// Get a description of this instance with the given recorder options.
+  ///
+  /// - Parameters:
+  ///   - options: Options to use when writing the comments.
+  ///
+  /// - Returns: A formatted description of `self`.
+  fileprivate func formattedDescription(options: Set<Event.Recorder.Option>) -> String {
+    guard options.contains(.useANSIEscapeCodes) else {
+      return String(describing: self)
+    }
+
+    return String(describing: self)
+      .split(whereSeparator: \.isNewline)
+      .map { line in
+        switch line.first {
+        case "+":
+          "\(_ansiEscapeCodePrefix)32m\(line)\(_resetANSIEscapeCode)"
+        case "-":
+          "\(_ansiEscapeCodePrefix)31m\(line)\(_resetANSIEscapeCode)"
+        default:
+          String(line)
+        }
+      }.joined(separator: "\n")
+  }
+}
+
+// MARK: -
+
 extension Tag {
   /// Get an ANSI escape code that sets the foreground text color to this tag's
   /// corresponding color, if applicable.
@@ -553,9 +584,9 @@ extension Event.Recorder {
       }
 
       var difference = ""
-      if case let .expectationFailed(expectation) = issue.kind, let differenceDescription = expectation.differenceDescription {
+      if case let .expectationFailed(expectation) = issue.kind, let differenceValue = expectation.difference {
         let differenceSymbol = _Symbol.difference.stringValue(options: options)
-        difference = "\n\(differenceSymbol) \(differenceDescription)"
+        difference = "\n\(differenceSymbol) \(differenceValue.formattedDescription(options: options))"
       }
 
       var issueComments = ""

--- a/Sources/Testing/Expectations/Difference.swift
+++ b/Sources/Testing/Expectations/Difference.swift
@@ -1,0 +1,193 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+/// A type that describes the difference between two values as a sequence of
+/// insertions, deletions, or unmodified elements.
+/// 
+/// To ensure that ``Difference`` can always conform to `Sendable`, the elements
+/// in an instance of this type are stored as strings rather than as their
+/// original types. They are converted to strings using
+/// ``Swift/String/init(describingForTest:)``. Types can implement
+/// ``CustomTestStringConvertible`` to customize how they appear in the
+/// description of an instance of this type.
+@_spi(ExperimentalEventHandling)
+public struct Difference: Sendable {
+  /// An enumeration representing the kinds of change that can occur during
+  /// diffing.
+  enum ElementKind: Sendable {
+    /// The element was inserted.
+    case insert
+
+    /// The element was removed.
+    case remove
+
+    /// The element replaced a previous value.
+    ///
+    /// - Parameters:
+    ///   - oldValue: The old value at this position.
+    case replace(oldValue: String)
+  }
+
+  /// A type representing an element of a collection that may have been changed
+  /// after diffing was applied.
+  ///
+  /// This type roughly approximates `CollectionDifference.Change`, however it
+  /// is used to track _all_ elements in the collection, not just those that
+  /// have changed, allowing for insertion of "marker" elements where removals
+  /// occurred.
+  typealias Element = (value: String, kind: ElementKind?)
+
+  /// The changed elements from the comparison.
+  var elements = [Element]()
+
+  init(elements: some Sequence<Element>) {
+    self.elements = Array(elements)
+  }
+
+  /// Initialize an instance of this type by comparing two collections.
+  ///
+  /// - Parameters:
+  ///   - lhs: The "old" state of the collection to compare.
+  ///   - rhs: The "new" state of the collection to compare.
+  ///   - describingForTest: Whether or not to convert values in `lhs` and `rhs`
+  ///     to strings using ``Swift/String/init(describingForTest:)``.
+  init<T, U>(from lhs: T, to rhs: U, describingForTest: Bool = true)
+  where T: BidirectionalCollection, T.Element: Equatable, U: BidirectionalCollection, T.Element == U.Element {
+    // Compute the difference between the two elements. Sort the resulting set
+    // of changes by their offsets, and ensure that insertions come before
+    // removals located at the same offset. This helps to ensure that the offset
+    // values do not drift as we walk the changeset.
+    let difference = rhs.difference(from: lhs)
+
+    // Walk the initial string and slowly transform it into the final string.
+    // Add an additional "scratch" string that is used to store a removal marker
+    // if the last character is removed.
+    var result: [[(value: T.Element, kind: ElementKind?)]] = lhs.map { [($0, nil)] } + CollectionOfOne([])
+    for change in difference.removals.reversed() {
+      // Remove the character at the specified index, then re-insert it into the
+      // slot at the previous index (with the marker character applied.) The
+      // previous index will then contain whatever character it already
+      // contained after the character representing this removal.
+      result.remove(at: change.offset)
+      result[change.offset].insert((change.element, kind: .remove), at: 0)
+    }
+    for change in difference.insertions {
+      // Insertions can occur verbatim by inserting a new substring at the
+      // specified offset.
+      result.insert([(change.element, kind: .insert)], at: change.offset)
+    }
+
+    let describe: (T.Element) -> String = if describingForTest {
+      String.init(describingForTest:)
+    } else {
+      String.init(describing:)
+    }
+
+    self.init(
+      elements: result.lazy
+        .flatMap { $0 }
+        .map { (describe($0.value), $0.kind) }
+        .reduce(into: []) { (result: inout _, element: Element) in
+          if element.kind == .remove, let previous = result.last, previous.kind == .insert {
+            result[result.index(before: result.endIndex)] = (previous.value, .replace(oldValue: element.value))
+          } else {
+            result.append(element)
+          }
+        }
+    )
+  }
+
+  /// Get a string reflecting a value, similar to how it might have been
+  /// initialized and suitable for display as part of a difference.
+  ///
+  /// - Parameters:
+  ///   - value: The value to reflect.
+  ///
+  /// - Returns: A string reflecting `value`, or `nil` if its reflection is
+  ///   trivial.
+  ///
+  /// This function uses `Mirror`, so if the type of `value` conforms to
+  /// `CustomReflectable`, the resulting string will be derived from the value's
+  /// custom mirror.
+  private static func _reflect<T>(_ value: T) -> String? {
+    let mirrorChildren = Mirror(reflecting: value).children
+    if mirrorChildren.isEmpty {
+      return nil
+    }
+
+    let typeName = _typeName(T.self, qualified: true)
+    let children = mirrorChildren.lazy
+      .map { child in
+        if let label = child.label {
+          "  \(label): \(String(describingForTest: child.value))"
+        } else {
+          "  \(String(describingForTest: child.value))"
+        }
+      }.joined(separator: "\n")
+    return """
+    \(typeName)(
+    \(children)
+    )
+    """
+  }
+
+  /// Initialize an instance of this type by comparing the reflections of two
+  /// values.
+  ///
+  /// - Parameters:
+  ///   - lhs: The "old" value to compare.
+  ///   - rhs: The "new" value to compare.
+  init?<T, U>(comparingValue lhs: T, to rhs: U) {
+    guard let lhsDump = Self._reflect(lhs), let rhsDump = Self._reflect(rhs) else {
+      return nil
+    }
+
+    let lhsDumpLines = lhsDump.split(whereSeparator: \.isNewline)
+    let rhsDumpLines = rhsDump.split(whereSeparator: \.isNewline)
+    if lhsDumpLines.count > 1 || rhsDumpLines.count > 1 {
+      self.init(from: lhsDumpLines, to: rhsDumpLines, describingForTest: false)
+    } else {
+      return nil
+    }
+  }
+}
+
+// MARK: - Equatable
+
+extension Difference.ElementKind: Equatable {}
+
+// MARK: - CustomStringConvertible
+
+extension Difference: CustomStringConvertible {
+  public var description: String {
+    // Show individual lines of the text with leading + or - characters to
+    // indicate insertions and removals respectively.
+    // FIXME: better descriptive output for one-line strings.
+    let diffCount = elements.lazy
+      .filter { $0.kind != nil }
+      .count
+    return "\(diffCount.counting("change")):\n" + elements.lazy
+      .flatMap { element in
+        switch element.kind {
+        case nil:
+          ["  \(element.value)"]
+        case .insert:
+          ["+ \(element.value)"]
+        case .remove:
+          ["- \(element.value)"]
+        case let .replace(oldValue):
+          [
+            "- \(oldValue)",
+            "+ \(element.value)"
+          ]
+        }
+      }.joined(separator: "\n")
+  }
+}

--- a/Sources/Testing/Expectations/Difference.swift
+++ b/Sources/Testing/Expectations/Difference.swift
@@ -19,22 +19,6 @@
 /// description of an instance of this type.
 @_spi(ExperimentalEventHandling)
 public struct Difference: Sendable {
-  /// An enumeration representing the kinds of change that can occur during
-  /// diffing.
-  enum ElementKind: Sendable {
-    /// The element was inserted.
-    case insert
-
-    /// The element was removed.
-    case remove
-
-    /// The element replaced a previous value.
-    ///
-    /// - Parameters:
-    ///   - oldValue: The old value at this position.
-    case replace(oldValue: String)
-  }
-
   /// A type representing an element of a collection that may have been changed
   /// after diffing was applied.
   ///
@@ -42,14 +26,26 @@ public struct Difference: Sendable {
   /// is used to track _all_ elements in the collection, not just those that
   /// have changed, allowing for insertion of "marker" elements where removals
   /// occurred.
-  typealias Element = (value: String, kind: ElementKind?)
+  enum Element: Sendable {
+    /// The element did not change during diffing.
+    case unchanged(String)
+
+    /// The element was inserted.
+    case inserted(String)
+
+    /// The element was removed.
+    case removed(String)
+
+    /// The element replaced a previous value.
+    ///
+    /// - Parameters:
+    ///   - oldValue: The old value at this position.
+    ///   - with: The new value at this position.
+    case replaced(_ oldValue: String, with: String)
+  }
 
   /// The changed elements from the comparison.
   var elements = [Element]()
-
-  init(elements: some Sequence<Element>) {
-    self.elements = Array(elements)
-  }
 
   /// Initialize an instance of this type by comparing two collections.
   ///
@@ -77,42 +73,45 @@ public struct Difference: Sendable {
     // Walk the initial string and slowly transform it into the final string.
     // Add an additional "scratch" string that is used to store a removal marker
     // if the last character is removed.
-    var result: [[Element]] = lhsDump.map { [($0, nil)] } + CollectionOfOne([])
+    var result = lhsDump.map { [Element.unchanged($0)] } + CollectionOfOne([])
     for change in difference.removals.reversed() {
       // Remove the character at the specified index, then re-insert it into the
-      // slot at the previous index (with the marker character applied.) The
-      // previous index will then contain whatever character it already
-      // contained after the character representing this removal.
+      // slot at the next index (with the marker character applied.) The next
+      // index will then contain whatever character it already contained after
+      // the character representing this removal.
       result.remove(at: change.offset)
-      result[change.offset].insert((change.element, kind: .remove), at: 0)
+      result[change.offset].insert(.removed(change.element), at: 0)
     }
     for change in difference.insertions {
       // Insertions can occur verbatim by inserting a new substring at the
       // specified offset.
-      result.insert([(change.element, kind: .insert)], at: change.offset)
+      result.insert([.inserted(change.element)], at: change.offset)
     }
 
     // Flatten the arrays of arrays of elements into a single array, then merge
     // pairs of removals/insertions (i.e. where an element was replaced with
     // another element) because it's easier to do after the array of arrays has
     // been flatted.
-    let elements: some Sequence<Element> = result.lazy
+    elements = result.lazy
       .flatMap { $0 }
       .reduce(into: []) { result, element in
-        if element.kind == .remove, let previous = result.last, previous.kind == .insert {
-          result[result.index(before: result.endIndex)] = (previous.value, .replace(oldValue: element.value))
+        if case let .removed(removedValue) = element, let previous = result.last, case let .inserted(insertedValue) = previous {
+          result[result.index(before: result.endIndex)] = .replaced(removedValue, with: insertedValue)
         } else {
           result.append(element)
         }
       }
-
-    self.init(elements: elements)
   }
 }
 
 // MARK: - Equatable
 
-extension Difference.ElementKind: Equatable {}
+extension Difference.Element: Equatable {}
+
+// MARK: - Codable
+
+extension Difference: Codable {}
+extension Difference.Element: Codable {}
 
 // MARK: - CustomStringConvertible
 
@@ -122,21 +121,26 @@ extension Difference: CustomStringConvertible {
     // indicate insertions and removals respectively.
     // FIXME: better descriptive output for one-line strings.
     let diffCount = elements.lazy
-      .filter { $0.kind != nil }
-      .count
-    return "\(diffCount.counting("change")):\n" + elements.lazy
+      .filter { element in
+        if case .unchanged = element {
+          return false
+        }
+        return true
+      }.count.counting("change")
+
+    return "\(diffCount):\n" + elements.lazy
       .flatMap { element in
-        switch element.kind {
-        case nil:
-          ["  \(element.value)"]
-        case .insert:
-          ["+ \(element.value)"]
-        case .remove:
-          ["- \(element.value)"]
-        case let .replace(oldValue):
+        switch element {
+        case let .unchanged(value):
+          ["  \(value)"]
+        case let .inserted(value):
+          ["+ \(value)"]
+        case let .removed(value):
+          ["- \(value)"]
+        case let .replaced(oldValue, with: newValue):
           [
             "- \(oldValue)",
-            "+ \(element.value)"
+            "+ \(newValue)"
           ]
         }
       }.joined(separator: "\n")

--- a/Sources/Testing/Expectations/Expectation.swift
+++ b/Sources/Testing/Expectations/Expectation.swift
@@ -31,8 +31,8 @@ public struct Expectation: Sendable {
   @_spi(ExperimentalEventHandling)
   public var expandedExpressionDescription: String?
 
-  /// An array of changes that collectively describe the difference between two
-  /// values or collections that have been compared.
+  /// An opaque value that describes the difference between two values or
+  /// collections that have been compared.
   ///
   /// If this expectation did not involve the comparison of two values or
   /// collections, the value of this property is `nil`.

--- a/Sources/Testing/Expectations/Expectation.swift
+++ b/Sources/Testing/Expectations/Expectation.swift
@@ -31,14 +31,17 @@ public struct Expectation: Sendable {
   @_spi(ExperimentalEventHandling)
   public var expandedExpressionDescription: String?
 
-  /// A description of the difference between the operands in the expression
-  /// evaluated by this expectation, if the difference could be determined.
+  /// An array of changes that collectively describe the difference between two
+  /// values or collections that have been compared.
   ///
-  /// If this expectation passed, the value of this property is `nil` because
-  /// the difference is only computed when necessary to assist with diagnosing
-  /// test failures.
+  /// If this expectation did not involve the comparison of two values or
+  /// collections, the value of this property is `nil`.
+  ///
+  /// If this expectation passed, the value of this property will be `nil`
+  /// because the difference is only computed when necessary to assist with
+  /// diagnosing failures.
   @_spi(ExperimentalEventHandling)
-  public var differenceDescription: String?
+  public var difference: Difference?
 
   /// Whether the expectation passed or failed.
   ///

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -180,7 +180,7 @@ public func __checkBinaryOperation<T, U>(
     guard let rhs else {
       return nil
     }
-    return Difference(comparingValue: lhs, to: rhs)
+    return Difference(from: lhs, to: rhs)
   }
   return __checkValue(
     condition,
@@ -313,43 +313,7 @@ public func __checkInoutFunctionCall<T, /*each*/ U, R>(
   )
 }
 
-// MARK: - Collection diffing
-
-/// Check that an expectation has passed after a condition has been evaluated
-/// and throw an error if it failed.
-///
-/// This overload is necessary because `String` satisfies the requirements for
-/// the generic overload above, but the output from that overload splits the
-/// strings into individual characters for display.
-///
-/// - Warning: This function is used to implement the `#expect()` and
-///   `#require()` macros. Do not call it directly.
-public func __checkBinaryOperation<T, U>(
-  _ lhs: T, _ op: (T, () -> U) -> Bool, _ rhs: @autoclosure () -> U,
-  sourceCode: SourceCode,
-  comments: @autoclosure () -> [Comment],
-  isRequired: Bool,
-  sourceLocation: SourceLocation
-) -> Result<Void, any Error> where T: StringProtocol, U: StringProtocol {
-  let (condition, rhs) = _callBinaryOperator(lhs, op, rhs)
-  func difference() -> Difference? {
-    guard let rhs else {
-      return nil
-    }
-    let lhsSplit = lhs.split(whereSeparator: \.isNewline).map { String($0) }
-    let rhsSplit = rhs.split(whereSeparator: \.isNewline).map { String($0) }
-    return Difference(from: lhsSplit, to: rhsSplit)
-  }
-  return __checkValue(
-    condition,
-    sourceCode: sourceCode,
-    expandedExpressionDescription: sourceCode.expandWithOperands(lhs, rhs),
-    difference: difference(),
-    comments: comments(),
-    isRequired: isRequired,
-    sourceLocation: sourceLocation
-  )
-}
+// MARK: - Type checks
 
 /// Check that an expectation has passed after a condition has been evaluated
 /// and throw an error if it failed.

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -318,42 +318,9 @@ public func __checkInoutFunctionCall<T, /*each*/ U, R>(
 /// Check that an expectation has passed after a condition has been evaluated
 /// and throw an error if it failed.
 ///
-/// This overload is used to implement difference-reporting support when
-/// comparing collections.
-///
-/// - Warning: This function is used to implement the `#expect()` and
-///   `#require()` macros. Do not call it directly.
-public func __checkBinaryOperation<T, U>(
-  _ lhs: T, _ op: (T, () -> U) -> Bool, _ rhs: @autoclosure () -> U,
-  sourceCode: SourceCode,
-  comments: @autoclosure () -> [Comment],
-  isRequired: Bool,
-  sourceLocation: SourceLocation
-) -> Result<Void, any Error> where T: BidirectionalCollection, T.Element: Equatable, U: BidirectionalCollection, T.Element == U.Element {
-  let (condition, rhs) = _callBinaryOperator(lhs, op, rhs)
-  func difference() -> Difference? {
-    guard let rhs else {
-      return nil
-    }
-    return Difference(from: lhs, to: rhs)
-  }
-  return __checkValue(
-    condition,
-    sourceCode: sourceCode,
-    expandedExpressionDescription: sourceCode.expandWithOperands(lhs, rhs),
-    difference: difference(),
-    comments: comments(),
-    isRequired: isRequired,
-    sourceLocation: sourceLocation
-  )
-}
-
-/// Check that an expectation has passed after a condition has been evaluated
-/// and throw an error if it failed.
-///
 /// This overload is necessary because `String` satisfies the requirements for
-/// the difference-calculating overload above, but the output from that overload
-/// may be unexpectedly complex.
+/// the generic overload above, but the output from that overload splits the
+/// strings into individual characters for display.
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -157,7 +157,7 @@ extension Issue.Kind: CustomStringConvertible {
     case let .expectationFailed(expectation):
       if let mismatchedErrorDescription = expectation.mismatchedErrorDescription {
         "Expectation failed: \(mismatchedErrorDescription)"
-      } else if let expandedExpressionDescription = expectation.expandedExpressionDescription {
+      } else if let expandedExpressionDescription = expectation.expandedExpressionDescription, expectation.difference == nil {
         "Expectation failed: \(expandedExpressionDescription)"
       } else if let sourceCode = expectation.sourceCode {
         "Expectation failed: \(sourceCode)"

--- a/Sources/Testing/SourceAttribution/CustomTestStringConvertible.swift
+++ b/Sources/Testing/SourceAttribution/CustomTestStringConvertible.swift
@@ -224,6 +224,7 @@ private func _reflect<T>(_ value: T) -> String? {
 
   let children = mirrorChildren.lazy
     .map { child in
+      // TODO: handle multi-line descriptions elegantly
       if let label = child.label {
         "  \(label): \(String(describingForTest: child.value))"
       } else {

--- a/Sources/Testing/Support/Additions/CollectionDifferenceAdditions.swift
+++ b/Sources/Testing/Support/Additions/CollectionDifferenceAdditions.swift
@@ -16,4 +16,15 @@ extension CollectionDifference.Change {
       return result
     }
   }
+
+  /// The offset to the change.
+  ///
+  /// Note that the semantic meaning of this value depends on this instance's
+  /// case.
+  var offset: Int {
+    switch self {
+    case let .insert(offset: result, element: _, associatedWith: _), let .remove(offset: result, element: _, associatedWith: _):
+      return result
+    }
+  }
 }

--- a/Tests/TestingTests/Event.RecorderTests.swift
+++ b/Tests/TestingTests/Event.RecorderTests.swift
@@ -75,8 +75,6 @@ struct EventRecorderTests {
       #expect(!buffer.contains("●"))
     }
 
-    #expect(buffer.contains(#"+ "xyz""#))
-
     if testsWithSignificantIOAreEnabled {
       print(buffer, terminator: "")
     }

--- a/Tests/TestingTests/Event.RecorderTests.swift
+++ b/Tests/TestingTests/Event.RecorderTests.swift
@@ -75,7 +75,7 @@ struct EventRecorderTests {
       #expect(!buffer.contains("●"))
     }
 
-    #expect(buffer.contains("inserted ["))
+    #expect(buffer.contains(#"+ "xyz""#))
 
     if testsWithSignificantIOAreEnabled {
       print(buffer, terminator: "")

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -991,14 +991,58 @@ final class IssueTests: XCTestCase {
         return XCTFail("Unexpected nil difference")
       }
       let differenceDescription = String(describing: difference)
-
-      XCTAssertTrue(differenceDescription.contains(#"+ "Ht was the best of times, it was the blurst of times! Go chvappy way...""#))
-      XCTAssertTrue(differenceDescription.contains(#"- "It was the best of times, it was the worst of times. Oh happy day!""#))
+      XCTAssertTrue(differenceDescription.contains(#"- consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse"#))
+      XCTAssertTrue(differenceDescription.contains(#"+ potato salad. Duis aute irure dolor in reprehenderit in voluptate velit esse"#))
     }
 
     await Test {
-      let lhs = "It was the best of times, it was the worst of times. Oh happy day!"
-      let rhs = "Ht was the best of times, it was the blurst of times! Go chvappy way..."
+      let lhs = """
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+      cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+      non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      """
+      let rhs = """
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+      potato salad. Duis aute irure dolor in reprehenderit in voluptate velit esse
+      cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+      non dentistry, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      """
+      #expect(lhs == rhs)
+    }.run(configuration: configuration)
+  }
+
+  func testComplexStructureDifference() async {
+    var configuration = Configuration()
+    configuration.eventHandler = { event, _ in
+      guard case let .issueRecorded(issue) = event.kind else {
+        return
+      }
+      guard case let .expectationFailed(expectation) = issue.kind else {
+        XCTFail("Unexpected issue kind \(issue.kind)")
+        return
+      }
+      guard let difference = expectation.difference else {
+        return XCTFail("Unexpected nil difference")
+      }
+      let differenceDescription = String(describing: difference)
+      print(differenceDescription)
+      XCTAssertTrue(differenceDescription.contains(#"+   y: "def""#))
+      XCTAssertTrue(differenceDescription.contains(#"-   y: "abc""#))
+    }
+
+    struct S: Equatable {
+      var x: Int
+      var y: String
+    }
+
+    await Test {
+      let lhs = S(x: 123, y: "abc")
+      let rhs = S(x: 123, y: "def")
       #expect(lhs == rhs)
     }.run(configuration: configuration)
   }

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -966,8 +966,8 @@ final class IssueTests: XCTestCase {
         return XCTFail("Unexpected nil difference")
       }
       let differenceDescription = String(describing: difference)
-      XCTAssertTrue(differenceDescription.contains("+ 6"))
-      XCTAssertTrue(differenceDescription.contains("- 3"))
+      XCTAssertTrue(differenceDescription.contains("+   6"))
+      XCTAssertTrue(differenceDescription.contains("-   3"))
     }
 
     await Test {

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -1030,7 +1030,6 @@ final class IssueTests: XCTestCase {
         return XCTFail("Unexpected nil difference")
       }
       let differenceDescription = String(describing: difference)
-      print(differenceDescription)
       XCTAssertTrue(differenceDescription.contains(#"+   y: "def""#))
       XCTAssertTrue(differenceDescription.contains(#"-   y: "abc""#))
     }


### PR DESCRIPTION
This PR improves the test output when comparing collections and structured values (using `#expect()`) when the comparison fails. Previously, we'd just the insertions and deletions as arrays, which was potentially hard to read and didn't show the test author _where_ these changes occurred. Now, we convert the compared values into something similar to multi-line `diff` output. Consider the following test function:

```swift
@Test func f() {
  let lhs = """
  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
  tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
  quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
  consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
  cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
  non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
  """
  let rhs = """
  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
  tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
  quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
  potato salad. Duis aute irure dolor in reprehenderit in voluptate velit esse
  cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
  non dentistry, sunt in culpa qui officia deserunt mollit anim id est laborum.
  """
  #expect(lhs == rhs)
}
```

The output will now be:

```
◇ Test f() started.
✘ Test f() recorded an issue at MyTests.swift:45:5: Expectation failed: lhs == rhs
± 2 changes:
  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod"
  "tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,"
  "quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo"
+ "potato salad. Duis aute irure dolor in reprehenderit in voluptate velit esse"
- "consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse"
  "cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat"
+ "non dentistry, sunt in culpa qui officia deserunt mollit anim id est laborum."
- "non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
✘ Test f() failed after 0.001 seconds with 1 issue.
```

Similarly, with this test:

```swift
struct S: Equatable {
  var x: Int
  var y: String
}

@Test func f() {
  let lhs = S(x: 123, y: "abc")
  let rhs = S(x: 123, y: "def")
  #expect(lhs == rhs)
}
```

The output should appear similar to:

```
◇ Test f() started.
✘ Test f() recorded an issue at MyTests.swift:36:5: Expectation failed: lhs == rhs
± 1 change:
  MyTests.S(
    x: 123
-   y: "abc"
+   y: "def"
  )
✘ Test f() failed after 0.001 seconds with 1 issue.
```

Resolves rdar://66351980.