### PR TITLE
Make `Comment.Kind` conform to `Codable`

### DIFF
--- a/Sources/Testing/Traits/Comment.swift
+++ b/Sources/Testing/Traits/Comment.swift
@@ -95,6 +95,8 @@ extension Comment: Equatable, Hashable {}
 
 extension Comment: Codable {}
 
+extension Comment.Kind: Codable {}
+
 // MARK: - Trait, TestTrait, SuiteTrait
 
 extension Comment: TestTrait, SuiteTrait {


### PR DESCRIPTION
I forgot to explicitly mark `Comment.Kind` as `Codable` in #68.

### Motivation:
An explicit conformance makes it clearer that `Comment.Kind` conforms to `Codable`.

### Modifications:

Added an explicit conformance of `Codable` to `Comment.Kind`.

### Result:

`Comment.Kind` now explicitly conforms to `Codable`.
