### PR TITLE
Allow converting from TimeValue to timespec

### DIFF
--- a/Sources/Testing/Events/Clock.swift
+++ b/Sources/Testing/Events/Clock.swift
@@ -113,7 +113,8 @@ extension Test.Clock {
   @available(_clockAPI, *)
   static func sleep(for duration: Duration) async throws {
 #if SWT_NO_UNSTRUCTURED_TASKS
-    var ts = timespec(duration)
+    let timeValue = TimeValue(duration)
+    var ts = timespec(timeValue)
     var tsRemaining = ts
     while 0 != nanosleep(&ts, &tsRemaining) {
       try Task.checkCancellation()
@@ -140,7 +141,7 @@ extension Test.Clock: _Concurrency.Clock {
 #if SWT_TARGET_OS_APPLE
     var res = timespec()
     _ = clock_getres(CLOCK_UPTIME_RAW, &res)
-    return Duration(res)
+    return Duration(TimeValue(res))
 #else
     SuspendingClock().minimumResolution
 #endif

--- a/Sources/Testing/Events/TimeValue.swift
+++ b/Sources/Testing/Events/TimeValue.swift
@@ -84,3 +84,9 @@ extension SuspendingClock.Instant {
     self = unsafeBitCast(Duration(timeValue), to: SuspendingClock.Instant.self)
   }
 }
+
+extension timespec {
+  init(_ timeValue: TimeValue) {
+    self.init(tv_sec: .init(timeValue.seconds), tv_nsec: .init(timeValue.attoseconds / 1_000_000_000))
+  }
+}


### PR DESCRIPTION
This extends the `TimeValue` type added in #83 by allowing conversion to `timespec`. It then adopts that in a couple places to ensure consistency.
