### PR TITLE
Add support for `swift test` options.

### DIFF
--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -23,17 +23,22 @@ private import TestingInternals
 @_spi(SwiftPackageManagerSupport)
 @_disfavoredOverload
 public func swiftPMEntryPoint() async -> CInt {
-  let args = CommandLine.arguments()
-  _ = args
-
   @Locked var exitCode = EXIT_SUCCESS
 
-  await runTests { event, _ in
-    if case let .issueRecorded(issue) = event.kind, !issue.isKnown {
-      $exitCode.withLock { exitCode in
-        exitCode = EXIT_FAILURE
+  let args = CommandLine.arguments()
+  if args.count == 2 && args[1] == "--list-tests" {
+    await _listTestsForSwiftPM(Test.all)
+  } else {
+    var configuration = _configurationForSwiftPMEntryPoint(withArguments: args)
+    configuration.eventHandler = { event, _ in
+      if case let .issueRecorded(issue) = event.kind, !issue.isKnown {
+        $exitCode.withLock { exitCode in
+          exitCode = EXIT_FAILURE
+        }
       }
     }
+
+    await runTests(configuration: configuration)
   }
 
   return exitCode
@@ -55,39 +60,127 @@ public func swiftPMEntryPoint() async -> Never {
   exit(exitCode)
 }
 
+// MARK: -
+
+/// List all of the given tests in the "specifier" format used by Swift Package
+/// Manager.
+///
+/// - Parameters:
+///   - tests: The tests to list.
+private func _listTestsForSwiftPM(_ tests: some Sequence<Test>) {
+  // Filter out hidden tests and test suites. Hidden tests should not generally
+  // be presented to the user, and suites (XCTestCase classes) are not included
+  // in the equivalent XCTest-based output.
+  let tests = tests.lazy
+    .filter { !$0.isSuite }
+    .filter { !$0.isHidden }
+
+  // Group tests by the name components of the tests' IDs. If the name
+  // components of two tests' IDs are ambiguous, present their source locations
+  // to disambiguate.
+  let allTestIDs = Dictionary(
+    grouping: tests.lazy.map(\.id),
+    by: \.nameComponents
+  ).values.lazy
+    .map { ($0, isAmbiguous: $0.count > 1) }
+    .flatMap { testIDs, isAmbiguous in
+      testIDs.lazy
+        .map { testID in
+          if !isAmbiguous, testID.sourceLocation != nil {
+            return testID.parent ?? testID
+          }
+          return testID
+        }
+    }.map(String.init(describing:))
+    .sorted(by: <)
+
+  // Print all the test IDs to the console in neutral sorted order.
+  for testID in allTestIDs {
+    print(testID)
+  }
+}
+
+/// Get an instance of ``Configuration`` given a sequence of command-line
+/// arguments passed from Swift Package Manager.
+///
+/// - Parameters:
+///   - args: The command-line arguments to interpret.
+///
+/// - Returns: An instance of ``Configuration``. Note that the caller is
+///   responsible for setting this instance's ``Configuration/eventHandler``
+///   property.
+///
+/// This function generally assumes that Swift Package Manager has already
+/// validated the passed arguments.
+private func _configurationForSwiftPMEntryPoint(withArguments args: [String]) -> Configuration {
+  var configuration = Configuration()
+  configuration.isParallelizationEnabled = false
+
+  guard let separatorArgIndex = args.firstIndex(of: "--") else {
+    return configuration
+  }
+  let args = args[args.index(after: separatorArgIndex)...]
+
+  // Parallelization
+  if args.contains("--parallel") {
+    configuration.isParallelizationEnabled = true
+  }
+
+  // Filtering
+  // NOTE: Regex is not marked Sendable, but because the regexes we use are
+  // constructed solely from a string, they are safe to send across isolation
+  // boundaries.
+  var filters = [Configuration.TestFilter]()
+  if #available(_regexAPI, *) {
+    if let filterArgIndex = args.firstIndex(of: "--filter"), filterArgIndex < args.endIndex {
+      let filterArg = args[args.index(after: filterArgIndex)]
+
+      let regex = try? UncheckedSendable(rawValue: Regex(filterArg))
+      filters.append { test in
+        let id = String(describing: test.id)
+        return regex.map(\.rawValue).map(id.contains) ?? false
+      }
+    }
+    if let skipArgIndex = args.firstIndex(of: "--skip"), skipArgIndex < args.endIndex {
+      let skipArg = args[args.index(after: skipArgIndex)]
+
+      let regex = try? UncheckedSendable(rawValue: Regex(skipArg))
+      filters.append { test in
+        let id = String(describing: test.id)
+        return regex.map(\.rawValue).map { !id.contains($0) } ?? true
+      }
+    }
+  }
+  filters.append { test in
+    // Don't run the fixture tests in the testing library's own test targets.
+    !test.isHidden
+  }
+  configuration.testFilter = { [filters] test in
+    filters.allSatisfy { filter in
+      filter(test)
+    }
+  }
+
+  return configuration
+}
+
 /// The common implementation of ``swiftPMEntryPoint()`` and
 /// ``XCTestScaffold/runAllTests(hostedBy:)``.
 ///
 /// - Parameters:
-///   - testIDs: The test IDs to run. If `nil`, all tests are run.
-///   - tags: The tags to filter by (only tests with one or more of these tags
-///     will be run.)
-///   - eventHandler: An event handler to invoke after events are written to
-///     the standard error stream.
-func runTests(identifiedBy testIDs: [Test.ID]? = nil, taggedWith tags: Set<Tag>? = nil, eventHandler: @escaping Event.Handler = { _, _ in }) async {
+///   - configuration: The configuration to use for running.
+func runTests(configuration: Configuration) async {
   let eventRecorder = Event.Recorder(options: .forStandardError) { string in
     let stderr = swt_stderr()
     fputs(string, stderr)
     fflush(stderr)
   }
 
-  var configuration = Configuration()
-  configuration.isParallelizationEnabled = false
+  var configuration = configuration
+  let oldEventHandler = configuration.eventHandler
   configuration.eventHandler = { event, context in
     eventRecorder.record(event, in: context)
-    eventHandler(event, context)
-  }
-  
-  if let testIDs {
-    configuration.setTestFilter(toMatch: Set(testIDs))
-  }
-  if let tags {
-    // Check if the test's tags intersect the set of selected tags. If there
-    // was a previous filter function, it must also pass.
-    let oldTestFilter = configuration.testFilter ?? { _ in true }
-    configuration.testFilter = { test in
-      !tags.isDisjoint(with: test.tags) && oldTestFilter(test)
-    }
+    oldEventHandler(event, context)
   }
 
   let runner = await Runner(configuration: configuration)

--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -127,10 +127,8 @@ func configurationForSwiftPMEntryPoint(withArguments args: [String]) throws -> C
   var configuration = Configuration()
   configuration.isParallelizationEnabled = false
 
-  guard let separatorArgIndex = args.firstIndex(of: "--") else {
-    return configuration
-  }
-  let args = args[args.index(after: separatorArgIndex)...]
+  // Do not consider the executable path AKA argv[0].
+  let args = args.dropFirst()
 
   // Parallelization
   if args.contains("--parallel") {

--- a/Sources/Testing/Test.ID.swift
+++ b/Sources/Testing/Test.ID.swift
@@ -120,7 +120,15 @@ extension Test: Identifiable {
 
 extension Test.ID: CustomStringConvertible {
   public var description: String {
-    keyPathRepresentation.joined(separator: "/")
+    // Match the "specifier" format used by `swift test` with XCTest. The module
+    // name is separated from the rest of the ID by a period, and the name
+    // components are separated by slashes. The source location of the test
+    // is, when present, treated as an additional name component.
+    var result = "\(moduleName).\(nameComponents.joined(separator: "/"))"
+    if let sourceLocation {
+      result += "/\(sourceLocation)"
+    }
+    return result
   }
 }
 

--- a/Tests/TestingMacrosTests/TestSupport/Scaffolding.swift
+++ b/Tests/TestingMacrosTests/TestSupport/Scaffolding.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if !SWT_NO_XCTEST_SCAFFOLDING
+#if !SWT_NO_XCTEST_SCAFFOLDING && !SWIFT_PM_SUPPORTS_SWIFT_TESTING
 import XCTest
 import Testing
 

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -467,7 +467,7 @@ struct MiscellaneousTests {
   @Test("Test.id property")
   func id() async throws {
     let typeTest = Test.__type(SendableTests.self, displayName: "SendableTests", traits: [], sourceLocation: .init())
-    #expect(String(describing: typeTest.id) == "TestingTests/SendableTests")
+    #expect(String(describing: typeTest.id) == "TestingTests.SendableTests")
 
     let fileID = "Module/Y.swift"
     let filePath = "/Y.swift"
@@ -475,7 +475,7 @@ struct MiscellaneousTests {
     let column = 67890
     let sourceLocation = SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column)
     let testFunction = Test.__function(named: "myTestFunction()", in: nil, xcTestCompatibleSelector: nil, displayName: nil, traits: [], sourceLocation: sourceLocation) {}
-    #expect(String(describing: testFunction.id) == "Module/myTestFunction()/Y.swift:12345:67890")
+    #expect(String(describing: testFunction.id) == "Module.myTestFunction()/Y.swift:12345:67890")
   }
 
   @Test("Test.ID.parent property")

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -1,0 +1,96 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable @_spi(ExperimentalTestRunning) import Testing
+
+@Suite("Swift Package Manager Integration Tests")
+struct SwiftPMTests {
+  @Test("--parallel argument")
+  func parallel() throws {
+    var configuration = try configurationForSwiftPMEntryPoint(withArguments: ["--"])
+    #expect(!configuration.isParallelizationEnabled)
+    
+    configuration = try configurationForSwiftPMEntryPoint(withArguments: ["--", "--parallel"])
+    #expect(configuration.isParallelizationEnabled)
+  }
+
+  @Test("No --filter or --skip argument")
+  func defaultFiltering() throws {
+    let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["--"])
+    let testFilter = try #require(configuration.testFilter)
+    let test1 = Test(name: "hello") {}
+    #expect(testFilter(test1))
+    let test2 = Test(name: "goodbye") {}
+    #expect(testFilter(test2))
+  }
+
+  @Test("--filter argument")
+  func filter() throws {
+    let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["--", "--filter", "hello"])
+    let testFilter = try #require(configuration.testFilter)
+    let test1 = Test(name: "hello") {}
+    #expect(testFilter(test1))
+    let test2 = Test(name: "goodbye") {}
+    #expect(!testFilter(test2))
+  }
+
+  @Test("--filter or --skip argument with bad regex")
+  func badArguments() throws {
+    #expect(throws: (any Error).self) {
+      _ = try configurationForSwiftPMEntryPoint(withArguments: ["--", "--filter", "("])
+    }
+    #expect(throws: (any Error).self) {
+      _ = try configurationForSwiftPMEntryPoint(withArguments: ["--", "--skip", ")"])
+    }
+  }
+
+  @Test("--skip argument")
+  func skip() throws {
+    let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["--", "--skip", "hello"])
+    let testFilter = try #require(configuration.testFilter)
+    let test1 = Test(name: "hello") {}
+    #expect(!testFilter(test1))
+    let test2 = Test(name: "goodbye") {}
+    #expect(testFilter(test2))
+  }
+
+  @Test(".hidden trait")
+  func hidden() throws {
+    let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["--"])
+    let testFilter = try #require(configuration.testFilter)
+    let test1 = Test(name: "hello") {}
+    #expect(testFilter(test1))
+    let test2 = Test(.hidden, name: "goodbye") {}
+    #expect(!testFilter(test2))
+  }
+
+  @Test("--filter/--skip arguments and .hidden trait")
+  func filterAndSkipAndHidden() throws {
+    let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["--", "--filter", "hello", "--skip", "hello2"])
+    let testFilter = try #require(configuration.testFilter)
+    let test1 = Test(name: "hello") {}
+    #expect(testFilter(test1))
+    let test2 = Test(.hidden, name: "hello") {}
+    #expect(!testFilter(test2))
+    let test3 = Test(.hidden, name: "hello2") {}
+    #expect(!testFilter(test3))
+  }
+
+  @Test("list subcommand")
+  func list() async throws {
+    let testIDs = await listTestsForSwiftPM(Test.all)
+    let currentTestID = try #require(
+      Test.current
+        .flatMap(\.id.parent)
+        .map(String.init(describing:))
+    )
+    #expect(testIDs.contains(currentTestID))
+  }
+}

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -14,16 +14,16 @@
 struct SwiftPMTests {
   @Test("--parallel argument")
   func parallel() throws {
-    var configuration = try configurationForSwiftPMEntryPoint(withArguments: ["--"])
+    var configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH"])
     #expect(!configuration.isParallelizationEnabled)
     
-    configuration = try configurationForSwiftPMEntryPoint(withArguments: ["--", "--parallel"])
+    configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--parallel"])
     #expect(configuration.isParallelizationEnabled)
   }
 
   @Test("No --filter or --skip argument")
   func defaultFiltering() throws {
-    let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["--"])
+    let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH"])
     let testFilter = try #require(configuration.testFilter)
     let test1 = Test(name: "hello") {}
     #expect(testFilter(test1))
@@ -33,7 +33,7 @@ struct SwiftPMTests {
 
   @Test("--filter argument")
   func filter() throws {
-    let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["--", "--filter", "hello"])
+    let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--filter", "hello"])
     let testFilter = try #require(configuration.testFilter)
     let test1 = Test(name: "hello") {}
     #expect(testFilter(test1))
@@ -44,16 +44,16 @@ struct SwiftPMTests {
   @Test("--filter or --skip argument with bad regex")
   func badArguments() throws {
     #expect(throws: (any Error).self) {
-      _ = try configurationForSwiftPMEntryPoint(withArguments: ["--", "--filter", "("])
+      _ = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--filter", "("])
     }
     #expect(throws: (any Error).self) {
-      _ = try configurationForSwiftPMEntryPoint(withArguments: ["--", "--skip", ")"])
+      _ = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--skip", ")"])
     }
   }
 
   @Test("--skip argument")
   func skip() throws {
-    let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["--", "--skip", "hello"])
+    let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--skip", "hello"])
     let testFilter = try #require(configuration.testFilter)
     let test1 = Test(name: "hello") {}
     #expect(!testFilter(test1))
@@ -63,7 +63,7 @@ struct SwiftPMTests {
 
   @Test(".hidden trait")
   func hidden() throws {
-    let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["--"])
+    let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH"])
     let testFilter = try #require(configuration.testFilter)
     let test1 = Test(name: "hello") {}
     #expect(testFilter(test1))
@@ -73,7 +73,7 @@ struct SwiftPMTests {
 
   @Test("--filter/--skip arguments and .hidden trait")
   func filterAndSkipAndHidden() throws {
-    let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["--", "--filter", "hello", "--skip", "hello2"])
+    let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--filter", "hello", "--skip", "hello2"])
     let testFilter = try #require(configuration.testFilter)
     let test1 = Test(name: "hello") {}
     #expect(testFilter(test1))

--- a/Tests/TestingTests/TestSupport/Scaffolding.swift
+++ b/Tests/TestingTests/TestSupport/Scaffolding.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if !SWT_NO_XCTEST_SCAFFOLDING
+#if !SWT_NO_XCTEST_SCAFFOLDING && !SWIFT_PM_SUPPORTS_SWIFT_TESTING
 import XCTest
 import Testing
 


### PR DESCRIPTION
This PR adds support for the `swift test` arguments `--parallel`, `--filter`, and `--skip`, as well as the `swift test list` subcommand.

Resolves rdar://114997559.
Resolves https://github.com/apple/swift-package-manager/issues/7027.