### PR TITLE
build: ignore `TestingMacrosTest` on Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -100,7 +100,7 @@ let package = Package(
   cxxLanguageStandard: .cxx20
 )
 
-// https://github.com/apple/swift-package-manager/issues/6367
+// BUG: swift-package-manager-#6367
 #if !os(Windows)
 package.targets.append(contentsOf: [
   .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -76,14 +76,6 @@ let package = Package(
         .unsafeFlags(["-Xfrontend", "-allowable-client", "-Xfrontend", "TestingMacrosTests"]),
       ]
     ),
-    .testTarget(
-      name: "TestingMacrosTests",
-      dependencies: [
-        "Testing",
-        "TestingMacros",
-      ],
-      swiftSettings: .packageSettings
-    ),
 
     // "Support" targets: These contain C family code and are used exclusively
     // by other targets above, not directly included in product libraries.
@@ -107,6 +99,20 @@ let package = Package(
 
   cxxLanguageStandard: .cxx20
 )
+
+// https://github.com/apple/swift-package-manager/issues/6367
+#if !os(Windows)
+package.targets.append(contentsOf: [
+  .testTarget(
+    name: "TestingMacrosTests",
+    dependencies: [
+      "Testing",
+      "TestingMacros",
+    ],
+    swiftSettings: .packageSettings
+  )
+])
+#endif
 
 extension Array where Element == PackageDescription.SwiftSetting {
   /// Settings intended to be applied to every Swift target in this package.


### PR DESCRIPTION
This relies on symbolic renaming which is not available on Windows. This allows us to build the test suite on Windows.