### PR TITLE
 Use `reinterpret_cast` instead of a C-style cast in Discovery.cpp.

### DIFF
--- a/Sources/TestingInternals/Discovery.cpp
+++ b/Sources/TestingInternals/Discovery.cpp
@@ -228,7 +228,7 @@ static SWTMachHeaderList getMachHeaders(void) {
 
   static constinit dispatch_once_t once = 0;
   dispatch_once_f(&once, nullptr, [] (void *) {
-    machHeaders = (SWTMachHeaderList *)std::malloc(sizeof(SWTMachHeaderList));
+    machHeaders = reinterpret_cast<SWTMachHeaderList *>(std::malloc(sizeof(SWTMachHeaderList)));
     ::new (machHeaders) SWTMachHeaderList();
     machHeaders->reserve(_dyld_image_count());
 


### PR DESCRIPTION
 As described: this file is C++ and should prefer C++-style casts where possible. My mistake.