### PR TITLE
Lower the 'TestCases' protocol to internal

### DIFF
--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -210,7 +210,7 @@ extension Runner {
   ///
   /// If parallelization is supported and enabled, the generated test cases will
   /// be run in parallel using a task group.
-  private func _runTestCases(_ testCases: some TestCases, within step: Plan.Step) async throws {
+  private func _runTestCases(_ testCases: some Sequence<Test.Case>, within step: Plan.Step) async throws {
     if configuration.isParallelizationEnabled {
       try await withThrowingTaskGroup(of: Void.self) { taskGroup in
         for testCase in testCases {

--- a/Sources/Testing/Test.Case.swift
+++ b/Sources/Testing/Test.Case.swift
@@ -83,8 +83,7 @@ extension Test {
 /// ([96960993](rdar://96960993)). It is also not possible to have a value of
 /// an underlying generic sequence type without specifying its generic
 /// parameters.
-@_spi(ExperimentalParameterizedTesting)
-public protocol TestCases: Sequence & Sendable where Element == Test.Case {
+protocol TestCases: Sequence<Test.Case> & Sendable {
   /// Whether this sequence is for a parameterized test.
   ///
   /// Both non-parameterized and parameterized tests may have an associated

--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -103,6 +103,8 @@ public struct Test: Sendable {
   /// combination of parameterized inputs. For non-parameterized tests, a single
   /// test case is synthesized. For test suite types (as opposed to test
   /// functions), the value of this property is `nil`.
+  ///
+  /// The value of this property is guaranteed to be `Sendable`.
   @_spi(ExperimentalParameterizedTesting)
   public var testCases: (any Sequence<Test.Case>)? {
     _testCases as? any Sequence<Test.Case>

--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -94,6 +94,9 @@ public struct Test: Sendable {
   @_spi(ExperimentalTestRunning)
   public var xcTestCompatibleSelector: __XCTestCompatibleSelector?
 
+  /// Storage for the ``testCases`` property.
+  private var _testCases: (any TestCases)?
+
   /// The set of test cases associated with this test, if any.
   ///
   /// For parameterized tests, each test case is associated with a single
@@ -101,12 +104,14 @@ public struct Test: Sendable {
   /// test case is synthesized. For test suite types (as opposed to test
   /// functions), the value of this property is `nil`.
   @_spi(ExperimentalParameterizedTesting)
-  public var testCases: (any TestCases)?
+  public var testCases: (any Sequence<Test.Case>)? {
+    _testCases as? any Sequence<Test.Case>
+  }
 
   /// Whether or not this test is parameterized.
   @_spi(ExperimentalParameterizedTesting)
   public var isParameterized: Bool {
-    testCases?.isParameterized ?? false
+    _testCases?.isParameterized ?? false
   }
 
   /// The test function parameters, if any.
@@ -127,6 +132,26 @@ public struct Test: Sendable {
   /// A test suite can be declared using the ``Suite(_:_:)`` macro.
   public var isSuite: Bool {
     containingType != nil && testCases == nil
+  }
+
+  init(
+    name: String,
+    displayName: String? = nil,
+    traits: [any Trait],
+    sourceLocation: SourceLocation,
+    containingType: Any.Type? = nil,
+    xcTestCompatibleSelector: __XCTestCompatibleSelector? = nil,
+    testCases: (any TestCases)? = nil,
+    parameters: [ParameterInfo]? = nil
+  ) {
+    self.name = name
+    self.displayName = displayName
+    self.traits = traits
+    self.sourceLocation = sourceLocation
+    self.containingType = containingType
+    self.xcTestCompatibleSelector = xcTestCompatibleSelector
+    self._testCases = testCases
+    self.parameters = parameters
   }
 }
 

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -433,7 +433,6 @@ struct MiscellaneousTests {
     #expect(!monomorphicTestFunction.isParameterized)
     let monomorphicTestFunctionTestCases = try #require(monomorphicTestFunction.testCases)
     #expect(monomorphicTestFunctionTestCases.underestimatedCount == 1)
-    #expect(!monomorphicTestFunctionTestCases.isParameterized)
     let monomorphicTestFunctionParameters = try #require(monomorphicTestFunction.parameters)
     #expect(monomorphicTestFunctionParameters.isEmpty)
 
@@ -441,7 +440,6 @@ struct MiscellaneousTests {
     #expect(parameterizedTestFunction.isParameterized)
     let parameterizedTestFunctionTestCases = try #require(parameterizedTestFunction.testCases)
     #expect(parameterizedTestFunctionTestCases.underestimatedCount == 100)
-    #expect(parameterizedTestFunctionTestCases.isParameterized)
     let parameterizedTestFunctionParameters = try #require(parameterizedTestFunction.parameters)
     #expect(parameterizedTestFunctionParameters.count == 1)
     let parameterizedTestFunctionFirstParameter = try #require(parameterizedTestFunctionParameters.first)
@@ -454,7 +452,6 @@ struct MiscellaneousTests {
     #expect(parameterizedTestFunction2.isParameterized)
     let parameterizedTestFunction2TestCases = try #require(parameterizedTestFunction2.testCases)
     #expect(parameterizedTestFunction2TestCases.underestimatedCount == 100 * 100)
-    #expect(parameterizedTestFunction2TestCases.isParameterized)
     let parameterizedTestFunction2Parameters = try #require(parameterizedTestFunction2.parameters)
     #expect(parameterizedTestFunction2Parameters.count == 2)
     let parameterizedTestFunction2FirstParameter = try #require(parameterizedTestFunction2Parameters.first)


### PR DESCRIPTION
Lower the access level of the `TestCases` protocol from `@_spi public` to `internal` (implicitly).

### Motivation:

Due to some limitations in Swift's type system, we currently need a protocol named `TestCases` as a workaround to type-erase our sequence of test cases so that it can be constrained to `Sendable` (see [comment](https://github.com/apple/swift-testing/blob/b9a03b12b01afe238894904eaf56ba118093e960/Sources/Testing/Test.Case.swift#L81)). But because the `Test.testCases` is `public`, that protocol also needs to match its access level. Since this protocol is just a workaround, we'd rather not expose the protocol and only expose a property returning a `Sequence` of test case instances on `Test`.

### Modifications:

- Add `Test._testCases` as a `private` stored property of type `(any TestCases)?`.
- Change `Test.testCases` to a computed property which conditionally down-casts `self._testCases`.
- Lower `TestCases` protocol to `internal`.

### Result:

The `TestCases` protocol is no longer exposed, and the type of the computed `Test.testCases` property is `any Sequence<Test.Case>`.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
