### PR TITLE
Add `includeHiddenTests` parameter to `setTestFilter(toMatch:)` APIs.

### DIFF
--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -128,17 +128,38 @@ public struct Configuration: Sendable {
   ///
   /// By default, all tests are run and no filter is set.
   public mutating func setTestFilter(toMatch selection: Set<Test.ID>?) {
-    setTestFilter(toMatch: selection.map(Test.ID.Selection.init))
+    setTestFilter(toMatch: selection, includeHiddenTests: false)
   }
-  
+
+    /// The granularity to enforce test filtering.
+    /// - Parameters:
+    ///   - selection: A set of test IDs to be filtered. If `nil`, the current
+    ///     selection is cleared.
+    ///   - includeHiddenTests: If false, a test annotated with the `.hidden` trait will not be included, even if its ID is present in `selection`.
+    ///
+    /// By default, all tests are run and no filter is set.
+    mutating func setTestFilter(toMatch selection: Set<Test.ID>?, includeHiddenTests: Bool) {
+      setTestFilter(toMatch: selection.map(Test.ID.Selection.init), includeHiddenTests: includeHiddenTests)
+    }
+
   /// The granularity to enforce test filtering.
   ///
   /// - Parameters:
   ///   - selection: A selection of test IDs to be filtered. If `nil`, the
   ///     current selection is cleared.
+  ///   - includeHiddenTests: If false, a test annotated with the `.hidden` trait will not be included, even if its ID is present in `selection`.
   ///
   /// By default, all tests are run and no filter is set.
-  mutating func setTestFilter(toMatch selection: Test.ID.Selection?) {
-    testFilter = selection.map { $0.contains }
+  mutating func setTestFilter(toMatch selection: Test.ID.Selection?, includeHiddenTests: Bool) {
+    if let selection {
+      testFilter = { test in
+        if includeHiddenTests || !test.isHidden {
+          return selection.contains(test)
+        }
+        return false
+      }
+    } else {
+      testFilter = nil
+    }
   }
 }

--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -131,16 +131,16 @@ public struct Configuration: Sendable {
     setTestFilter(toMatch: selection, includeHiddenTests: false)
   }
 
-    /// The granularity to enforce test filtering.
-    /// - Parameters:
-    ///   - selection: A set of test IDs to be filtered. If `nil`, the current
-    ///     selection is cleared.
-    ///   - includeHiddenTests: If false, a test annotated with the `.hidden` trait will not be included, even if its ID is present in `selection`.
-    ///
-    /// By default, all tests are run and no filter is set.
-    mutating func setTestFilter(toMatch selection: Set<Test.ID>?, includeHiddenTests: Bool) {
-      setTestFilter(toMatch: selection.map(Test.ID.Selection.init), includeHiddenTests: includeHiddenTests)
-    }
+  /// The granularity to enforce test filtering.
+  /// - Parameters:
+  ///   - selection: A set of test IDs to be filtered. If `nil`, the current
+  ///     selection is cleared.
+  ///   - includeHiddenTests: If false, a test annotated with the `.hidden` trait will not be included, even if its ID is present in `selection`.
+  ///
+  /// By default, all tests are run and no filter is set.
+  mutating func setTestFilter(toMatch selection: Set<Test.ID>?, includeHiddenTests: Bool) {
+    setTestFilter(toMatch: selection.map(Test.ID.Selection.init), includeHiddenTests: includeHiddenTests)
+  }
 
   /// The granularity to enforce test filtering.
   ///

--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -121,28 +121,18 @@ public struct Configuration: Sendable {
   /// The test filter to which tests should be filtered when run.
   public var testFilter: TestFilter?
 
-  /// The granularity to enforce test filtering.
+  /// Filter tests to run to those specified via a set of test IDs.
+  ///
   /// - Parameters:
   ///   - selection: A set of test IDs to be filtered. If `nil`, the current
   ///     selection is cleared.
   ///
   /// By default, all tests are run and no filter is set.
   public mutating func setTestFilter(toMatch selection: Set<Test.ID>?) {
-    setTestFilter(toMatch: selection, includeHiddenTests: false)
+    setTestFilter(toMatch: selection.map(Test.ID.Selection.init), includeHiddenTests: false)
   }
 
-  /// The granularity to enforce test filtering.
-  /// - Parameters:
-  ///   - selection: A set of test IDs to be filtered. If `nil`, the current
-  ///     selection is cleared.
-  ///   - includeHiddenTests: If false, a test annotated with the `.hidden` trait will not be included, even if its ID is present in `selection`.
-  ///
-  /// By default, all tests are run and no filter is set.
-  mutating func setTestFilter(toMatch selection: Set<Test.ID>?, includeHiddenTests: Bool) {
-    setTestFilter(toMatch: selection.map(Test.ID.Selection.init), includeHiddenTests: includeHiddenTests)
-  }
-
-  /// The granularity to enforce test filtering.
+  /// Filter tests to run to those specified via a Test.ID.Selection instance.
   ///
   /// - Parameters:
   ///   - selection: A selection of test IDs to be filtered. If `nil`, the

--- a/Tests/TestingTests/PlanTests.swift
+++ b/Tests/TestingTests/PlanTests.swift
@@ -28,7 +28,7 @@ struct PlanTests {
 
     let selection = Test.ID.Selection(testIDs: [innerTestType.id])
     var configuration = Configuration()
-    configuration.setTestFilter(toMatch: selection)
+    configuration.setTestFilter(toMatch: selection, includeHiddenTests: true)
 
     let plan = await Runner.Plan(tests: tests, configuration: configuration)
     #expect(plan.steps.contains(where: { $0.test == outerTestType }))
@@ -53,7 +53,7 @@ struct PlanTests {
 
     var configuration = Configuration()
     let selection = Test.ID.Selection(testIDs: [innerTestType.id, outerTestType.id])
-    configuration.setTestFilter(toMatch: selection)
+    configuration.setTestFilter(toMatch: selection, includeHiddenTests: true)
 
     let plan = await Runner.Plan(tests: tests, configuration: configuration)
     let planTests = plan.steps.map(\.test)
@@ -73,7 +73,7 @@ struct PlanTests {
 
     var configuration = Configuration()
     let selection = Test.ID.Selection(testIDs: [outerTestType.id, deeplyNestedTest.id])
-    configuration.setTestFilter(toMatch: selection)
+    configuration.setTestFilter(toMatch: selection, includeHiddenTests: true)
 
     let plan = await Runner.Plan(tests: tests, configuration: configuration)
 
@@ -92,7 +92,7 @@ struct PlanTests {
 
     var configuration = Configuration()
     let selection = Test.ID.Selection(testIDs: [testSuiteA.id])
-    configuration.setTestFilter(toMatch: selection)
+    configuration.setTestFilter(toMatch: selection, includeHiddenTests: true)
 
     let plan = await Runner.Plan(tests: tests, configuration: configuration)
     let testFuncXWithTraits = try #require(plan.steps.map(\.test).first { $0.name == "x()" })

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -325,13 +325,18 @@ final class RunnerTests: XCTestCase {
       Test.ID(type: S.self).child(named: "f()")
     ]
 
-    var configuration = Configuration()
-    configuration.setTestFilter(toMatch: .init(testIDs: selectedTestIDs), includeHiddenTests: false)
+    var configuration1 = Configuration()
+    configuration1.setTestFilter(toMatch: .init(testIDs: selectedTestIDs), includeHiddenTests: false)
 
-    let runner = await Runner(configuration: configuration)
-    let plan = runner.plan
+    var configuration2 = Configuration()
+    configuration2.setTestFilter(toMatch: selectedTestIDs)
 
-    XCTAssertEqual(plan.steps.count, 0)
+    for configuration in [configuration1, configuration2] {
+      let runner = await Runner(configuration: configuration)
+      let plan = runner.plan
+
+      XCTAssertEqual(plan.steps.count, 0)
+    }
   }
 
   func testHardCodedPlan() async throws {

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -316,6 +316,24 @@ final class RunnerTests: XCTestCase {
     XCTAssertEqual(skipInfo.comment, "Some comment")
   }
 
+  func testPlanExcludesHiddenTests() async throws {
+    @Suite(.hidden) struct S {
+      @Test(.hidden) func f() {}
+    }
+
+    let selectedTestIDs: Set<Test.ID> = [
+      Test.ID(type: S.self).child(named: "f()")
+    ]
+
+    var configuration = Configuration()
+    configuration.setTestFilter(toMatch: selectedTestIDs, includeHiddenTests: false)
+
+    let runner = await Runner(configuration: configuration)
+    let plan = runner.plan
+
+    XCTAssert(plan.steps.count == 0)
+  }
+
   func testHardCodedPlan() async throws {
     let tests = try await [
       testFunction(named: "succeeds()", in: SendableTests.self),

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -316,22 +316,22 @@ final class RunnerTests: XCTestCase {
     XCTAssertEqual(skipInfo.comment, "Some comment")
   }
 
-  func testPlanExcludesHiddenTests() async throws {
-    @Suite(.hidden) struct S {
-      @Test(.hidden) func f() {}
-    }
+  @Suite(.hidden) struct S {
+    @Test(.hidden) func f() {}
+  }
 
+  func testPlanExcludesHiddenTests() async throws {
     let selectedTestIDs: Set<Test.ID> = [
       Test.ID(type: S.self).child(named: "f()")
     ]
 
     var configuration = Configuration()
-    configuration.setTestFilter(toMatch: selectedTestIDs, includeHiddenTests: false)
+    configuration.setTestFilter(toMatch: .init(testIDs: selectedTestIDs), includeHiddenTests: false)
 
     let runner = await Runner(configuration: configuration)
     let plan = runner.plan
 
-    XCTAssert(plan.steps.count == 0)
+    XCTAssertEqual(plan.steps.count, 0)
   }
 
   func testHardCodedPlan() async throws {

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -251,7 +251,7 @@ final class RunnerTests: XCTestCase {
 
     var configuration = Configuration()
     let selection = Test.ID.Selection(testIDs: [testSuite.id])
-    configuration.setTestFilter(toMatch: selection)
+    configuration.setTestFilter(toMatch: selection, includeHiddenTests: true)
 
     let runner = await Runner(testing: [
       testSuite,
@@ -302,7 +302,7 @@ final class RunnerTests: XCTestCase {
 
     var configuration = Configuration()
     let selection = Test.ID.Selection(testIDs: selectedTestIDs)
-    configuration.setTestFilter(toMatch: selection)
+    configuration.setTestFilter(toMatch: selection, includeHiddenTests: true)
 
     let runner = await Runner(configuration: configuration)
     let plan = runner.plan

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -68,7 +68,7 @@ func runTest(for containingType: Any.Type, configuration: Configuration = .init(
 func runTestFunction(named name: String, in containingType: Any.Type, configuration: Configuration = .init()) async {
   var configuration = configuration
   let selection = Test.ID.Selection(testIDs: [Test.ID(type: containingType).child(named: name)])
-  configuration.setTestFilter(toMatch: selection)
+  configuration.setTestFilter(toMatch: selection, includeHiddenTests: true)
 
   let runner = await Runner(configuration: configuration)
   await runner.run()
@@ -92,7 +92,7 @@ extension Runner {
 
     var configuration = configuration
     let selection = Test.ID.Selection(testIDs: [Test.ID(moduleName: moduleName, nameComponents: [testName], sourceLocation: nil)])
-    configuration.setTestFilter(toMatch: selection)
+    configuration.setTestFilter(toMatch: selection, includeHiddenTests: true)
 
     await self.init(configuration: configuration)
   }
@@ -107,7 +107,7 @@ extension Runner.Plan {
   init(selecting containingType: Any.Type, configuration: Configuration = .init()) async {
     var configuration = configuration
     let selection = Test.ID.Selection(testIDs: [Test.ID(type: containingType)])
-    configuration.setTestFilter(toMatch: selection)
+    configuration.setTestFilter(toMatch: selection, includeHiddenTests: true)
 
     await self.init(configuration: configuration)
   }


### PR DESCRIPTION
### Motivation:

When constructing a `Configuration` instance, the **public** `setTestFilter(toMatch:)` API can be used to specify a particular set of test IDs that should be executed. Today, the implementation includes tests that are annotated with the internal `.hidden` trait. This PR changes the implementation to instead _exclude_ these hidden tests.

### Modifications:

I added an internal variant of the `setTestFilter(toMatch:)` API that has an additional parameter, `includeHiddenTests`. If `false` is passed as an argument to this parameter, a test annotated with the `.hidden` trait will _not_ be included, even if its ID is present in the set of IDs (or if it's a hidden descendant of a non-hidden suite whose ID is present in the set).

### Result:

I added a unit test to verify this new functionality.
