### PR TITLE
Add the ability to filter tests by tag using an envvar.

### DIFF
--- a/Sources/Testing/Traits/Tag.swift
+++ b/Sources/Testing/Traits/Tag.swift
@@ -83,6 +83,14 @@ extension Tag: ExpressibleByStringLiteral, CustomStringConvertible {
 // MARK: - Equatable, Hashable, Comparable
 
 extension Tag: Equatable, Hashable, Comparable {
+  public static func ==(lhs: Self, rhs: Self) -> Bool {
+    lhs.rawValue == rhs.rawValue
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(rawValue)
+  }
+
   /// The index of this color, relative to other colors.
   ///
   /// The value of this property can be used for sorting color tags distinctly


### PR DESCRIPTION
This PR is a follow-on to #77. It adds the ability to filter tests to just the ones that contain a given tag using an environment variable. As before, `swift test --filter` is unaware of swift-testing, so we need a temporary solution until such time as `swift test` is taught about us.

To try it out:

```
SWT_SELECTED_TAGS='trait' swift test
```

Will run only those tests with the `"trait"` tag.

If both `"SWT_SELECTED_TAGS""` and `"SWT_SELECTED_TEST_IDS"` are specified, a test must have (at least one of) the given tags _and_ be selected by ID. Whether or not this is the right way to combine these environment variables is, to be polite, probably uninteresting since this is not meant to be a permanent solution.

This change also implements `==` and `hash(into:)` on `Tag` as they were previously synthesized which would cause them to consider the internal `sourceCode` property, which was not intentional.