### PR TITLE
Remove the 'Test.Case.index' property

### DIFF
--- a/Sources/Testing/Test.Case.swift
+++ b/Sources/Testing/Test.Case.swift
@@ -16,9 +16,6 @@ extension Test {
   /// Tests that are _not_ parameterized map to a single instance of
   /// ``Test/Case``.
   public struct Case: Sendable {
-    /// The zero-based index of this test case.
-    public var index: Int
-
     /// The parameterized inputs to this test case.
     public var arguments: [any Sendable]
 

--- a/Tests/TestingTests/Test.CaseTests.swift
+++ b/Tests/TestingTests/Test.CaseTests.swift
@@ -16,7 +16,7 @@ struct Test_CaseTests {
   struct ArgumentsPairedWith {
     @Test("Single parameter")
     func singleParameter() throws {
-      let testCase = Test.Case(index: 0, arguments: ["value"]) {}
+      let testCase = Test.Case(arguments: ["value"]) {}
       let pairedArguments = Array(testCase.arguments(pairedWith: [Test.ParameterInfo(firstName: "foo")]))
       #expect(pairedArguments.count == 1)
 
@@ -28,7 +28,7 @@ struct Test_CaseTests {
 
     @Test("Two parameters")
     func twoParameters() throws {
-      let testCase = Test.Case(index: 0, arguments: [
+      let testCase = Test.Case(arguments: [
         "value",
         123,
       ]) {}
@@ -54,7 +54,7 @@ struct Test_CaseTests {
 
     @Test("One-value tuple parameter")
     func oneValueTupleParameter() throws {
-      let testCase = Test.Case(index: 0, arguments: [("value")]) {}
+      let testCase = Test.Case(arguments: [("value")]) {}
       let pairedArguments = Array(testCase.arguments(pairedWith: [Test.ParameterInfo(firstName: "foo")]))
       #expect(pairedArguments.count == 1)
 
@@ -66,7 +66,7 @@ struct Test_CaseTests {
 
     @Test("Two-value tuple parameter")
     func twoValueTupleParameter() throws {
-      let testCase = Test.Case(index: 0, arguments: [("value", 123)]) {}
+      let testCase = Test.Case(arguments: [("value", 123)]) {}
       let pairedArguments = Array(testCase.arguments(pairedWith: [
         Test.ParameterInfo(firstName: "foo"),
         Test.ParameterInfo(firstName: "bar"),


### PR DESCRIPTION
Remove the `Test.Case.index` property.

### Motivation:

The `Test.Case` type includes an `Int` property named `index`, whose value is assigned using a simple counter while iterating all argument combinations for a parameterized test function. This property does not always have a stable value between runs: this is most obvious when the arguments passed to the `@Test` macro are modified, but even given the same arguments, a `Collection` (such as `Dictionary`) may iterate its elements in a different order each time. Also, the semantics of this property can be unclear when it comes to parameterized tests accepting 2 or more arguments.

This PR removes this property due to these problems. In a future PR, my goal is to introduce a stronger, stable representation of the argument(s) of each `Test.Case`.

### Modifications:

- Remove the `Test.Case.index` property and its supporting code in `Test.Case.Generator`.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
