### PR TITLE
Testing: fix Windows specific code for application data

### DIFF
--- a/Sources/Testing/Traits/Tag.Color+Loading.swift
+++ b/Sources/Testing/Traits/Tag.Color+Loading.swift
@@ -36,7 +36,8 @@ private var _homeDirectoryPath: String? {
 /// The path to the current user's App Data directory, if known.
 private var _appDataDirectoryPath: String? {
   var appDataDirectoryPath: PWSTR? = nil
-  if S_OK == SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, NULL, &appDataDirectoryPath), let appDataDirectoryPath {
+  var FOLDERID_LocalAppData = FOLDERID_LocalAppData
+  if S_OK == SHGetKnownFolderPath(&FOLDERID_LocalAppData, 0, nil, &appDataDirectoryPath), let appDataDirectoryPath {
     defer {
       CoTaskMemFree(appDataDirectoryPath)
     }


### PR DESCRIPTION
The parameter is expected to be `KNOWNFOLDERID` which is a `Optional<UnsafePointer<GUID>>`.  Additionally, correct the spelling of `NULL` to `nil`.  This allows the target to build on Windows.