### PR TITLE
Derive `Test.isParameterized` from `Test.parameters`

### DIFF
--- a/Sources/Testing/Test.Case.Generator.swift
+++ b/Sources/Testing/Test.Case.Generator.swift
@@ -141,8 +141,4 @@ extension Test.Case.Generator: Sequence {
 
 // MARK: - TestCases
 
-extension Test.Case.Generator: TestCases {
-  var isParameterized: Bool {
-    S.self != CollectionOfOne<Void>.self
-  }
-}
+extension Test.Case.Generator: TestCases {}

--- a/Sources/Testing/Test.Case.swift
+++ b/Sources/Testing/Test.Case.swift
@@ -80,11 +80,4 @@ extension Test {
 /// ([96960993](rdar://96960993)). It is also not possible to have a value of
 /// an underlying generic sequence type without specifying its generic
 /// parameters.
-protocol TestCases: Sequence<Test.Case> & Sendable {
-  /// Whether this sequence is for a parameterized test.
-  ///
-  /// Both non-parameterized and parameterized tests may have an associated
-  /// sequence of ``Test/Case`` instances, so this can be used to distinguish
-  /// between them.
-  var isParameterized: Bool { get }
-}
+protocol TestCases: Sequence<Test.Case> & Sendable {}

--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -113,7 +113,10 @@ public struct Test: Sendable {
   /// Whether or not this test is parameterized.
   @_spi(ExperimentalParameterizedTesting)
   public var isParameterized: Bool {
-    _testCases?.isParameterized ?? false
+    guard let parameterCount = parameters?.count else {
+      return false
+    }
+    return parameterCount != 0
   }
 
   /// The test function parameters, if any.


### PR DESCRIPTION
A small simplification: derive `Test.isParameterized` from `Test.parameters`, and eliminate the need for the `isParameterized` property requirement on the `TestCases` protocol. This was needed back before we added the `Test.parameters` property, but now it's easier and simpler to infer whether a test is parameterized from whether it has parameters.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
