### PR TITLE
Make `SkipInfo`, `SourceLocation`, `SourceContext`, `Test.ID`, and `Comment` conform to `Codable`

### DIFF
--- a/Sources/Testing/Running/SkipInfo.swift
+++ b/Sources/Testing/Running/SkipInfo.swift
@@ -47,3 +47,7 @@ public struct SkipInfo: Sendable {
 // This conforms to `Error` because throwing an instance of this type is how a
 // custom trait can signal that the test it is attached to should be skipped.
 extension SkipInfo: Error {}
+
+// MARK: - Codable
+
+extension SkipInfo: Codable {}

--- a/Sources/Testing/SourceAttribution/SourceContext.swift
+++ b/Sources/Testing/SourceAttribution/SourceContext.swift
@@ -36,3 +36,7 @@ public struct SourceContext: Sendable {
 }
 
 extension SourceContext: Equatable, Hashable {}
+
+// MARK: - Codable
+
+extension SourceContext: Codable {}

--- a/Sources/Testing/SourceAttribution/SourceLocation.swift
+++ b/Sources/Testing/SourceAttribution/SourceLocation.swift
@@ -140,3 +140,7 @@ extension SourceLocation: CustomStringConvertible, CustomDebugStringConvertible 
     return "\(fileID):\(line):\(column)"
   }
 }
+
+// MARK: - Codable
+
+extension SourceLocation: Codable {}

--- a/Sources/Testing/Test.ID.swift
+++ b/Sources/Testing/Test.ID.swift
@@ -123,3 +123,7 @@ extension Test.ID: CustomStringConvertible {
     keyPathRepresentation.joined(separator: "/")
   }
 }
+
+// MARK: - Codable
+
+extension Test.ID: Codable {}

--- a/Sources/Testing/Traits/Comment.swift
+++ b/Sources/Testing/Traits/Comment.swift
@@ -91,6 +91,10 @@ extension Comment: ExpressibleByStringLiteral, ExpressibleByStringInterpolation,
 
 extension Comment: Equatable, Hashable {}
 
+// MARK: - Codable
+
+extension Comment: Codable {}
+
 // MARK: - Trait, TestTrait, SuiteTrait
 
 extension Comment: TestTrait, SuiteTrait {


### PR DESCRIPTION
This facilitates progress integrating the testing library with related tools by allowing `SkipInfo`, `SourceLocation`, `SourceContext`, `Test.ID`, and `Comment` (and eventually `Event`s generated by tests to be serialized.

### Motivation:

This is the second in a series of PRs (see #67 for the first one) to make types in the hierarchy of `Event` conform to `Codable`.

### Modifications:

I've used the compiler-generated conformances of `Codable` for these types.

### Result:

`SkipInfo`, `SourceLocation`, `SourceContext`, `Test.ID`, and `Comment` now conform to `Codable`.

Resolves: rdar://117053915