### PR TITLE
Create a `Event.[Kind.]Snapshot` type that conforms to `Codable`

### DIFF
--- a/Sources/Testing/Events/Event.swift
+++ b/Sources/Testing/Events/Event.swift
@@ -252,3 +252,146 @@ extension Event {
     }
   }
 }
+
+// MARK: - Snapshot
+
+extension Event {
+  /// A serializable event that occurred during testing.
+  @_spi(ExperimentalSnapshotting)
+  public struct Snapshot: Sendable, Codable {
+
+    /// The kind of event.
+    public var kind: Kind.Snapshot
+
+    /// The ID of the test for which this event occurred.
+    ///
+    /// If an event occurred independently of any test, or if the running test
+    /// cannot be determined, the value of this property is `nil`.
+    public var testID: Test.ID?
+
+    /// The instant at which the event occurred.
+    public var instant: Test.Clock.Instant
+
+    /// Snapshots an ``Event``.
+    /// - Parameter event: The original ``Event`` to snapshot.
+    public init(snapshotting event: Event) {
+      kind = Event.Kind.Snapshot(snapshotting: event.kind)
+      testID = event.testID
+      instant = event.instant
+    }
+  }
+}
+
+extension Event.Kind {
+  /// A serializable enumeration describing the various kinds of event that can be observed.
+  @_spi(ExperimentalSnapshotting)
+  public enum Snapshot: Sendable, Codable {
+    /// A test run started.
+    ///
+    /// This is the first event posted after ``Runner/run()`` is called.
+    @_spi(ExperimentalTestRunning)
+    case runStarted
+
+    /// A step in the runner plan started.
+    ///
+    /// - Parameters:
+    ///   - step: The step in the runner plan which started.
+    ///
+    /// This is posted when a ``Runner`` begins processing a
+    /// ``Runner/Plan/Step``. Processing this step may result in its associated
+    /// ``Test`` being run, skipped, or another action, so this event will only
+    /// be followed by a ``testStarted`` event if the step's test is run.
+    @_spi(ExperimentalTestRunning)
+    case planStepStarted
+
+    /// A test started.
+    case testStarted
+
+    /// A test case started.
+    @_spi(ExperimentalParameterizedTesting)
+    case testCaseStarted
+
+    /// A test case ended.
+    @_spi(ExperimentalParameterizedTesting)
+    case testCaseEnded
+
+    /// An expectation was checked with `#expect()` or `#require()`.
+    ///
+    /// - Parameters:
+    ///   - expectation: The expectation which was checked.
+    ///
+    /// By default, events of this kind are not generated because they occur
+    /// frequently in a typical test run and can generate significant
+    /// backpressure on the event handler.
+    ///
+    /// Failed expectations also, unless expected to fail, generate events of
+    /// kind ``Event/Kind-swift.enum/issueRecorded(_:)``. Those events are
+    /// always posted to the current event handler.
+    ///
+    /// To enable events of this kind, set
+    /// ``Configuration/deliverExpectationCheckedEvents`` to `true` before
+    /// running tests.
+    case expectationChecked(_ expectation: Expectation.Snapshot)
+
+    /// An issue was recorded.
+    ///
+    /// - Parameters:
+    ///   - issue: The issue which was recorded.
+    case issueRecorded(_ issue: Issue.Snapshot)
+
+    /// A test ended.
+    case testEnded
+
+    /// A test was skipped.
+    ///
+    /// - Parameters:
+    ///   - skipInfo: A ``SkipInfo`` containing details about this skipped test.
+    case testSkipped(_ skipInfo: SkipInfo)
+
+    /// A step in the runner plan ended.
+    ///
+    /// - Parameters:
+    ///   - step: The step in the runner plan which ended.
+    ///
+    /// This is posted when a ``Runner`` finishes processing a
+    /// ``Runner/Plan/Step``.
+    @_spi(ExperimentalTestRunning)
+    case planStepEnded
+
+    /// A test run ended.
+    ///
+    /// This is the last event posted before ``Runner/run()`` returns.
+    @_spi(ExperimentalTestRunning)
+    case runEnded
+
+    /// Snapshots an ``Event.Kind``.
+    /// - Parameter kind: The original ``Event.Kind`` to snapshot.
+    public init(snapshotting kind: Event.Kind) {
+      switch kind {
+      case .runStarted:
+        self = .runStarted
+      case .planStepStarted:
+        self = .planStepStarted
+      case .testStarted:
+        self = .testStarted
+      case .testCaseStarted:
+        self = .testCaseStarted
+      case .testCaseEnded:
+        self = .testCaseEnded
+      case let .expectationChecked(expectation):
+        let expectationSnapshot = Expectation.Snapshot(snapshotting: expectation)
+        self = Snapshot.expectationChecked(expectationSnapshot)
+      case let .issueRecorded(issue):
+        self = .issueRecorded(Issue.Snapshot(snapshotting: issue))
+      case .testEnded:
+        self = .testEnded
+      case let .testSkipped(skipInfo):
+        self = .testSkipped(skipInfo)
+      case .planStepEnded:
+        self = .planStepEnded
+      case .runEnded:
+        self = .runEnded
+      }
+    }
+  }
+}

--- a/Sources/Testing/Expectations/Expectation.swift
+++ b/Sources/Testing/Expectations/Expectation.swift
@@ -113,7 +113,7 @@ extension Expectation {
 
     /// Creates a snapshot expectation from a real ``Expectation``.
     /// - Parameter expectation: The real expectation.
-    init(snapshotting expectation: Expectation) {
+    public init(snapshotting expectation: Expectation) {
       self.sourceCodeDescription = String(describing: expectation.sourceCode)
       self.mismatchedErrorDescription = expectation.mismatchedErrorDescription
       self.expandedExpressionDescription = expectation.expandedExpressionDescription

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -204,7 +204,7 @@ extension Issue {
     /// Initialize an issue instance with the specified details.
     ///
     /// - Parameter issue: The original issue that gets snapshotted.
-    init(snapshotting issue: Issue) {
+    public init(snapshotting issue: Issue) {
       self.kind = Issue.Kind.Snapshot(snapshotting: issue.kind)
       self.comments = issue.comments
       self.sourceContext = issue.sourceContext
@@ -275,7 +275,7 @@ extension Issue.Kind {
 
     /// Snapshots an ``Issue.Kind``.
     /// - Parameter kind: The original ``Issue.Kind`` to snapshot.
-    init(snapshotting kind: Issue.Kind) {
+    public init(snapshotting kind: Issue.Kind) {
       self = switch kind {
       case .unconditional:
           .unconditional

--- a/Tests/TestingTests/EventTests.swift
+++ b/Tests/TestingTests/EventTests.swift
@@ -1,0 +1,66 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+import Foundation
+@testable @_spi(ExperimentalEventHandling) @_spi(ExperimentalParameterizedTesting) @_spi(ExperimentalSnapshotting) @_spi(ExperimentalTestRunning) import Testing
+@_implementationOnly import TestingInternals
+
+struct EventTests {
+  @Test("Event's and Event.Kinds's Codable Conformances",
+        arguments: [
+          Event.Kind.expectationChecked(
+            Expectation(
+              sourceCode: SourceCode(kind: .syntaxNode("SyntaxNode")),
+              mismatchedErrorDescription: "Mismatched Error Description",
+              expandedExpressionDescription: "Expanded Expression Description",
+              differenceDescription: "Difference Description",
+              isPassing: false,
+              isRequired: true,
+              sourceLocation: SourceLocation()
+            )
+          ),
+          Event.Kind.testSkipped(
+            SkipInfo(
+              comment: "Comment",
+              sourceContext: SourceContext(
+                backtrace: Backtrace.current(),
+                sourceLocation: SourceLocation()
+              )
+            )
+          ),
+          Event.Kind.issueRecorded(
+            Issue(
+              kind: .system,
+              comments: ["Comment"],
+              sourceContext: SourceContext(
+                backtrace: nil,
+                sourceLocation: nil)
+            )
+          ),
+          Event.Kind.runStarted,
+          Event.Kind.runEnded,
+          Event.Kind.testCaseStarted,
+          Event.Kind.testCaseEnded,
+          Event.Kind.testStarted,
+          Event.Kind.testEnded,
+        ]
+  )
+  func codable(kind: Event.Kind) async throws {
+    let testID = Test.ID(moduleName: "ModuleName",
+                         nameComponents: ["NameComponent1", "NameComponent2"],
+                         sourceLocation: SourceLocation())
+    let event = Event(kind, testID: testID, instant: .now)
+    let eventSnapshot = Event.Snapshot(snapshotting: event)
+    let encoded = try JSONEncoder().encode(eventSnapshot)
+    let decoded = try JSONDecoder().decode(Event.Snapshot.self, from: encoded)
+
+    #expect(String(describing: decoded) == String(describing: eventSnapshot))
+  }
+}


### PR DESCRIPTION
This facilitates progress integrating the testing library with related tools by allowing Events generated by tests to be serialized.

Motivation:

This is the sixth and last in a series of PRs (#67, #68, #69, #73, #79) to make types in the hierarchy of `Event` conform to `Codable`, or create Snapshot types for types that can't / shouldn't become `Codable`.

Modifications:

I created two snapshot types that contain copies of all stored properties of Issue and `Event.Kind`. I've also added a test that encodes and decodes various Event / EventSnapshots.

Result:

`Event` and `Event.Kind` themselves do not conform to `Codable` but there are equivalent `Event.Snapshot` and `Event.Kind.Snapshot` types that are.

Resolves: rdar://117054776