### PR TITLE
Make `Test.Clock.Instant` conform to `Codable`

### DIFF
--- a/Sources/Testing/Events/Clock.swift
+++ b/Sources/Testing/Events/Clock.swift
@@ -64,6 +64,23 @@ extension Test {
 // MARK: - Converting to other clocks
 
 extension timespec {
+  /// Initialize an instance of this type from an instance of
+  /// `SuspendingClock.Instant`.
+  ///
+  /// - Parameters:
+  ///   - instant: The instant to initialize this instance from.
+  ///
+  /// The resulting instance of `timespec` measures the duration between the
+  /// suspending clock's epoch and `instant`.
+  ///
+  /// This initializer is not part of the public interface of the testing
+  /// library.
+  @available(_clockAPI, *)
+  init(_ instant: SuspendingClock.Instant) {
+    let duration = unsafeBitCast(instant, to: Duration.self)
+    self.init(duration)
+  }
+
   /// Initialize an instance of this type from an instance of `Duration`.
   ///
   /// - Parameters:
@@ -131,11 +148,25 @@ extension SuspendingClock.Instant {
   ///   - testClockInstant: The equivalent instant on ``Test/Clock``.
   public init(_ testClockInstant: Test.Clock.Instant) {
 #if SWT_TARGET_OS_APPLE
-    let duration = Duration(testClockInstant.uptime)
-    self = unsafeBitCast(duration, to: Self.self)
+    self.init(testClockInstant.uptime)
 #else
     self = testClockInstant.suspending
 #endif
+  }
+
+  /// Initialize an instance of this type from an instance of `timespec`.
+  ///
+  /// - Parameters:
+  ///   - ts: The `timespec` value to initialize this instance from.
+  ///
+  /// The resulting instance of `SuspendingClock.Instant` is equal to the
+  /// suspending clock's epoch offset by `ts` seconds and nanoseconds.
+  ///
+  /// This initializer is not part of the public interface of the testing
+  /// library.
+  init(_ ts: timespec) {
+    let duration = Duration(ts)
+    self = unsafeBitCast(duration, to: Self.self)
   }
 }
 

--- a/Tests/TestingTests/ClockTests.swift
+++ b/Tests/TestingTests/ClockTests.swift
@@ -8,6 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+import Foundation
 @testable @_spi(ExperimentalEventHandling) import Testing
 @_implementationOnly import TestingInternals
 
@@ -118,5 +119,16 @@ struct ClockTests {
     #expect(instant1.nanosecondsSince1970 + offsetNanoseconds == instant2.nanosecondsSince1970)
 #endif
     #expect(duration == .nanoseconds(offsetNanoseconds))
+  }
+
+  @Test("Codable")
+  func codable() async throws {
+    let now = Test.Clock.Instant()
+    let instant = now.advanced(by: .nanoseconds(100))
+    let decoded = try JSONDecoder().decode(Test.Clock.Instant.self,
+                                           from: JSONEncoder().encode(instant))
+
+    #expect(instant == decoded)
+    #expect(instant != now)
   }
 }


### PR DESCRIPTION
This facilitates progress integrating the testing library with related tools by allowing `Test.Clock.Instant` (and eventually `Event`s generated by tests to be serialized.

### Motivation:

This is the first in a series of PRs to make types in the hierarchy of `Event` conform to `Codable`.

### Modifications:

I've added a custom `Codable` implementation for `Test.Clock.Instant` because due the rather complex setup of that type the compiler couldn't generate a default implementation.

I've also added a unit test verifying that what gets encoded is equal to what we gets decoded.

### Result:

`Test.Clock.Instant` now conforms to `Codable`.

Resolves: rdar://117053111