### PR TITLE
Remove a dependency on XCTest.

### DIFF
--- a/Sources/Testing/Support/Additions/TypeAdditions.swift
+++ b/Sources/Testing/Support/Additions/TypeAdditions.swift
@@ -67,3 +67,22 @@ func isImportedFromC(_ type: Any.Type) -> Bool {
   let endIndex = mangledTypeName.index(mangledTypeName.startIndex, offsetBy: 2)
   return mangledTypeName[..<endIndex] == "So"
 }
+
+/// Check if a class is a subclass (or equal to) another class.
+///
+/// - Parameters:
+///   - subclass: The (possible) subclass to check.
+///   - superclass The (possible) superclass to check.
+///
+/// - Returns: Whether `subclass` is a subclass of, or is equal to,
+///   `superclass`.
+func isClass(_ subclass: AnyClass, subclassOf superclass: AnyClass) -> Bool {
+  if subclass == superclass {
+    true
+  } else if let subclassImmediateSuperclass = _getSuperclass(subclass) {
+    isClass(subclassImmediateSuperclass, subclassOf: superclass)
+  } else {
+    false
+  }
+}
+

--- a/Tests/TestingTests/ObjCInteropTests.swift
+++ b/Tests/TestingTests/ObjCInteropTests.swift
@@ -22,14 +22,10 @@ final class NonXCTestCaseClassTests: NSObject {
   }
 }
 
-@Suite("Objective-C/XCTest Interop Tests")
-struct ObjCAndXCTestInteropTests {
-  @TaskLocal static var areObjCClassTestsEnabled = false
+class IndirectXCTestCase: XCTestCase {}
 
-  class IndirectXCTestCase: XCTestCase {}
-
-  @Suite(.hidden, .enabled(if: ObjCAndXCTestInteropTests.areObjCClassTestsEnabled))
-  final class ObjCClassTests: IndirectXCTestCase {
+@Suite(.hidden, .enabled(if: ObjCAndXCTestInteropTests.areObjCClassTestsEnabled))
+final class ObjCClassTests: IndirectXCTestCase {
 #if !SWT_TARGET_OS_APPLE
   convenience init() {
     self.init(name: "") { _ in }
@@ -37,37 +33,41 @@ struct ObjCAndXCTestInteropTests {
 #endif
 
 #if _runtime(_ObjC)
-    @Test(.hidden)
-    @objc(testExplicitName) func wrongAnswer() {}
+  @Test(.hidden)
+  @objc(testExplicitName) func wrongAnswer() {}
 
-    @Test(.hidden)
-    @objc(testExplicitNameWithCompletionHandler:) func wrongAnswerAsync() async {}
+  @Test(.hidden)
+  @objc(testExplicitNameWithCompletionHandler:) func wrongAnswerAsync() async {}
 
-    @Test(.hidden)
-    @objc(testExplicitNameThrowsFunError:) func wrongAnswerThrows() throws {}
+  @Test(.hidden)
+  @objc(testExplicitNameThrowsFunError:) func wrongAnswerThrows() throws {}
 
-    @Test(.hidden)
-    @objc(testExplicitNameAsyncThrowsWithCompletionHandler:) func wrongAnswerAsyncThrows() async throws {}
+  @Test(.hidden)
+  @objc(testExplicitNameAsyncThrowsWithCompletionHandler:) func wrongAnswerAsyncThrows() async throws {}
 
-    @Test(.hidden)
-    @objc(`testExplicitNameWithBackticks`) func wrongAnswerWithBackticks() {}
+  @Test(.hidden)
+  @objc(`testExplicitNameWithBackticks`) func wrongAnswerWithBackticks() {}
 #endif
 
-    @Test(.hidden)
-    func testImplicitName() {}
+  @Test(.hidden)
+  func testImplicitName() {}
 
-    @Test(.hidden)
-    func `testImplicitNameWithBackticks`() {}
+  @Test(.hidden)
+  func `testImplicitNameWithBackticks`() {}
 
-    @Test(.hidden)
-    func testAsynchronous() async {}
+  @Test(.hidden)
+  func testAsynchronous() async {}
 
-    @Test(.hidden)
-    func testThrowing() throws {}
+  @Test(.hidden)
+  func testThrowing() throws {}
 
-    @Test(.hidden)
-    func testAsynchronousThrowing() async throws {}
-  }
+  @Test(.hidden)
+  func testAsynchronousThrowing() async throws {}
+}
+
+@Suite("Objective-C/XCTest Interop Tests")
+struct ObjCAndXCTestInteropTests {
+  @TaskLocal static var areObjCClassTestsEnabled = false
 
 #if _runtime(_ObjC)
   @Test("Objective-C selectors are discovered")


### PR DESCRIPTION
This PR removes a static dependency on XCTest in swift-testing. The dependency exists because a single Swift function cannot be _both_ an XCTest test method _and_ a swift-testing test function, so we have a runtime check in our generated thunk that records an issue if a developer manages to produce such code.

This change removes a reference to `XCTestCase` on non-Darwin platforms. Instead, on those platforms we dynamically look up the `XCTest.XCTestCase` class by name at runtime (similar to how we find it on Darwin.)

The generic function that performs this check is now generic over `AnyObject` rather than `XCTestCase`. There is a nominal runtime cost to taking this code path for all reference types, however it is not expected to be a problem except for pathologically deep class hierarchies (which we'd expect would suffer performance issues elsewhere in Swift/the runtime anyway.)