### PR TITLE
Implement `swift test --xunit-output`.

### DIFF
--- a/Sources/Testing/Events/Clock.swift
+++ b/Sources/Testing/Events/Clock.swift
@@ -101,7 +101,7 @@ extension Test.Clock.Instant {
   ///
   /// - Returns: The number of nanoseconds between `self` and `other`. If
   ///   `other` is ordered before this instance, the result is negative.
-  func nanoseconds(until other: Test.Clock.Instant) -> Int64 {
+  func nanoseconds(until other: Self) -> Int64 {
     if other < self {
       return -other.nanoseconds(until: self)
     }

--- a/Sources/Testing/Events/Clock.swift
+++ b/Sources/Testing/Events/Clock.swift
@@ -96,6 +96,9 @@ extension Test.Clock.Instant {
 
   /// Get the number of nanoseconds from this instance to another.
   ///
+  /// - Parameters:
+  ///   - other: The later instant.
+  ///
   /// - Returns: The number of nanoseconds between `self` and `other`. If
   ///   `other` is ordered before this instance, the result is negative.
   func nanoseconds(until other: Test.Clock.Instant) -> Int64 {

--- a/Sources/Testing/Events/Clock.swift
+++ b/Sources/Testing/Events/Clock.swift
@@ -93,6 +93,19 @@ extension Test.Clock.Instant {
   public var durationSince1970: Duration {
     Duration(wall)
   }
+
+  /// Get the number of nanoseconds from this instance to another.
+  ///
+  /// - Returns: The number of nanoseconds between `self` and `other`. If
+  ///   `other` is ordered before this instance, the result is negative.
+  func nanoseconds(until other: Test.Clock.Instant) -> Int64 {
+    if other < self {
+      return -other.nanoseconds(until: self)
+    }
+    let otherNanoseconds = (other.suspending.seconds * 1_000_000_000) + (other.suspending.attoseconds / 1_000_000_000)
+    let selfNanoseconds = (suspending.seconds * 1_000_000_000) + (suspending.attoseconds / 1_000_000_000)
+    return otherNanoseconds - selfNanoseconds
+  }
 }
 #endif
 
@@ -209,9 +222,7 @@ extension Test.Clock.Instant {
   ///   up to millisecond accuracy.
   func descriptionOfDuration(to other: Test.Clock.Instant) -> String {
 #if SWT_TARGET_OS_APPLE
-    let otherNanoseconds = (other.suspending.seconds * 1_000_000_000) + (other.suspending.attoseconds / 1_000_000_000)
-    let selfNanoseconds = (suspending.seconds * 1_000_000_000) + (suspending.attoseconds / 1_000_000_000)
-    let (seconds, nanosecondsRemaining) = (otherNanoseconds - selfNanoseconds).quotientAndRemainder(dividingBy: 1_000_000_000)
+    let (seconds, nanosecondsRemaining) = nanoseconds(until: other).quotientAndRemainder(dividingBy: 1_000_000_000)
     return String(describing: TimeValue((seconds, nanosecondsRemaining * 1_000_000_000)))
 #else
     return String(describing: TimeValue(Duration(other.suspending) - Duration(suspending)))

--- a/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
@@ -13,7 +13,7 @@ extension Event {
   /// them as human-readable strings.
   ///
   /// The format of the output is not meant to be machine-readable and is
-  /// subject to change.
+  /// subject to change. For machine-readable output, use ``JUnitXMLRecorder``.
   public struct ConsoleOutputRecorder: Sendable {
     /// An enumeration describing options to use when writing events to a
     /// stream.

--- a/Sources/Testing/Events/Recorder/Event.JUnitXMLRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.JUnitXMLRecorder.swift
@@ -1,0 +1,213 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+extension Event {
+  /// A type which handles ``Event`` instances and outputs representations of
+  /// them as JUnit-compatible XML.
+  public struct JUnitXMLRecorder: Sendable {
+    /// The write function for this event recorder.
+    var write: @Sendable (String) -> Void
+
+    /// A type that contains mutable context for ``Event/JUnitXMLRecorder``.
+    ///
+    /// - Bug: Although the data being tracked is different, this type could
+    ///   potentially be reconciled with
+    ///   ``Event/ConsoleOutputRecorder/Context``.
+    private struct _Context: Sendable {
+      /// The instant at which the run started.
+      var runStartInstant: Test.Clock.Instant?
+
+      /// The number of tests started or skipped during the run.
+      ///
+      /// This value does not include test suites.
+      var testCount = 0
+
+      /// A type describing data tracked on a per-test basis.
+      struct TestData: Sendable {
+        /// The ID of the test.
+        var id: Test.ID
+
+        /// The instant at which the test started.
+        var startInstant: Test.Clock.Instant
+
+        /// The instant at which the test started.
+        var endInstant: Test.Clock.Instant?
+
+        /// Any issues recorded for the test.
+        var issues = [Issue]()
+      }
+
+      /// Data tracked on a per-test basis.
+      var testData = Graph<String, TestData?>()
+    }
+
+    /// This event recorder's mutable context about events it has received,
+    /// which may be used to inform how subsequent events are written.
+    @Locked private var _context = _Context()
+
+    /// Initialize a new event recorder.
+    ///
+    /// - Parameters:
+    ///   - write: A closure that writes output to its destination. The closure
+    ///     may be invoked concurrently.
+    ///
+    /// Output from the testing library is written using `write`.
+    init(writingUsing write: @escaping @Sendable (String) -> Void) {
+      self.write = write
+    }
+  }
+}
+
+extension Event.JUnitXMLRecorder: EventRecorder {
+  /// Record the specified event by generating a representation of it as a
+  /// human-readable string.
+  ///
+  /// - Parameters:
+  ///   - event: The event to record.
+  ///   - eventContext: The context associated with the event.
+  ///
+  /// - Returns: A string description of the event, or `nil` if there is nothing
+  ///   useful to output for this event.
+  private func _record(_ event: borrowing Event, in eventContext: borrowing Event.Context) -> String? {
+    let instant = event.instant
+    let test = eventContext.test
+
+    switch event.kind {
+    case .runStarted:
+      $_context.withLock { context in
+        context.runStartInstant = instant
+      }
+      return #"""
+        <?xml version="1.0" encoding="UTF-8"?>
+        <testsuites>
+
+        """#
+    case .testStarted where false == test?.isSuite:
+      let id = test!.id
+      let keyPath = id.keyPathRepresentation
+      $_context.withLock { context in
+        context.testData[keyPath] = _Context.TestData(id: id, startInstant: instant)
+      }
+      return nil
+    case .testEnded where false == test?.isSuite:
+      let id = test!.id
+      let keyPath = id.keyPathRepresentation
+      $_context.withLock { context in
+        context.testData[keyPath]?.endInstant = instant
+      }
+      return nil
+    case .testSkipped where false == test?.isSuite:
+      return nil
+    case let .issueRecorded(issue):
+      if issue.isKnown {
+        return nil
+      }
+      guard let id = test?.id else {
+        return nil // FIXME: handle issues without known tests
+      }
+      let keyPath = id.keyPathRepresentation
+      $_context.withLock { context in
+        context.testData[keyPath]?.issues.append(issue)
+      }
+      return nil
+    case .runEnded:
+      return $_context.withLock { context in
+        let issueCount = context.testData
+          .compactMap(\.value?.issues.count)
+          .reduce(into: 0, +=)
+        let durationNanoseconds = context.runStartInstant.map { $0.nanoseconds(until: instant) } ?? 0
+        let durationSeconds = Double(durationNanoseconds) / 1_000_000_000
+        return #"""
+            <testsuite name="TestResults" errors="0" tests="\#(context.testCount)" failures="\#(issueCount)" time="\#(durationSeconds)">
+          \#(Self._xml(for: context.testData))
+            </testsuite>
+          </testsuites>
+
+          """#
+      }
+    default:
+      return nil
+    }
+  }
+
+  /// Generate XML for a graph of test data.
+  ///
+  /// - Parameters:
+  ///   - testDataGraph: The test data graph.
+  ///
+  /// - Returns: A string containing (partial) XML for the given test graph.
+  ///
+  /// This function calls itself recursively as it walks `testDataGraph` in
+  /// order to build up the XML output for all nodes therein.
+  private static func _xml(for testDataGraph: Graph<String, _Context.TestData?>) -> String {
+    var result = [String]()
+
+    if let testData = testDataGraph.value {
+      let id = testData.id
+      let classNameComponents = CollectionOfOne(id.moduleName) + id.nameComponents.dropLast()
+      let className = classNameComponents.joined(separator: ".")
+      let name = id.nameComponents.last!
+      let durationNanoseconds = testData.startInstant.nanoseconds(until: testData.endInstant ?? .now)
+      let durationSeconds = Double(durationNanoseconds) / 1_000_000_000
+      if testData.issues.isEmpty {
+        result.append(#"    <testcase classname="\#(className)" name="\#(name)" time="\#(durationSeconds)" />"#)
+      } else {
+        result.append(#"    <testcase classname="\#(className)" name="\#(name)" time="\#(durationSeconds)">"#)
+        result += testData.issues.lazy
+          .map(String.init(describing:))
+          .map { #"      <failure message="\#(Self._escapeForXML($0))" />"# }
+        result.append(#"    </testcase>"#)
+      }
+    } else {
+      for childGraph in testDataGraph.children.values {
+        result.append(_xml(for: childGraph))
+      }
+    }
+
+    return result.joined(separator: "\n")
+  }
+
+  /// Escape a single Unicode character for use in an XML-encoded string.
+  ///
+  /// - Parameters:
+  ///   - character: The character to escape.
+  ///
+  /// - Returns: `character`, or a string containing its escaped form.
+  private static func _escapeForXML(_ character: Character) -> String {
+    if character == #"""# {
+      "&quot;"
+    } else if !character.isASCII {
+      character.unicodeScalars.lazy
+        .map(\.value)
+        .map { "&#\($0);" }
+        .joined()
+    } else {
+      String(character)
+    }
+  }
+
+  /// Escape a string for use in XML.
+  ///
+  /// - Parameters:
+  ///   - string: The string to escape.
+  ///
+  /// - Returns: A copy of `string` that has been escaped for XML.
+  private static func _escapeForXML(_ string: String) -> String {
+    string.lazy.map(_escapeForXML).joined()
+  }
+
+  @discardableResult public func record(_ event: borrowing Event, in context: borrowing Event.Context) -> Bool {
+    if let output = _record(event, in: context) {
+      write(output)
+      return true
+    }
+    return false
+  }
+}

--- a/Sources/Testing/Events/Recorder/EventRecorder.swift
+++ b/Sources/Testing/Events/Recorder/EventRecorder.swift
@@ -8,6 +8,14 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+/// A protocol describing types that can record events that occur during
+/// testing.
+///
+/// Types that conform to this protocol provide an interface for recording
+/// events; the exact meaning of "record" in this context is specific to each
+/// type, but typically involves transforming events into some output format
+/// such as human-readable text or machine-readable structured data and writing
+/// it to an output stream.
 @_spi(ExperimentalEventHandling)
 public protocol EventRecorder: Sendable {
   /// Record the specified event by generating a representation of it in this

--- a/Sources/Testing/Events/Recorder/EventRecorder.swift
+++ b/Sources/Testing/Events/Recorder/EventRecorder.swift
@@ -1,0 +1,23 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@_spi(ExperimentalEventHandling)
+public protocol EventRecorder: Sendable {
+  /// Record the specified event by generating a representation of it in this
+  /// instance's output format and writing it to this instance's destination.
+  ///
+  /// - Parameters:
+  ///   - event: The event to record.
+  ///   - context: The context associated with the event.
+  ///
+  /// - Returns: Whether any output was produced and written to this instance's
+  ///   destination.
+  func record(_ event: borrowing Event, in context: borrowing Event.Context) -> Bool
+}

--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -33,12 +33,14 @@ public func swiftPMEntryPoint() async -> CInt {
       }
     } else {
       var configuration = try configurationForSwiftPMEntryPoint(withArguments: args)
-      configuration.eventHandler = { event, _ in
+      let oldEventHandler = configuration.eventHandler
+      configuration.eventHandler = { event, context in
         if case let .issueRecorded(issue) = event.kind, !issue.isKnown {
           $exitCode.withLock { exitCode in
             exitCode = EXIT_FAILURE
           }
         }
+        oldEventHandler(event, context)
       }
 
       await runTests(configuration: configuration)
@@ -135,6 +137,37 @@ func configurationForSwiftPMEntryPoint(withArguments args: [String]) throws -> C
     configuration.isParallelizationEnabled = true
   }
 
+  // XML output
+  if let xunitOutputIndex = args.firstIndex(of: "--xunit-output"), xunitOutputIndex < args.endIndex {
+    let xunitOutputPath = args[args.index(after: xunitOutputIndex)]
+
+    // Open the XML file for writing.
+    guard let file = fopen(xunitOutputPath, "wb") else {
+      throw CError(rawValue: errno)
+    }
+
+    // Create a simple type that contains the C file handle we created and
+    // ensures it is closed when it goes out of scope.
+    struct FileCloser: @unchecked Sendable, ~Copyable {
+      var file: SWT_FILEHandle
+      deinit {
+        fclose(file)
+      }
+    }
+
+    // Set up the XML recorder.
+    let xmlRecorder = Event.JUnitXMLRecorder { [file = FileCloser(file: file)] string in
+      fputs(string, file.file)
+      fflush(file.file)
+    }
+
+    let oldEventHandler = configuration.eventHandler
+    configuration.eventHandler = { event, context in
+      _ = xmlRecorder.record(event, in: context)
+      oldEventHandler(event, context)
+    }
+  }
+
   // Filtering
   // NOTE: Regex is not marked Sendable, but because the regexes we use are
   // constructed solely from a string, they are safe to send across isolation
@@ -179,7 +212,7 @@ func configurationForSwiftPMEntryPoint(withArguments args: [String]) throws -> C
 /// - Parameters:
 ///   - configuration: The configuration to use for running.
 func runTests(configuration: Configuration) async {
-  let eventRecorder = Event.Recorder(options: .forStandardError) { string in
+  let eventRecorder = Event.ConsoleOutputRecorder(options: .forStandardError) { string in
     let stderr = swt_stderr()
     fputs(string, stderr)
     fflush(stderr)
@@ -198,7 +231,7 @@ func runTests(configuration: Configuration) async {
 
 // MARK: - Command-line interface options
 
-extension [Event.Recorder.Option] {
+extension [Event.ConsoleOutputRecorder.Option] {
   /// The set of options to use when writing to the standard error stream.
   static var forStandardError: Self {
     var result = Self()

--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -143,7 +143,7 @@ func configurationForSwiftPMEntryPoint(withArguments args: [String]) throws -> C
 
     // Open the XML file for writing.
     guard let file = fopen(xunitOutputPath, "wb") else {
-      throw CError(rawValue: errno)
+      throw CError(rawValue: swt_errno())
     }
 
     // Create a simple type that contains the C file handle we created and

--- a/Sources/Testing/Support/CError.swift
+++ b/Sources/Testing/Support/CError.swift
@@ -20,6 +20,8 @@ struct CError: Error, RawRepresentable {
   var rawValue: CInt
 }
 
+// MARK: - CustomStringConvertible
+
 extension CError: CustomStringConvertible {
   var description: String {
     String(cString: strerror(rawValue))

--- a/Sources/Testing/Support/CError.swift
+++ b/Sources/Testing/Support/CError.swift
@@ -1,0 +1,27 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+private import TestingInternals
+
+/// A type representing an error from a C function such as `fopen()`.
+///
+/// This type is necessary because Foundation's `POSIXError` is not available in
+/// all contexts.
+///
+/// This type is not part of the public interface of the testing library.
+struct CError: Error, RawRepresentable {
+  var rawValue: CInt
+}
+
+extension CError: CustomStringConvertible {
+  var description: String {
+    String(cString: strerror(rawValue))
+  }
+}

--- a/Sources/Testing/Traits/Tag.Color+Loading.swift
+++ b/Sources/Testing/Traits/Tag.Color+Loading.swift
@@ -86,7 +86,7 @@ var swiftTestingDirectoryPath: String {
 /// dictionary) where the keys are tags' string values and the values represent
 /// tag colors. For a list of the supported formats for tag colors in this
 /// dictionary, see <doc:AddingTags>.
-func tagColorOptions(fromFileInDirectoryAtPath swiftTestingDirectoryPath: String = swiftTestingDirectoryPath) -> [Event.Recorder.Option] {
+func tagColorOptions(fromFileInDirectoryAtPath swiftTestingDirectoryPath: String = swiftTestingDirectoryPath) -> [Event.ConsoleOutputRecorder.Option] {
 #if !SWT_NO_TAG_COLORS && canImport(Foundation)
   // Find the path to the tag-colors.json file.
   let tagColorsURL = URL(fileURLWithPath: swiftTestingDirectoryPath, isDirectory: true)

--- a/Sources/TestingInternals/include/Includes.h
+++ b/Sources/TestingInternals/include/Includes.h
@@ -26,6 +26,7 @@
 ///
 /// - Note: Avoid including headers that aren't actually used.
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/Sources/TestingInternals/include/Stubs.h
+++ b/Sources/TestingInternals/include/Stubs.h
@@ -16,12 +16,19 @@
 
 SWT_ASSUME_NONNULL_BEGIN
 
+/// The C file handle type.
+///
+/// This typedef is necessary because `FILE *` may be imported into Swift as
+/// either `OpaquePointer` or `UnsafeMutablePointer<FILE>` depending on the
+/// current platform.
+typedef FILE *SWT_FILEHandle;
+
 /// Get the standard error stream.
 ///
 /// This function is provided because directly accessing `stderr` from Swift
 /// triggers concurrency warnings on some platforms about accessing shared
 /// mutable state.
-static FILE *swt_stderr(void) {
+static SWT_FILEHandle swt_stderr(void) {
   return stderr;
 }
 

--- a/Sources/TestingInternals/include/Stubs.h
+++ b/Sources/TestingInternals/include/Stubs.h
@@ -32,6 +32,14 @@ static SWT_FILEHandle swt_stderr(void) {
   return stderr;
 }
 
+/// Get the current C error.
+///
+/// This function is provided because `errno` is a complex macro on some
+/// platforms and cannot be imported directly into Swift.
+static int swt_errno(void) {
+  return errno;
+}
+
 #if __has_include(<sys/stat.h>) && defined(S_ISFIFO)
 /// Check if a given `mode_t` value indicates that a file is a pipe (FIFO.)
 ///

--- a/Tests/TestingTests/ClockTests.swift
+++ b/Tests/TestingTests/ClockTests.swift
@@ -121,6 +121,7 @@ struct ClockTests {
     #expect(duration == .nanoseconds(offsetNanoseconds))
   }
 
+  @available(_clockAPI, *)
   @Test("Codable")
   func codable() async throws {
     let now = Test.Clock.Instant()
@@ -130,5 +131,19 @@ struct ClockTests {
 
     #expect(instant == decoded)
     #expect(instant != now)
+  }
+
+  @available(_clockAPI, *)
+  @Test("Clock.Instant.nanoseconds(until:) method",
+    arguments: [
+      (Duration.zero, 0),
+      (.nanoseconds(1), 1),
+      (.seconds(1), 1_000_000_000),
+      (Duration(secondsComponent: 0, attosecondsComponent: 1), 0),
+    ]
+  )
+  func nanoseconds(until offset: Duration, nanoseconds: Int) {
+    let now = Test.Clock.Instant.now
+    #expect(now.nanoseconds(until: now.advanced(by: offset)) == nanoseconds)
   }
 }

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -12,8 +12,9 @@
 #if !os(Windows)
 import RegexBuilder
 #endif
+import Foundation
 
-@Suite("Event.Recorder Tests")
+@Suite("EventRecorder Tests")
 struct EventRecorderTests {
   final class Stream: TextOutputStream, Sendable {
     let buffer = Locked<String>(wrappedValue: "")
@@ -25,8 +26,8 @@ struct EventRecorderTests {
     }
   }
 
-  private static var optionCombinations: [[Event.Recorder.Option]] {
-    var result: [[Event.Recorder.Option]] = [
+  private static var optionCombinations: [[Event.ConsoleOutputRecorder.Option]] {
+    var result: [[Event.ConsoleOutputRecorder.Option]] = [
       [],
       [.useANSIEscapeCodes],
       [.use256ColorANSIEscapeCodes],
@@ -44,12 +45,12 @@ struct EventRecorderTests {
   }
 
   @Test("Writing events", arguments: optionCombinations)
-  func writingToStream(options: [Event.Recorder.Option]) async throws {
+  func writingToStream(options: [Event.ConsoleOutputRecorder.Option]) async throws {
     let stream = Stream()
 
     var configuration = Configuration()
     configuration.deliverExpectationCheckedEvents = true
-    let eventRecorder = Event.Recorder(options: options, writingUsing: stream.write)
+    let eventRecorder = Event.ConsoleOutputRecorder(options: options, writingUsing: stream.write)
     configuration.eventHandler = { event, context in
       eventRecorder.record(event, in: context)
     }
@@ -96,7 +97,7 @@ struct EventRecorderTests {
     let stream = Stream()
 
     var configuration = Configuration()
-    let eventRecorder = Event.Recorder(writingUsing: stream.write)
+    let eventRecorder = Event.ConsoleOutputRecorder(writingUsing: stream.write)
     configuration.eventHandler = { event, context in
       eventRecorder.record(event, in: context)
     }
@@ -139,7 +140,7 @@ struct EventRecorderTests {
     let stream = Stream()
 
     var configuration = Configuration()
-    let eventRecorder = Event.Recorder(writingUsing: stream.write)
+    let eventRecorder = Event.ConsoleOutputRecorder(writingUsing: stream.write)
     configuration.eventHandler = { event, context in
       eventRecorder.record(event, in: context)
     }
@@ -162,7 +163,7 @@ struct EventRecorderTests {
     let stream = Stream()
 
     var configuration = Configuration()
-    let eventRecorder = Event.Recorder(writingUsing: stream.write)
+    let eventRecorder = Event.ConsoleOutputRecorder(writingUsing: stream.write)
     configuration.eventHandler = { event, context in
       eventRecorder.record(event, in: context)
     }
@@ -202,6 +203,33 @@ struct EventRecorderTests {
     #expect(match.output.2 == 4)
   }
 #endif
+
+  @Test("JUnitXMLRecorder outputs valid XML")
+  func junitXMLIsValid() async throws {
+    let stream = Stream()
+
+    var configuration = Configuration()
+    configuration.deliverExpectationCheckedEvents = true
+    let eventRecorder = Event.JUnitXMLRecorder(writingUsing: stream.write)
+    configuration.eventHandler = { event, context in
+      eventRecorder.record(event, in: context)
+    }
+
+    await runTest(for: WrittenTests.self, configuration: configuration)
+
+    // There is no formal schema for us to test against, so we're just testing
+    // that the XML can be parsed by Foundation.
+
+    let xmlString = stream.buffer.wrappedValue
+    #expect(xmlString.hasPrefix("<?xml"))
+    let xmlData = try #require(xmlString.data(using: .utf8))
+    #expect(xmlData.count > 1024)
+    let parser = XMLParser(data: xmlData)
+    #expect(parser.parse())
+    if let error = parser.parserError {
+      throw error
+    }
+  }
 }
 
 // MARK: - Fixtures
@@ -261,13 +289,21 @@ struct EventRecorderTests {
   }
 
   @Test(.hidden) func diffyDuck() {
-    #expect([1, 2, 3] == [1, 2])
+    #expect([1, 2, 3] as Array == [1, 2] as Array)
   }
 
   @Test(.hidden) func woefulWombat() {
     #expect(throws: MyError.self) {
       throw MyDescriptiveError(description: "Woe!")
     }
+  }
+
+  @Test(.hidden) func quotationalQuokka() throws {
+    throw MyDescriptiveError(description: #""Quotation marks!""#)
+  }
+
+  @Test(.hidden) func cornyUnicorn🦄() throws {
+    throw MyDescriptiveError(description: #"🦄"#)
   }
 }
 

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -12,7 +12,11 @@
 #if !os(Windows)
 import RegexBuilder
 #endif
+#if SWT_TARGET_OS_APPLE
 import Foundation
+#else
+import FoundationXML
+#endif
 
 @Suite("EventRecorder Tests")
 struct EventRecorderTests {

--- a/Tests/TestingTests/Support/CErrorTests.swift
+++ b/Tests/TestingTests/Support/CErrorTests.swift
@@ -15,8 +15,6 @@ import TestingInternals
 struct CErrorTests {
   @Test("CError.description property", arguments: 1 ..< 100)
   func errorDescription(errorCode: CInt) {
-    // The set of error codes actually defined by standard C is quite narrow.
-    // EDOM is one of the few defined codes.
     let description = String(describing: CError(rawValue: errorCode))
     #expect(!description.isEmpty)
     description.withCString { description in

--- a/Tests/TestingTests/Support/CErrorTests.swift
+++ b/Tests/TestingTests/Support/CErrorTests.swift
@@ -1,0 +1,26 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable import Testing
+import TestingInternals
+
+@Suite("CError Tests")
+struct CErrorTests {
+  @Test("CError.description property", arguments: 1 ..< 100)
+  func errorDescription(errorCode: CInt) {
+    // The set of error codes actually defined by standard C is quite narrow.
+    // EDOM is one of the few defined codes.
+    let description = String(describing: CError(rawValue: errorCode))
+    #expect(!description.isEmpty)
+    description.withCString { description in
+      #expect(0 == strcmp(strerror(errorCode), description))
+    }
+  }
+}

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -91,13 +91,16 @@ struct SwiftPMTests {
     #expect(!testFilter(test3))
   }
 
-  @Test("--xunit-output argument")
-  func xunitOutput() throws {
+  @Test("--xunit-output argument (bad path)")
+  func xunitOutputWithBadPath() {
     // Test that a bad path produces an error.
     #expect(throws: CError.self) {
       _ = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--xunit-output", "/nonexistent/path/we/cannot/write/to"])
     }
+  }
 
+  @Test("--xunit-output argument (writes to file)")
+  func xunitOutputIsWrittenToFile() throws {
     // Test that a file is opened when requested. Testing of the actual output
     // occurs in EventRecorderTests.
     let temporaryFileURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: false)


### PR DESCRIPTION
This PR implements the `--xunit-output` option when using SwiftPM. Note that internally, the code refers to JUnit rather than xUnit: that's because the format produced by XCTest and SwiftPM today does not _not_ conform to the xUnit schema(s) described at https://www.xunit.org, but rather are a variant of the (schema-less?) JUnit format.

This change renames `Event.Recorder` to `Event.ConsoleOutputRecorder` and adds `Event.JUnitXMLRecorder`. It adds a protocol, `EventRecorder` (remember that protocols cannot be nested in types, so no dot) to which both of these types conform, although that's a formality only as we are not doing anything generic over recorder instances.

If the user specifies `--xunit-output` when calling into `swift test`, we open a file (using good ol' `fopen()`.) Our first official use of a non-copyable type is here (hooray!) as we use one to box the resulting file handle and ensure we call `fclose()` after tests finish running. We do **not** use Foundation's `FileHandle` for this purpose because, although it has the right ownership semantics, it does not expose API for creating _new_ files, only for opening existing ones.

`fopen()` can of course fail, so we now need to potentially throw a C error code. I've added an internal `CError` type to represent them. We're not using `POSIXError` here because it's a Foundation dependency, but also because it's possible for `errno` to be set to a value that is not representable as an instance of `POSIXErrorCode`, which is a closed enumeration.

> [!NOTE]
> Without changes (TBD) in swift-package-manager, using `--xunit-output` when running _both_ swift-testing and XCTest tests will result in one library overwriting the other's output. The work to resolve that will need to take place on the SwiftPM side.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Resolves rdar://118199250.
