### PR TITLE
Add an `index` property to `Test.ParameterInfo`

### DIFF
--- a/Sources/Testing/Test+Macro.swift
+++ b/Sources/Testing/Test+Macro.swift
@@ -172,6 +172,19 @@ extension Test {
   }
 }
 
+extension [Test.__ParameterInfo] {
+  /// An array of ``Test/ParameterInfo`` values based on this array of parameter
+  /// tuples.
+  ///
+  /// This conversion derives the value of the `index` property of the resulting
+  /// parameter instances from the position of the tuple in the original array.
+  fileprivate var parameters: [Test.ParameterInfo] {
+    enumerated().map { index, parameter in
+      Test.ParameterInfo(index: index, firstName: parameter.firstName, secondName: parameter.secondName)
+    }
+  }
+}
+
 // MARK: - @Test(arguments:)
 
 /// This macro declaration is necessary to help the compiler disambiguate
@@ -226,12 +239,11 @@ extension Test {
     traits: [any TestTrait],
     arguments collection: C,
     sourceLocation: SourceLocation,
-    parameters: [__ParameterInfo],
+    parameters paramTuples: [__ParameterInfo],
     testFunction: @escaping @Sendable (C.Element) async throws -> Void
   ) -> Self where C: Collection & Sendable, C.Element: Sendable {
     let caseGenerator = Case.Generator(arguments: collection, testFunction: testFunction)
-    let parameters = parameters.map(ParameterInfo.init)
-    return Self(name: testFunctionName, displayName: displayName, traits: traits, sourceLocation: sourceLocation, containingType: containingType, xcTestCompatibleSelector: xcTestCompatibleSelector, testCases: caseGenerator, parameters: parameters)
+    return Self(name: testFunctionName, displayName: displayName, traits: traits, sourceLocation: sourceLocation, containingType: containingType, xcTestCompatibleSelector: xcTestCompatibleSelector, testCases: caseGenerator, parameters: paramTuples.parameters)
   }
 }
 
@@ -354,12 +366,11 @@ extension Test {
     traits: [any TestTrait],
     arguments collection1: C1, _ collection2: C2,
     sourceLocation: SourceLocation,
-    parameters: [__ParameterInfo],
+    parameters paramTuples: [__ParameterInfo],
     testFunction: @escaping @Sendable (C1.Element, C2.Element) async throws -> Void
   ) -> Self where C1: Collection & Sendable, C1.Element: Sendable, C2: Collection & Sendable, C2.Element: Sendable {
     let caseGenerator = Case.Generator(arguments: collection1, collection2, testFunction: testFunction)
-    let parameters = parameters.map(ParameterInfo.init)
-    return Self(name: testFunctionName, displayName: displayName, traits: traits, sourceLocation: sourceLocation, containingType: containingType, xcTestCompatibleSelector: xcTestCompatibleSelector, testCases: caseGenerator, parameters: parameters)
+    return Self(name: testFunctionName, displayName: displayName, traits: traits, sourceLocation: sourceLocation, containingType: containingType, xcTestCompatibleSelector: xcTestCompatibleSelector, testCases: caseGenerator, parameters: paramTuples.parameters)
   }
 
   /// Create an instance of ``Test`` for a parameterized function.
@@ -374,14 +385,13 @@ extension Test {
     traits: [any TestTrait],
     arguments zippedCollections: Zip2Sequence<C1, C2>,
     sourceLocation: SourceLocation,
-    parameters: [__ParameterInfo],
+    parameters paramTuples: [__ParameterInfo],
     testFunction: @escaping @Sendable (C1.Element, C2.Element) async throws -> Void
   ) -> Self where C1: Collection & Sendable, C1.Element: Sendable, C2: Collection & Sendable, C2.Element: Sendable {
     let caseGenerator = Case.Generator(arguments: zippedCollections) {
       try await testFunction($0, $1)
     }
-    let parameters = parameters.map(ParameterInfo.init)
-    return Self(name: testFunctionName, displayName: displayName, traits: traits, sourceLocation: sourceLocation, containingType: containingType, xcTestCompatibleSelector: xcTestCompatibleSelector, testCases: caseGenerator, parameters: parameters)
+    return Self(name: testFunctionName, displayName: displayName, traits: traits, sourceLocation: sourceLocation, containingType: containingType, xcTestCompatibleSelector: xcTestCompatibleSelector, testCases: caseGenerator, parameters: paramTuples.parameters)
   }
 }
 

--- a/Sources/Testing/Test.Case.swift
+++ b/Sources/Testing/Test.Case.swift
@@ -65,6 +65,10 @@ extension Test {
   /// obtain the arguments of a particular ``Test/Case`` paired with their
   /// corresponding parameters, use ``Test/Case/arguments(pairedWith:)``.
   public struct ParameterInfo: Sendable {
+    /// The zero-based index of this parameter within its associated test's
+    /// parameter list.
+    public var index: Int
+
     /// The first name of this parameter.
     public var firstName: String
 

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -362,6 +362,7 @@ struct MiscellaneousTests {
       let parameters = try #require(test.parameters)
       #expect(parameters.count == 1)
       let firstParameter = try #require(parameters.first)
+      #expect(firstParameter.index == 0)
       #expect(firstParameter.firstName == "i")
       #expect(firstParameter.secondName == nil)
     } catch {}
@@ -371,9 +372,11 @@ struct MiscellaneousTests {
       let parameters = try #require(test.parameters)
       #expect(parameters.count == 2)
       let firstParameter = try #require(parameters.first)
+      #expect(firstParameter.index == 0)
       #expect(firstParameter.firstName == "i")
       #expect(firstParameter.secondName == nil)
       let secondParameter = try #require(parameters.last)
+      #expect(secondParameter.index == 1)
       #expect(secondParameter.firstName == "j")
       #expect(secondParameter.secondName == "k")
     } catch {}
@@ -436,7 +439,7 @@ struct MiscellaneousTests {
     let monomorphicTestFunctionParameters = try #require(monomorphicTestFunction.parameters)
     #expect(monomorphicTestFunctionParameters.isEmpty)
 
-    let parameterizedTestFunction = Test(arguments: 0 ..< 100, parameters: [Test.ParameterInfo(firstName: "i")]) { _ in }
+    let parameterizedTestFunction = Test(arguments: 0 ..< 100, parameters: [Test.ParameterInfo(index: 0, firstName: "i")]) { _ in }
     #expect(parameterizedTestFunction.isParameterized)
     let parameterizedTestFunctionTestCases = try #require(parameterizedTestFunction.testCases)
     #expect(parameterizedTestFunctionTestCases.underestimatedCount == 100)
@@ -446,8 +449,8 @@ struct MiscellaneousTests {
     #expect(parameterizedTestFunctionFirstParameter.firstName == "i")
 
     let parameterizedTestFunction2 = Test(arguments: 0 ..< 100, 0 ..< 100, parameters: [
-      Test.ParameterInfo(firstName: "i"),
-      Test.ParameterInfo(firstName: "j", secondName: "value"),
+      Test.ParameterInfo(index: 0, firstName: "i"),
+      Test.ParameterInfo(index: 1, firstName: "j", secondName: "value"),
     ]) { _, _ in }
     #expect(parameterizedTestFunction2.isParameterized)
     let parameterizedTestFunction2TestCases = try #require(parameterizedTestFunction2.testCases)

--- a/Tests/TestingTests/Test.CaseTests.swift
+++ b/Tests/TestingTests/Test.CaseTests.swift
@@ -17,7 +17,7 @@ struct Test_CaseTests {
     @Test("Single parameter")
     func singleParameter() throws {
       let testCase = Test.Case(arguments: ["value"]) {}
-      let pairedArguments = Array(testCase.arguments(pairedWith: [Test.ParameterInfo(firstName: "foo")]))
+      let pairedArguments = Array(testCase.arguments(pairedWith: [Test.ParameterInfo(index: 0, firstName: "foo")]))
       #expect(pairedArguments.count == 1)
 
       let (parameter, opaqueArgument) = try #require(pairedArguments.first)
@@ -33,8 +33,8 @@ struct Test_CaseTests {
         123,
       ]) {}
       let pairedArguments = Array(testCase.arguments(pairedWith: [
-        Test.ParameterInfo(firstName: "foo"),
-        Test.ParameterInfo(firstName: "bar"),
+        Test.ParameterInfo(index: 0, firstName: "foo"),
+        Test.ParameterInfo(index: 1, firstName: "bar"),
       ]))
       #expect(pairedArguments.count == 2)
 
@@ -55,7 +55,7 @@ struct Test_CaseTests {
     @Test("One-value tuple parameter")
     func oneValueTupleParameter() throws {
       let testCase = Test.Case(arguments: [("value")]) {}
-      let pairedArguments = Array(testCase.arguments(pairedWith: [Test.ParameterInfo(firstName: "foo")]))
+      let pairedArguments = Array(testCase.arguments(pairedWith: [Test.ParameterInfo(index: 0, firstName: "foo")]))
       #expect(pairedArguments.count == 1)
 
       let (parameter, opaqueArgument) = try #require(pairedArguments.first)
@@ -68,8 +68,8 @@ struct Test_CaseTests {
     func twoValueTupleParameter() throws {
       let testCase = Test.Case(arguments: [("value", 123)]) {}
       let pairedArguments = Array(testCase.arguments(pairedWith: [
-        Test.ParameterInfo(firstName: "foo"),
-        Test.ParameterInfo(firstName: "bar"),
+        Test.ParameterInfo(index: 0, firstName: "foo"),
+        Test.ParameterInfo(index: 1, firstName: "bar"),
       ]))
       #expect(pairedArguments.count == 2)
 


### PR DESCRIPTION
Add an `index` property to `Test.ParameterInfo` containing the index of the parameter within its associated test function's parameter list.

### Motivation:

Parameterized test functions can include multiple parameters, and like any Swift function, the names of those parameters may be repeated. When looking at one `Test.ParameterInfo` parameter in isolation, it can be useful to know what index the parameter is, to distinguish it from other parameters which may have the same name.

### Modifications:

- Add `index` to `Test.Parameter`
- Adjust callers to derive the index from macro-expanded code based on position in array.

### Checklist:

- [X] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [X] If public symbols are renamed or modified, DocC references should be updated.
