### PR TITLE
Add a mutable subscript to `Graph` when `V` is optional.

### DIFF
--- a/Sources/Testing/Events/Event.Recorder.swift
+++ b/Sources/Testing/Events/Event.Recorder.swift
@@ -557,7 +557,7 @@ extension Event.Recorder {
     case .testStarted:
       let test = test!
       $context.withLock { context in
-        context.testData.insertValue(.init(), at: test.id.keyPathRepresentation)
+        context.testData[test.id.keyPathRepresentation] = .init()
         if test.isSuite {
           context.suiteCount += 1
         } else {
@@ -614,13 +614,13 @@ extension Event.Recorder {
       if let test {
         let id = test.id.keyPathRepresentation
         $context.withLock { context in
-          var testData = context.testData[id].flatMap { $0 } ?? .init()
+          var testData = context.testData[id] ?? .init()
           if issue.isKnown {
             testData.knownIssueCount += 1
           } else {
             testData.issueCount += 1
           }
-          context.testData.insertValue(testData, at: id)
+          context.testData[id] = testData
         }
       }
       let parameterCount = if let parameters = test?.parameters {

--- a/Sources/Testing/Support/Graph.swift
+++ b/Sources/Testing/Support/Graph.swift
@@ -79,7 +79,7 @@ struct Graph<K, V> where K: Hashable {
   ///   present.
   ///
   /// - Complexity: O(*n*) where *n* is the number of elements in `keyPath`.
-  subscript(keyPath: some Collection<K>) -> V? {
+  @_disfavoredOverload subscript(keyPath: some Collection<K>) -> V? {
     subgraph(at: keyPath)?.value
   }
 
@@ -93,7 +93,7 @@ struct Graph<K, V> where K: Hashable {
   ///   present.
   ///
   /// - Complexity: O(*n*) where *n* is the number of elements in `keyPath`.
-  subscript(keyPath: K...) -> V? {
+  @_disfavoredOverload subscript(keyPath: K...) -> V? {
     self[keyPath]
   }
 
@@ -223,6 +223,55 @@ extension Graph {
     self.init(value: nil, children: children)
   }
 
+  /// Get or set the leaf value at the node identified by the specified sequence
+  /// of keys.
+  ///
+  /// - Parameters:
+  ///   - keyPath: A sequence of keys leading to the node of interest.
+  ///
+  /// - Returns: The value at the specified node, or `nil` if the node is not
+  ///   present.
+  ///
+  /// When setting the value at `keyPath`, intermediate nodes are created as
+  /// needed and are given `nil` values. To specify a different value for
+  /// intermediate nodes, use ``insertValue(_:at:intermediateValue:)`` instead.
+  ///
+  /// - Complexity: O(*n*) where *n* is the number of elements in `keyPath`.
+  subscript<U>(keyPath: some Collection<K>) -> V where V == U? {
+    get {
+      subgraph(at: keyPath)?.value
+    }
+    set {
+      insertValue(newValue, at: keyPath)
+    }
+  }
+
+  /// Get or set the leaf value at the node identified by the specified sequence
+  /// of keys.
+  ///
+  /// - Parameters:
+  ///   - keyPath: A sequence of keys leading to the node of interest.
+  ///
+  /// - Returns: The value at the specified node, or `nil` if the node is not
+  ///   present.
+  ///
+  /// When setting the value at `keyPath`, intermediate nodes are created as
+  /// needed and are given `nil` values. To specify a different value for
+  /// intermediate nodes, use ``insertValue(_:at:intermediateValue:)`` instead.
+  ///
+  /// - Complexity: To get a value, O(*n*) where *n* is the number of elements
+  ///   in `keyPath`. To set a value, O(*m* + *n*) where *n* is the number of
+  ///   elements in `keyPath` and *m* is the number of children at the
+  ///   penultimate node in `keyPath`.
+  subscript<U>(keyPath: K...) -> V where V == U? {
+    get {
+      self[keyPath]
+    }
+    set {
+      self[keyPath] = newValue
+    }
+  }
+
   /// Set the leaf value at the node identified by the specified sequence of
   /// keys.
   ///
@@ -236,9 +285,10 @@ extension Graph {
   /// intermediate to it, the graph is not modified. To add a value when none
   /// previously exists, use ``insertValue(_:at:intermediateValue:)``.
   ///
-  /// - Complexity: O(*m* + *n*) where *n* is the number of elements in
-  ///   `keyPath` and *m* is the number of children at the penultimate node in
-  ///   `keyPath`.
+  /// - Complexity: To get a value, O(*n*) where *n* is the number of elements
+  ///   in `keyPath`. To set a value, O(*m* + *n*) where *n* is the number of
+  ///   elements in `keyPath` and *m* is the number of children at the
+  ///   penultimate node in `keyPath`.
   @discardableResult
   mutating func updateValue<U>(_ newValue: V, at keyPath: some Collection<K>) -> V where V == U? {
     (updateValue(newValue, at: keyPath) as V?) ?? nil
@@ -250,8 +300,6 @@ extension Graph {
   /// - Parameters:
   ///   - newValue: The leaf value to set at the specified node.
   ///   - keyPath: A sequence of keys leading to the node of interest.
-  ///   - intermediateValue: A value to use when creating nodes intermediate to
-  ///     the one identified by `keyPath`.
   ///
   /// - Returns: The old value at `keyPath`, or `nil` if no value was present.
   ///

--- a/Sources/Testing/Support/Graph.swift
+++ b/Sources/Testing/Support/Graph.swift
@@ -236,7 +236,10 @@ extension Graph {
   /// needed and are given `nil` values. To specify a different value for
   /// intermediate nodes, use ``insertValue(_:at:intermediateValue:)`` instead.
   ///
-  /// - Complexity: O(*n*) where *n* is the number of elements in `keyPath`.
+  /// - Complexity: To get a value, O(*n*) where *n* is the number of elements
+  ///   in `keyPath`. To set a value, O(*m* + *n*) where *n* is the number of
+  ///   elements in `keyPath` and *m* is the number of children at the
+  ///   penultimate node in `keyPath`.
   subscript<U>(keyPath: some Collection<K>) -> V where V == U? {
     get {
       subgraph(at: keyPath)?.value
@@ -285,10 +288,9 @@ extension Graph {
   /// intermediate to it, the graph is not modified. To add a value when none
   /// previously exists, use ``insertValue(_:at:intermediateValue:)``.
   ///
-  /// - Complexity: To get a value, O(*n*) where *n* is the number of elements
-  ///   in `keyPath`. To set a value, O(*m* + *n*) where *n* is the number of
-  ///   elements in `keyPath` and *m* is the number of children at the
-  ///   penultimate node in `keyPath`.
+  /// - Complexity: O(*m* + *n*) where *n* is the number of elements in
+  ///   `keyPath` and *m* is the number of children at the penultimate node in
+  ///   `keyPath`.
   @discardableResult
   mutating func updateValue<U>(_ newValue: V, at keyPath: some Collection<K>) -> V where V == U? {
     (updateValue(newValue, at: keyPath) as V?) ?? nil

--- a/Tests/TestingTests/PlanTests.swift
+++ b/Tests/TestingTests/PlanTests.swift
@@ -109,9 +109,9 @@ struct PlanTests {
     // The tests themselves are nested deeper, under the source location, so
     // we're just checking here that the key path has been constructed correctly
     // up to the function names.
-    #expect((plan.stepGraph[nameComponents(of: SendableTests.self) + CollectionOfOne("succeeds()")] as Any?) != nil)
-    #expect((plan.stepGraph[nameComponents(of: SendableTests.self) + CollectionOfOne("static()")] as Any?) != nil)
-    #expect((plan.stepGraph[nameComponents(of: SendableTests.self) + CollectionOfOne("reserved1(reserved2:)")] as Any?) != nil)
+    #expect(plan.stepGraph.subgraph(at: nameComponents(of: SendableTests.self) + CollectionOfOne("succeeds()")) != nil)
+    #expect(plan.stepGraph.subgraph(at: nameComponents(of: SendableTests.self) + CollectionOfOne("static()")) != nil)
+    #expect(plan.stepGraph.subgraph(at: nameComponents(of: SendableTests.self) + CollectionOfOne("reserved1(reserved2:)")) != nil)
   }
 
   @Test("Runner.Plan.independentlyRunnableSteps property")

--- a/Tests/TestingTests/Support/GraphTests.swift
+++ b/Tests/TestingTests/Support/GraphTests.swift
@@ -66,6 +66,28 @@ struct GraphTests {
     #expect(graph["C1", "C2", "C3"] == nil)
   }
 
+  @Test("subscript([K]) operator (sparse)")
+  func subscriptWithOptionals() {
+    let graph = Graph<String, Int?>(value: 123, children: [
+      "C1": Graph(value: 456),
+      "C2": Graph(value: nil, children: [
+        "C3": Graph(value: 2468),
+      ]),
+    ])
+    #expect(graph["C2", "C3"] == 2468)
+    #expect(graph["C0", "C2", "C3"] == nil)
+    #expect(graph["C1", "C2", "C3"] == nil)
+  }
+
+  @Test("subscript([K]) operator (sparse, mutating)")
+  func mutatingSubscriptWithOptionals() {
+    var graph = Graph<String, Int?>()
+    graph["C1", "C2", "C3", "C4", "C5"] = 123
+    #expect(graph["C1"] == nil)
+    #expect(graph["C1", "C2", "C3", "C4"] == nil)
+    #expect(graph["C1", "C2", "C3", "C4", "C5"] == 123)
+  }
+
   @Test("updateValue(_:at:) function")
   func update() {
     var graph = Graph<String, Int>(value: 123, children: [


### PR DESCRIPTION
This PR modifies the subscript operator of the `Graph` pseudo-collection type such that, when `V` is optional, it is settable (with intermediate values defaulting to `nil`). This change simplifies some code that uses these subscripts.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
