### PR TITLE
Adopt `TimeValue` in more places.

### DIFF
--- a/Sources/Testing/Events/Clock.swift
+++ b/Sources/Testing/Events/Clock.swift
@@ -199,30 +199,6 @@ extension Test.Clock.Instant: InstantProtocol {
 
 // MARK: - Duration descriptions
 
-/// Get a description of a duration represented as a tuple containing seconds
-/// and attoseconds.
-///
-/// - Parameters:
-///   - components: The duration.
-///
-/// - Returns: A string describing the specified duration, up to millisecond
-///   accuracy.
-func descriptionOfTimeComponents(_ components: (seconds: Int64, attoseconds: Int64)) -> String {
-  let (secondsFromAttoseconds, attosecondsRemaining) = components.attoseconds.quotientAndRemainder(dividingBy: 1_000_000_000_000_000_000)
-  let seconds = components.seconds + secondsFromAttoseconds
-  var milliseconds = attosecondsRemaining / 1_000_000_000_000_000
-  if seconds == 0 && milliseconds == 0 && attosecondsRemaining > 0 {
-    milliseconds = 1
-  }
-
-  return withUnsafeTemporaryAllocation(of: CChar.self, capacity: 512) { buffer in
-    withVaList([CLongLong(seconds), CInt(milliseconds)]) { args in
-      _ = vsnprintf(buffer.baseAddress!, buffer.count, "%lld.%03d seconds", args)
-    }
-    return String(cString: buffer.baseAddress!)
-  }
-}
-
 extension Test.Clock.Instant {
   /// Get a description of the duration between this instance and another.
   ///
@@ -236,9 +212,9 @@ extension Test.Clock.Instant {
     let otherNanoseconds = (other.suspending.seconds * 1_000_000_000) + (other.suspending.attoseconds / 1_000_000_000)
     let selfNanoseconds = (suspending.seconds * 1_000_000_000) + (suspending.attoseconds / 1_000_000_000)
     let (seconds, nanosecondsRemaining) = (otherNanoseconds - selfNanoseconds).quotientAndRemainder(dividingBy: 1_000_000_000)
-    return descriptionOfTimeComponents((seconds, nanosecondsRemaining * 1_000_000_000))
+    return String(describing: TimeValue((seconds, nanosecondsRemaining * 1_000_000_000)))
 #else
-    return descriptionOfTimeComponents((Duration(other.suspending) - Duration(suspending)).components)
+    return String(describing: TimeValue(Duration(other.suspending) - Duration(suspending)))
 #endif
   }
 }

--- a/Sources/Testing/Events/TimeValue.swift
+++ b/Sources/Testing/Events/TimeValue.swift
@@ -71,6 +71,26 @@ extension TimeValue: Equatable, Hashable, Comparable {
 
 extension TimeValue: Codable {}
 
+// MARK: - CustomStringConvertible
+
+extension TimeValue: CustomStringConvertible {
+  var description: String {
+    let (secondsFromAttoseconds, attosecondsRemaining) = attoseconds.quotientAndRemainder(dividingBy: 1_000_000_000_000_000_000)
+    let seconds = seconds + secondsFromAttoseconds
+    var milliseconds = attosecondsRemaining / 1_000_000_000_000_000
+    if seconds == 0 && milliseconds == 0 && attosecondsRemaining > 0 {
+      milliseconds = 1
+    }
+
+    return withUnsafeTemporaryAllocation(of: CChar.self, capacity: 512) { buffer in
+      withVaList([CLongLong(seconds), CInt(milliseconds)]) { args in
+        _ = vsnprintf(buffer.baseAddress!, buffer.count, "%lld.%03d seconds", args)
+      }
+      return String(cString: buffer.baseAddress!)
+    }
+  }
+}
+
 // MARK: -
 
 @available(_clockAPI, *)

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -169,7 +169,7 @@ extension Issue.Kind: CustomStringConvertible {
     case let .errorCaught(error):
       "Caught error: \(error)"
     case let .timeLimitExceeded(timeLimitComponents: timeLimitComponents):
-      "Time limit was exceeded: \(descriptionOfTimeComponents(timeLimitComponents))"
+      "Time limit was exceeded: \(TimeValue(timeLimitComponents))"
     case .knownIssueNotRecorded:
       "Known issue was not recorded"
     case .apiMisused:

--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -31,11 +31,10 @@ extension XCTSourceCodeContext {
 /// This type is not part of the public interface of the testing library.
 struct TimeoutError: Error, CustomStringConvertible {
   /// The time limit exceeded by the test that timed out.
-  var timeLimitComponents: (seconds: Int64, attoseconds: Int64)
+  var timeLimit: TimeValue
 
   var description: String {
-    let timeLimitDescription = descriptionOfTimeComponents(timeLimitComponents)
-    return "Timed out after \(timeLimitDescription) seconds."
+    "Timed out after \(timeLimit) seconds."
   }
 }
 
@@ -52,7 +51,7 @@ extension XCTIssue {
     case let .timeLimitExceeded(timeLimitComponents: timeLimitComponents):
       issueType = .thrownError
       if error == nil {
-        error = TimeoutError(timeLimitComponents: timeLimitComponents)
+        error = TimeoutError(timeLimit: TimeValue(timeLimitComponents))
       }
     case .unconditional:
       issueType = .assertionFailure

--- a/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
+++ b/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
@@ -208,7 +208,8 @@ struct TimeLimitTraitTests {
 #if !SWT_NO_XCTEST_SCAFFOLDING && SWT_TARGET_OS_APPLE
   @Test("TimeoutError.description property")
   func timeoutErrorDescription() async throws {
-    #expect(String(describing: TimeoutError(timeLimitComponents: (0, 0))).contains("0.000"))
+    let timeLimit = TimeValue((0, 0))
+    #expect(String(describing: TimeoutError(timeLimit: timeLimit)).contains("0.000"))
   }
 #endif
 


### PR DESCRIPTION
This PR modifies some existing timey-wimey code to use `TimeValue` instead of directly using time component tuples. It also makes `TimeValue` conform to `CustomStringConvertible`.