### PR TITLE
Fix a crash on Linux when invoking unavailable code.

### DIFF
--- a/Sources/TestingMacros/SuiteDeclarationMacro.swift
+++ b/Sources/TestingMacros/SuiteDeclarationMacro.swift
@@ -156,8 +156,12 @@ public struct SuiteDeclarationMacro: MemberMacro, PeerMacro, Sendable {
     let enumName = context.makeUniqueName("__🟠$test_container__suite__\(typeName)")
     result.append(
       """
+      #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
       @available(*, unavailable, message: "This type is an implementation detail of the testing library. It cannot be used directly.")
       @available(*, deprecated)
+      #else
+      @available(*, deprecated, message: "This type is an implementation detail of the testing library. Do not use it directly.")
+      #endif
       @frozen public enum \(enumName): Testing.__TestContainer {
         public static var __tests: [Testing.Test] {
           get async {[

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -473,8 +473,12 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
     let enumName = context.makeUniqueName(thunking: functionDecl, withPrefix: "__🟠$test_container__function__")
     result.append(
       """
+      #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
       @available(*, unavailable, message: "This type is an implementation detail of the testing library. It cannot be used directly.")
       @available(*, deprecated)
+      #else
+      @available(*, deprecated, message: "This type is an implementation detail of the testing library. Do not use it directly.")
+      #endif
       @frozen public enum \(enumName): Testing.__TestContainer {
         public static var __tests: [Testing.Test] {
           get async {[


### PR DESCRIPTION
On at least some toolchains, we crash on Linux when touching a synthesized test container type. This is happening because the types are annotated `unavailable`, and we end up calling into the Swift runtime function `_diagnoseUnavailableCodeReached()`. See https://ci.swift.org/job/swift-package-manager-self-hosted-Linux-smoke-test/3000/consoleText

The types are marked `unavailable` so they can't be used accidentally, but they have fairly esoteric names, so we can just remove the annotation and we should be safe.

Darwin is not affected, so the change is conditional on platform.