### PR TITLE
Add the ability for a trait to run code before and after a test

### DIFF
--- a/Sources/Testing/Traits/Trait.swift
+++ b/Sources/Testing/Traits/Trait.swift
@@ -98,3 +98,38 @@ extension SuiteTrait {
     false
   }
 }
+
+/// A protocol extending ``Trait`` that offers an additional customization point
+/// for trait authors to execute code before and after each test function (if
+/// added to the traits of a test function), or before and after each test suite
+/// (if added to the traits of a test suite).
+@_spi(ExperimentalTraits)
+public protocol CustomExecutionTrait: Trait {
+
+  /// Execute a function with the effects of this trait applied.
+  ///
+  /// - Parameters:
+  ///   - function: The function to perform. If `test` represents a test suite,
+  ///     this function encapsulates running all the tests in that suite. If
+  ///     `test` represents a test function, this function is the body of that
+  ///     test function (including all cases if it is parameterized.)
+  ///   - test: The test under which `function` is being performed.
+  ///   - testCase: The test case, if any, under which `function` is being
+  ///     performed. This is `nil` when invoked on a suite.
+  ///
+  /// - Throws: Whatever is thrown by `function`, or an error preventing the
+  ///   trait from running correctly.
+  ///
+  /// This function is called for each ``CustomExecutionTrait`` on a test suite
+  /// or test function and allows additional work to be performed before and
+  /// after the test runs.
+  ///
+  /// This function is invoked once for the test it is applied to, and then once
+  /// for each test case in that test, if applicable.
+  ///
+  /// Issues recorded by this function are recorded against `test`.
+  ///
+  /// - Note: If a test function or test suite is skipped, this function does
+  ///   not get invoked by the runner.
+  @Sendable func execute(_ function: @escaping @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws
+}

--- a/Tests/TestingTests/Traits/CustomExecutionTraitTests.swift
+++ b/Tests/TestingTests/Traits/CustomExecutionTraitTests.swift
@@ -1,0 +1,78 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) @_spi(ExperimentalTraits) import Testing
+
+private struct CustomTrait: CustomExecutionTrait, TestTrait {
+    var before: Confirmation
+    var after: Confirmation
+    func execute(_ function: @escaping @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws {
+        before()
+        defer {
+            after()
+        }
+        try await function()
+    }
+}
+
+private struct CustomThrowingErrorTrait: CustomExecutionTrait, TestTrait {
+    fileprivate struct CustomTraitError: Error {}
+
+    func execute(_ function: @escaping @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws {
+        throw CustomTraitError()
+    }
+}
+
+struct CustomTraitTest {
+    @Test("Execute code before and after a non-parameterized test.")
+    func executeCodeBeforeAndAfterNonParameterizedTest() async {
+        // `expectedCount` is 2 because we run it both for the test and the test case
+        await confirmation("Code was run before the test", expectedCount: 2) { before in
+            await confirmation("Code was run after the test", expectedCount: 2) { after in
+                await Test(CustomTrait(before: before, after: after)) {
+                    // do nothing
+                }.run()
+            }
+        }
+    }
+
+    @Test("Execute code before and after a parameterized test.")
+    func executeCodeBeforeAndAfterParameterizedTest() async {
+        // `expectedCount` is 3 because we run it both for the test and each test case
+        await confirmation("Code was run before the test", expectedCount: 3) { before in
+            await confirmation("Code was run after the test", expectedCount: 3) { after in
+                await Test(CustomTrait(before: before, after: after), arguments: ["Hello", "World"]) { _ in
+                    // do nothing
+                }.run()
+            }
+        }
+    }
+
+    @Test("Custom execution trait throws an error")
+    func customExecutionTraitThrowsAnError() async throws {
+        var configuration = Configuration()
+        await confirmation("Error thrown", expectedCount: 1) { errorThrownConfirmation in
+            configuration.eventHandler = { event, _ in
+                guard case let .issueRecorded(issue) = event.kind,
+                      case let .errorCaught(error) = issue.kind else {
+                    return
+                }
+
+                #expect(error is CustomThrowingErrorTrait.CustomTraitError)
+                errorThrownConfirmation()
+            }
+
+            await Test(CustomThrowingErrorTrait()) {
+                // Make sure this does not get reached
+                Issue.record("Expected trait to fail the test. Should not have reached test body.")
+            }.run(configuration: configuration)
+        }
+    }
+}


### PR DESCRIPTION
Add the ability for a trait to run code before and after a test.

### Motivation:

As laid out in the [vision document](https://github.com/apple/swift-testing/blob/main/Documentation/Vision.md#trait-extensibility), we want traits to become extensible, and be able to invoke code *before* and *after* a test's body is invoked.

This PR provides the foundation that will not just give test authors a lot more power and flexibility in what they can achieve with traits, but will allow us (in a future PR) to re-implement e.g. the timeout behavior to be less special-cased.

### Modifications:

I added a new protocol `CustomExecutionTrait` which inherits from `Trait`, that has a single additional requirement: an `execute` function that provides a function that eventually executes the test body in its argument so that trait authors can invoke it in whatever way they need, ie. have the ability to execute code before and after they invoke that function.

An example of such a trait is

```swift
struct DoSomethingBeforeAndAfterTrait: CustomExecutionTrait & TestTrait {

  func execute(_ function: () async throws -> Void, for test: Test) async throws {
    something()
    try await function()
    somethingElse()
  }
}
```

(or see `CustomTraitTest`).

### Result:

Test authors now have a much more flexible system to write traits, allowing them to execute custom code before and after a test body is run.