### PR TITLE
Warn when using `XCTestScaffold` when SwiftPM supports swift-testing.

### DIFF
--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -167,7 +167,20 @@ public enum XCTestScaffold: Sendable {
   /// ## See Also
   ///
   /// - <doc:TemporaryGettingStarted>
+#if SWIFT_PM_SUPPORTS_SWIFT_TESTING
+  @available(*, deprecated, message: "This version of Swift Package Manager supports running swift-testing tests directly.")
+#endif
   public static func runAllTests(hostedBy testCase: XCTestCase) async {
+#if SWIFT_PM_SUPPORTS_SWIFT_TESTING
+    let message = warning("This version of Swift Package Manager supports running swift-testing tests directly.", options: .forStandardError)
+#if SWT_TARGET_OS_APPLE
+    let stderr = swt_stderr()
+    fputs(message, stderr)
+    fflush(stderr)
+#else
+    print(message)
+#endif
+#else
     let testCase = UncheckedSendable(rawValue: testCase)
 #if SWT_TARGET_OS_APPLE
     let isProcessLaunchedByXcode = Environment.variable(named: "XCTestSessionIdentifier") != nil
@@ -218,6 +231,7 @@ public enum XCTestScaffold: Sendable {
       }
 #endif
     }
+#endif
   }
 }
 #endif

--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -168,11 +168,11 @@ public enum XCTestScaffold: Sendable {
   ///
   /// - <doc:TemporaryGettingStarted>
 #if SWIFT_PM_SUPPORTS_SWIFT_TESTING
-  @available(*, deprecated, message: "This version of Swift Package Manager supports running swift-testing tests directly.")
+  @available(*, deprecated, message: "This version of Swift Package Manager supports running swift-testing tests directly. This function has no effect.")
 #endif
   public static func runAllTests(hostedBy testCase: XCTestCase) async {
 #if SWIFT_PM_SUPPORTS_SWIFT_TESTING
-    let message = warning("This version of Swift Package Manager supports running swift-testing tests directly.", options: .forStandardError)
+    let message = warning("This version of Swift Package Manager supports running swift-testing tests directly. Ignoring call to \(#function).", options: .forStandardError)
 #if SWT_TARGET_OS_APPLE
     let stderr = swt_stderr()
     fputs(message, stderr)


### PR DESCRIPTION
This PR introduces a new compile-time check for `SWIFT_PM_SUPPORTS_SWIFT_TESTING` around `XCTestScaffold.runTests(hostedBy:)`. If that compiler condition is set, then `XCTestScaffold.runTests(hostedBy:)` is deprecated and calling it emits a warning message but does not run any tests.

Right now, nothing sets that condition, so this is dead code, but the expectation here is that SwiftPM _will_ set it in a future update, at which point developers who opt into experimental support for swift-testing won't end up running their tests multiple times.

Since `XCTestScaffold` is intended to be transient code, and since this code path is currently unreachable, I have not included new unit tests. Code has been tested at-desk with a branch of SwiftPM that sets the aforementioned condition.

Examples of new output from calling the function:

### macOS

<img width="809" alt="Screenshot 2023-10-31 at 10 33 24 AM" src="https://github.com/apple/swift-testing/assets/4145863/87c0f03c-ffbb-451d-bb14-25bc8deec619">

### Ubuntu

<img width="784" alt="Screenshot 2023-10-31 at 10 43 59 AM" src="https://github.com/apple/swift-testing/assets/4145863/c316e284-4ad8-482e-b4ef-232f841d2eaf">