### PR TITLE
Add documentation for `.timeLimit(_:)` and reorganize trait documentation.

### DIFF
--- a/Sources/Testing/Testing.docc/AddingComments.md
+++ b/Sources/Testing/Testing.docc/AddingComments.md
@@ -92,3 +92,9 @@ As in normal code, comments on tests are generally most useful when:
 
 If a test is related to a bug or issue, consider using the ``Bug`` trait instead
 of comments. For more information, review <doc:AssociatingBugs>.
+
+
+## Topics
+
+- ``Trait/comment(_:)``
+- ``Comment``

--- a/Sources/Testing/Testing.docc/AddingTags.md
+++ b/Sources/Testing/Testing.docc/AddingTags.md
@@ -1,0 +1,54 @@
+# Adding tags to tests
+
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2023 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+Add tags to tests and customize their appearance.
+
+## Overview
+
+A complex package or project may contain hundreds or thousands of tests and
+suites. Some subset of those tests may share some common facet, such as being
+"critical" or "flaky". The testing library includes a type of trait called
+"tags" that can be added to tests to group and categorize them.
+
+Tags are different from test suites: test suites impose structure on test
+functions at the source level, while tags provide semantic information for a
+test that can be shared with any number of other tests across test suites,
+source files, and even test targets.
+
+## Adding tags
+
+To add a tag to a test, use the ``Trait/tags(_:)-yg0i`` or
+``Trait/tags(_:)-272p`` trait. These traits take sequences of tags as arguments,
+and those tags are then applied to the corresponding test at runtime. If they
+are applied to a test suite, then all tests in that suite inherit those tags.
+
+Tags themselves are instances of ``Tag`` and can be expressed as string literals
+or as named constants declared elsewhere in a test target:
+
+```swift
+extension Tag {
+  static let legallyRequired = Tag(...)
+}
+
+@Test("Vendor's license is valid", .tags("critical", .legallyRequired))
+func licenseValid() { ... }
+```
+
+The testing library does not assign any semantic meaning to any tags, nor does
+the presence or absence of tags affect how the testing library runs tests.
+
+## Topics
+
+- ``Trait/tags(_:)-yg0i``
+- ``Trait/tags(_:)-272p``
+- ``Tag``
+- ``Tag/List``

--- a/Sources/Testing/Testing.docc/AddingTags.md
+++ b/Sources/Testing/Testing.docc/AddingTags.md
@@ -32,7 +32,7 @@ and those tags are then applied to the corresponding test at runtime. If they
 are applied to a test suite, then all tests in that suite inherit those tags.
 
 Tags themselves are instances of ``Tag`` and can be expressed as string literals
-or as named constants declared elsewhere in a test target:
+or as named constants declared elsewhere:
 
 ```swift
 extension Tag {

--- a/Sources/Testing/Testing.docc/AssociatingBugs.md
+++ b/Sources/Testing/Testing.docc/AssociatingBugs.md
@@ -82,3 +82,10 @@ The testing library defines several kinds of common bug/test relationship:
 
 <!-- Keep `.unspecified` as the last row above in order to imply it is a
 fallback. -->
+
+## Topics
+
+- <doc:BugIdentifiers>
+- ``Trait/bug(_:relationship:)-duvt``
+- ``Trait/bug(_:relationship:)-40riy``
+- ``Bug``

--- a/Sources/Testing/Testing.docc/EnablingAndDisabling.md
+++ b/Sources/Testing/Testing.docc/EnablingAndDisabling.md
@@ -116,3 +116,12 @@ func allIngredientsAvailable(for food: Food) -> Bool { ... }
 )
 func makeSundae() async throws { ... }
 ```
+
+## Topics
+
+- ``Trait/enabled(if:_:fileID:filePath:line:column:)``
+- ``Trait/enabled(_:fileID:filePath:line:column:_:)``
+- ``Trait/disabled(_:fileID:filePath:line:column:)``
+- ``Trait/disabled(if:_:fileID:filePath:line:column:)``
+- ``Trait/disabled(_:fileID:filePath:line:column:_:)``
+- ``ConditionTrait``

--- a/Sources/Testing/Testing.docc/LimitingExecutionTime.md
+++ b/Sources/Testing/Testing.docc/LimitingExecutionTime.md
@@ -24,7 +24,8 @@ be marked as failing if it runs for an excessive amount of time. Use the
 ``Trait/timeLimit(_:)`` trait as an upper bound:
 
 ```swift
-@Test(.timeLimit(.seconds(60 * 60)) func serve100CustomersInOneHour() async {
+@Test(.timeLimit(.seconds(60 * 60))
+func serve100CustomersInOneHour() async {
   for _ in 0 ..< 100 {
     let customer = await Customer.next()
     await customer.order()
@@ -33,8 +34,9 @@ be marked as failing if it runs for an excessive amount of time. Use the
 }
 ```
 
-If the above test function takes longer than 60 × 60 seconds (i.e. one hour) to
-execute, the task in which it is running will be [cancelled](https://developer.apple.com/documentation/swift/task/cancel())
+If the above test function takes longer than 60 &times; 60 seconds (i.e. one
+hour) to execute, the task in which it is running will be
+[cancelled](https://developer.apple.com/documentation/swift/task/cancel())
 and the test will fail with an issue of kind
 ``Issue/Kind-swift.enum/timeLimitExceeded(timeLimitComponents:)``.
 
@@ -55,8 +57,8 @@ test functions and child test suites within that suite.
 ### Time limits applied to parameterized tests
 
 When a time limit is applied to a parameterized test function, it is applied to
-each invocation _separately_ so that if only some inputs cause failures, then
-successful inputs are not incorrectly marked as failing too.
+each invocation _separately_ so that if only some arguments cause failures, then
+successful arguments are not incorrectly marked as failing too.
 
 ## Topics
 

--- a/Sources/Testing/Testing.docc/LimitingExecutionTime.md
+++ b/Sources/Testing/Testing.docc/LimitingExecutionTime.md
@@ -1,0 +1,64 @@
+# Limiting the execution time of a test
+
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2023 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+Set limits on how long a test can run for until it fails.
+
+## Overview
+
+Some tests may naturally run slowly: they may require significant system
+resources to complete, may rely on downloaded data from a server, or may
+otherwise be dependent on external factors.
+
+If a test may hang indefinitely or may consume too many system resources to
+complete effectively, consider setting a time limit for it so that it will
+be marked as failing if it runs for an excessive amount of time. Use the
+``Trait/timeLimit(_:)`` trait as an upper bound:
+
+```swift
+@Test(.timeLimit(.seconds(60 * 60)) func serve100CustomersInOneHour() async {
+  for _ in 0 ..< 100 {
+    let customer = await Customer.next()
+    await customer.order()
+    ...
+  }
+}
+```
+
+If the above test function takes longer than 60 × 60 seconds (i.e. one hour) to
+execute, the task in which it is running will be [cancelled](https://developer.apple.com/documentation/swift/task/cancel())
+and the test will fail with an issue of kind
+``Issue/Kind-swift.enum/timeLimitExceeded(timeLimitComponents:)``.
+
+- Note: if multiple time limit traits apply to a test, the shortest time limit
+  is used.
+
+The testing library may adjust the specified time limit for performance reasons
+or to ensure tests have enough time to run. In particular, a granularity of (by
+default) one minute is applied to tests. The testing library can also be
+configured with a maximum time limit per test that overrides any applied time
+limit traits.
+
+### Time limits applied to test suites
+
+When a time limit is applied to a test suite, it is recursively applied to all
+test functions and child test suites within that suite.
+
+### Time limits applied to parameterized tests
+
+When a time limit is applied to a parameterized test function, it is applied to
+each invocation _separately_ so that if only some inputs cause failures, then
+successful inputs are not incorrectly marked as failing too.
+
+## Topics
+
+- ``Trait/timeLimit(_:)``
+- ``TimeLimitTrait``

--- a/Sources/Testing/Testing.docc/Traits.md
+++ b/Sources/Testing/Testing.docc/Traits.md
@@ -23,41 +23,11 @@ types that customize the behavior of test functions and test suites.
 
 ## Topics
 
-### Defining conditions for a test
-
 - <doc:EnablingAndDisabling>
-- ``Trait/enabled(if:_:fileID:filePath:line:column:)``
-- ``Trait/enabled(_:fileID:filePath:line:column:_:)``
-- ``Trait/disabled(_:fileID:filePath:line:column:)``
-- ``Trait/disabled(if:_:fileID:filePath:line:column:)``
-- ``Trait/disabled(_:fileID:filePath:line:column:_:)``
-- ``ConditionTrait``
-
-### Adding tags to a test
-
-- ``Trait/tags(_:)-yg0i``
-- ``Trait/tags(_:)-272p``
-- ``Tag``
-- ``Tag/List``
-
-### Adding a comment to a test
-
+- <doc:AddingTags>
 - <doc:AddingComments>
-- ``Trait/comment(_:)``
-- ``Comment``
-
-### Referencing an issue or bug report from a test
-
 - <doc:AssociatingBugs>
-- <doc:BugIdentifiers>
-- ``Trait/bug(_:relationship:)-duvt``
-- ``Trait/bug(_:relationship:)-40riy``
-- ``Bug``
-
-### Limiting the execution time of a test
-
-- ``TimeLimitTrait``
-- ``Trait/timeLimit(_:)``
+- <doc:LimitingExecutionTime>
 
 ### Creating a custom trait
 


### PR DESCRIPTION
This PR adds some documentation for the time limit trait and reorganizes other trait documentation under its associated articles.