### PR TITLE
Limit usage of SE-0409 (Access Level-on-Import) to only the Testing module

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,10 @@ let package = Package(
         "TestingInternals",
         "TestingMacros",
       ],
-      swiftSettings: .packageSettings,
+      swiftSettings: .packageSettings + [
+        .enableExperimentalFeature("AccessLevelOnImport"),
+        .enableUpcomingFeature("InternalImportsByDefault"),
+      ],
       plugins: ["GitStatusPlugin"]
     ),
     .testTarget(
@@ -123,8 +126,6 @@ extension Array where Element == PackageDescription.SwiftSetting {
       ]),
       .enableExperimentalFeature("StrictConcurrency"),
       .enableUpcomingFeature("ExistentialAny"),
-      .enableExperimentalFeature("AccessLevelOnImport"),
-      .enableUpcomingFeature("InternalImportsByDefault"),
       .define("SWT_TARGET_OS_APPLE", .when(platforms: [.macOS, .iOS, .macCatalyst, .watchOS, .tvOS, .visionOS])),
     ]
   }


### PR DESCRIPTION
This is a follow-up fix to the changes recently landed in #87 to only adopt the SE-0409 feature in the `Testing` module/target, rather than in all targets.

The motivation is to fix [a build failure](https://ci.swift.org/job/swift-package-manager-self-hosted-Linux-smoke-test/2994/consoleFull) in the `TestingMacros` target when using recent `main` branch toolchains, which appear to have stronger enforcement that access level of imports within the parameters of `public` declarations. But I think this is a reasonable fix even if not for that build failure, since our primary motivation for adopting SE-0409 is to carefully curate the modules which are publicly imported by the `Testing` module. We don't need to worry as much about the other targets in this package since their modules are not used by clients.