### PR TITLE
Lower Apple Platform requirement in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,10 +17,11 @@ let package = Package(
   name: "swift-testing",
 
   platforms: [
-    .macOS(.v13),
-    .iOS(.v16),
-    .watchOS(.v9),
-    .tvOS(.v16),
+    .macOS(.v10_15),
+    .iOS(.v13),
+    .watchOS(.v6),
+    .tvOS(.v13),
+    .macCatalyst(.v13),
     .visionOS(.v1),
   ],
 

--- a/Sources/GitStatus/main.swift
+++ b/Sources/GitStatus/main.swift
@@ -56,10 +56,17 @@ func _runGit(passing arguments: String..., readingUpToCount maxOutputCount: Int)
   defer {
     process.terminate()
   }
-  guard let output = try? stdoutPipe.fileHandleForReading.read(upToCount: maxOutputCount) else {
-    return nil
+  if #available(macOS 10.15.4, *) {
+    guard let output = try? stdoutPipe.fileHandleForReading.read(upToCount: maxOutputCount) else {
+      return nil
+    }
+    return String(data: output, encoding: .utf8)
+  } else {
+    guard let output = try? stdoutPipe.fileHandleForReading.readData(ofLength: maxOutputCount) else {
+      return nil
+    }
+    return String(data: output, encoding: .utf8)
   }
-  return String(data: output, encoding: .utf8)
 #else
   return nil
 #endif

--- a/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
+++ b/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
@@ -65,7 +65,7 @@ can be used with):
 
 ```swift
 platforms: [
-  .macOS(.v13), .iOS(.v16), .watchOS(.v9), .tvOS(.v16), .visionOS(.v1)
+  .macOS(.v10_15), .iOS(.v13), .watchOS(.v6), .tvOS(.v13), .macCatalyst(.v13), .visionOS(.v1)
 ],
 ```
 

--- a/Tests/TestingTests/ClockTests.swift
+++ b/Tests/TestingTests/ClockTests.swift
@@ -121,6 +121,7 @@ struct ClockTests {
     #expect(duration == .nanoseconds(offsetNanoseconds))
   }
 
+  @available(_clockAPI, *)
   @Test("Codable")
   func codable() async throws {
     let now = Test.Clock.Instant()


### PR DESCRIPTION
Lower Apple Platform requirement in Package.swift

### Motivation:

Close #101 

### Modifications:

Lower Apple Platform requirement in Package.swift

### Result:

A Package with iOS 13 support can at least have a dependency on it.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
