### PR TITLE
Create a `Expectation.Snapshot` type that conforms to `Codable`

### DIFF
--- a/Sources/Testing/Expectations/Expectation.swift
+++ b/Sources/Testing/Expectations/Expectation.swift
@@ -69,9 +69,9 @@ extension Expectation {
   /// A serializable type describing an expectation that has been evaluated.
   @_spi(ExperimentalSnapshotting)
   public struct Snapshot: Sendable, Codable {
-    /// The source code of the expression evaluated by this expectation, if
-    /// available at compile time.
-    public var sourceCode: String?
+    /// The source code description (as a String) of the expression evaluated by
+    /// this expectation, if available at compile time.
+    public var sourceCodeDescription: String?
 
     /// A description of the error mismatch that occurred, if any.
     ///
@@ -114,7 +114,7 @@ extension Expectation {
     /// Creates a snapshot expectation from a real ``Expectation``.
     /// - Parameter expectation: The real expectation.
     init(expectation: Expectation) {
-      self.sourceCode = String(describing: expectation.sourceCode)
+      self.sourceCodeDescription = String(describing: expectation.sourceCode)
       self.mismatchedErrorDescription = expectation.mismatchedErrorDescription
       self.expandedExpressionDescription = expectation.expandedExpressionDescription
       self.differenceDescription = expectation.differenceDescription

--- a/Sources/Testing/Expectations/Expectation.swift
+++ b/Sources/Testing/Expectations/Expectation.swift
@@ -62,3 +62,65 @@ public struct ExpectationFailedError: Error {
   /// The expectation that failed.
   public var expectation: Expectation
 }
+
+// MARK: - Snapshot
+
+extension Expectation {
+  /// A serializable type describing an expectation that has been evaluated.
+  @_spi(ExperimentalSnapshotting)
+  public struct Snapshot: Sendable, Codable {
+    /// The source code of the expression evaluated by this expectation, if
+    /// available at compile time.
+    public var sourceCode: String?
+
+    /// A description of the error mismatch that occurred, if any.
+    ///
+    /// If this expectation passed, the value of this property is `nil` because no
+    /// error mismatch occurred.
+    @_spi(ExperimentalEventHandling)
+    public var mismatchedErrorDescription: String?
+
+    /// A description of the expression evaluated by this expectation, expanded
+    /// to include the values of any evaluated sub-expressions, if the source code
+    /// was available at compile time.
+    ///
+    /// If this expectation passed, the value of this property is `nil` because
+    /// source code expansion is only performed when necessary to assist with
+    /// diagnosing test failures.
+    @_spi(ExperimentalEventHandling)
+    public var expandedExpressionDescription: String?
+
+    /// A description of the difference between the operands in the expression
+    /// evaluated by this expectation, if the difference could be determined.
+    ///
+    /// If this expectation passed, the value of this property is `nil` because
+    /// the difference is only computed when necessary to assist with diagnosing
+    /// test failures.
+    @_spi(ExperimentalEventHandling)
+    public var differenceDescription: String?
+
+    /// Whether the expectation passed or failed.
+    ///
+    /// An expectation is considered to pass when its condition evaluates to
+    /// `true`. If it evaluates to `false`, it fails instead.
+    public var isPassing: Bool
+
+    /// Whether or not the expectation was required to pass.
+    public var isRequired: Bool
+
+    /// The source location where this expectation was evaluated.
+    public var sourceLocation: SourceLocation
+
+    /// Creates a snapshot expectation from a real ``Expectation``.
+    /// - Parameter expectation: The real expectation.
+    init(expectation: Expectation) {
+      self.sourceCode = String(describing: expectation.sourceCode)
+      self.mismatchedErrorDescription = expectation.mismatchedErrorDescription
+      self.expandedExpressionDescription = expectation.expandedExpressionDescription
+      self.differenceDescription = expectation.differenceDescription
+      self.isPassing = expectation.isPassing
+      self.isRequired = expectation.isRequired
+      self.sourceLocation = expectation.sourceLocation
+    }
+  }
+}


### PR DESCRIPTION
This facilitates progress integrating the testing library with related tools by allowing Expectation (and eventually Events generated by tests to be serialized.

Motivation:

This is the fourth in a series of PRs (#67, #68, #69) to make types in the hierarchy of Event conform to Codable, or create Snapshot types for types that can't / shouldn't become Codable.

Modifications:

I created a Snapshot type that contains copies of all stored properties of `Expectation`.

Result:

Expectation itself does not conform to Codable but there's an equivalent `Expectation.Snapshot` type that is, and will get used in other snapshot types higher up the hierarchy of `Event`.

Resolves: rdar://117054841