### PR TITLE
Adopt SE-0409 (Access Level-on-Imports)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -123,6 +123,8 @@ extension Array where Element == PackageDescription.SwiftSetting {
       ]),
       .enableExperimentalFeature("StrictConcurrency"),
       .enableUpcomingFeature("ExistentialAny"),
+      .enableExperimentalFeature("AccessLevelOnImport"),
+      .enableUpcomingFeature("InternalImportsByDefault"),
       .define("SWT_TARGET_OS_APPLE", .when(platforms: [.macOS, .iOS, .macCatalyst, .watchOS, .tvOS, .visionOS])),
     ]
   }

--- a/Sources/Testing/Events/Clock.swift
+++ b/Sources/Testing/Events/Clock.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@_implementationOnly import TestingInternals
+private import TestingInternals
 
 @_spi(ExperimentalEventHandling)
 extension Test {

--- a/Sources/Testing/Events/TimeValue.swift
+++ b/Sources/Testing/Events/TimeValue.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@_implementationOnly import TestingInternals
+internal import TestingInternals
 
 /// A container type representing a time value that is suitable for storage,
 /// conversion, encoding, and decoding.

--- a/Sources/Testing/Events/TimeValue.swift
+++ b/Sources/Testing/Events/TimeValue.swift
@@ -8,6 +8,8 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+// `internal` because `TimeValue.init(_ timespec:)` below is internal and
+// references a type (`timespec`) which comes from this import.
 internal import TestingInternals
 
 /// A container type representing a time value that is suitable for storage,

--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@_implementationOnly import TestingInternals
+private import TestingInternals
 
 /// The entry point to the testing library used by Swift Package Manager.
 ///

--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -9,8 +9,8 @@
 //
 
 #if !SWT_NO_XCTEST_SCAFFOLDING
-@_implementationOnly import TestingInternals
-import XCTest
+private import TestingInternals
+public import XCTest
 
 #if SWT_TARGET_OS_APPLE
 extension XCTSourceCodeContext {

--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@_implementationOnly import TestingInternals
+private import TestingInternals
 
 /// A type representing a backtrace or stack trace.
 public struct Backtrace: Sendable {

--- a/Sources/Testing/Support/Environment.swift
+++ b/Sources/Testing/Support/Environment.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@_implementationOnly import TestingInternals
+private import TestingInternals
 
 /// A type describing the environment of the current process.
 ///

--- a/Sources/Testing/Support/Locked.swift
+++ b/Sources/Testing/Support/Locked.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@_implementationOnly import TestingInternals
+private import TestingInternals
 
 /// A property wrapper that wraps a value requiring access from a synchronous
 /// caller during concurrent execution.

--- a/Sources/Testing/Support/Versions.swift
+++ b/Sources/Testing/Support/Versions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@_implementationOnly import TestingInternals
+private import TestingInternals
 
 /// A human-readable string describing the current operating system's version.
 ///

--- a/Sources/Testing/Test+Macro.swift
+++ b/Sources/Testing/Test+Macro.swift
@@ -8,10 +8,10 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@_implementationOnly import TestingInternals
+private import TestingInternals
 
 #if _runtime(_ObjC)
-import ObjectiveC
+public import ObjectiveC
 
 /// An XCTest-compatible Objective-C selector.
 ///
@@ -45,7 +45,7 @@ public typealias __XCTestCompatibleSelector = Never
 }
 
 #if !SWT_NO_XCTEST_SCAFFOLDING
-import XCTest
+public import XCTest
 #endif
 
 /// This file provides support for the `@Test` macro. Other than the macro

--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -9,7 +9,7 @@
 //
 
 #if _runtime(_ObjC)
-import ObjectiveC
+public import ObjectiveC
 #endif
 
 /// A type representing a test or suite.

--- a/Tests/TestingTests/ClockTests.swift
+++ b/Tests/TestingTests/ClockTests.swift
@@ -10,7 +10,7 @@
 
 import Foundation
 @testable @_spi(ExperimentalEventHandling) import Testing
-@_implementationOnly import TestingInternals
+import TestingInternals
 
 @Suite("Clock API Tests")
 struct ClockTests {

--- a/Tests/TestingTests/DumpTests.swift
+++ b/Tests/TestingTests/DumpTests.swift
@@ -9,7 +9,7 @@
 //
 
 @testable @_spi(InternalDiagnostics) @_spi(ExperimentalTestRunning) import Testing
-@_implementationOnly import TestingInternals
+import TestingInternals
 
 // NOTE: The tests in this file are here to exercise Plan.dump(), but they are
 // not intended to actually test that the output is in a particular format since

--- a/Tests/TestingTests/EventTests.swift
+++ b/Tests/TestingTests/EventTests.swift
@@ -10,7 +10,7 @@
 
 import Foundation
 @testable @_spi(ExperimentalEventHandling) @_spi(ExperimentalParameterizedTesting) @_spi(ExperimentalSnapshotting) @_spi(ExperimentalTestRunning) import Testing
-@_implementationOnly import TestingInternals
+import TestingInternals
 
 struct EventTests {
   @Test("Event's and Event.Kinds's Codable Conformances",

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -9,7 +9,7 @@
 //
 
 @testable @_spi(ExperimentalEventHandling) @_spi(ExperimentalTestRunning) @_spi(ExperimentalSnapshotting) import Testing
-@_implementationOnly import TestingInternals
+import TestingInternals
 
 #if canImport(XCTest)
 import XCTest


### PR DESCRIPTION
This adopts [SE-0409 Access-level modifiers on import declarations](https://github.com/apple/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md) in this package.

### Motivation:

We are currently using `@_implementationOnly` to ensure imports of our internal `TestingInternals` module are not exposed to clients, but it produces warnings when building without library evolution enabled.

### Modifications:

- Enable the experimental `AccessLevelOnImport` feature. (It's technically no longer experimental since the feature was approved, but including this attempts to preserve compatibility with older toolchains.)
- Enable the upcoming `InternalImportsByDefault` feature.
- Update various `import` declarations as appropriate.
- Remove `@_implementationOnly` usages from test targets where they are unnecessary.

Resolves rdar://115311986
