### PR TITLE
Modify Getting Started to recommend the 5.10 toolchain temporarily.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,11 +59,23 @@ and install a toolchain.
 
 #### Installing a toolchain
 
+<!--
+  - Bug: A compiler bug in the Swift main branch is temporarily preventing its
+    use with the testing library. ([swift-#69096](https://github.com/apple/swift/issues/69096))
+-->
+
+<!--
 1. Download a toolchain. A recent **development snapshot** toolchain is required
    to build the testing library. Visit
    [swift.org](https://www.swift.org/download/#trunk-development-main) and
    download the most recent toolchain from the section titled
    **Snapshots — Trunk Development (main)**.
+-->
+
+1. A recent **Swift 5.10 development snapshot** toolchain is required to build
+   the testing library. Visit [swift.org](https://www.swift.org/download/#swift-510-development)
+   to download and install a toolchain from the section titled
+   **Snapshots — Swift 5.10 Development**.
 
    Be aware that development snapshot toolchains are not intended for day-to-day
    development and may contain defects that affect the programs built with them.

--- a/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
+++ b/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
@@ -30,10 +30,20 @@ To learn how to contribute to the testing library itself, see
 
 ### Downloading a development toolchain
 
-A recent **development snapshot** toolchain is required to use the testing
+A recent **Swift 5.10 development snapshot** toolchain is required to use the
+testing library. Visit [swift.org](https://www.swift.org/download/#swift-510-development)
+to download and install a toolchain from the section titled
+**Snapshots — Swift 5.10 Development**.
+
+@Comment {
+  - Bug: A compiler bug in the Swift main branch is temporarily preventing its
+    use with the testing library. ([swift-#69096](https://github.com/apple/swift/issues/69096))
+}
+
+<!--A recent **development snapshot** toolchain is required to use the testing
 library. Visit [swift.org](https://www.swift.org/download/#trunk-development-main)
 to download and install a toolchain from the section titled
-**Snapshots — Trunk Development (main)**.
+**Snapshots — Trunk Development (main)**.-->
 
 Be aware that development snapshot toolchains are not intended for day-to-day
 development and may contain defects that affect the programs built with them.
@@ -109,7 +119,8 @@ export TOOLCHAINS=swift
 
 In Xcode, open the **Xcode** menu, then the Toolchains submenu, and select the
 development toolchain from the list of toolchains presented to you&mdash;it will
-be presented with a name such as "Swift Development Toolchain 2023-01-01 (a)".
+<!--be presented with a name such as "Swift Development Toolchain 2023-01-01 (a)".-->
+be presented with a name such as "Swift 5.10 Development Snapshot 2023-01-01 (a)".
 
 ### Running tests
 


### PR DESCRIPTION
Due to a [Swift compiler bug](https://github.com/apple/swift/issues/69096) in the main branch, swift-testing cannot currently be used with it. Until that issue is resolved, we should direct developers to the 5.10 toolchain which is still a happy path.

We can revert this change once the Swift compiler issue is resolved.