### PR TITLE
Simplify how `Runner` uses task groups.

### DIFF
--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -269,9 +269,6 @@ extension Runner {
   ///
   /// - Parameters:
   ///   - runner: The runner to run.
-  ///   - configuration: The configuration to use for running. The value of this
-  ///     argument temporarily replaces the value of `runner`'s
-  ///     ``Runner/configuration`` property.
   ///
   /// This function is `static` so that it cannot accidentally reference `self`
   /// or `self.configuration` when it should use a modified copy of either.


### PR DESCRIPTION
We have logic in a few places in `Runner` that creates a task group and, depending on if parallelization is enabled, either runs a bunch of child tasks in parallel or in serial. This PR extracts the common logic out into a helper function.