### PR TITLE
Simplify how we filter out hidden tests.

### DIFF
--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -193,10 +193,6 @@ func configurationForSwiftPMEntryPoint(withArguments args: [String]) throws -> C
       }
     }
   }
-  filters.append { test in
-    // Don't run the fixture tests in the testing library's own test targets.
-    !test.isHidden
-  }
   configuration.testFilter = { [filters] test in
     filters.allSatisfy { filter in
       filter(test)

--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -122,23 +122,6 @@ extension Runner.Plan {
     }
   }
 
-  /// Determine if a test is included in the selected test IDs, if any are
-  /// configured.
-  ///
-  /// - Parameters:
-  ///   - test: The test to query.
-  ///   - filter: The filter to decide if the test is included.
-  ///
-  /// - Returns: Whether or not the specified test is selected. If
-  ///   `selectedTests` is `nil`, `test` is considered selected if it is not
-  ///   hidden.
-  private static func _isTestIncluded(_ test: Test, using filter: Configuration.TestFilter?) -> Bool {
-    guard let filter else {
-      return !test.isHidden
-    }
-    return filter(test)
-  }
-
   /// Construct a graph of runner plan steps for the specified tests.
   ///
   /// - Parameters:
@@ -176,7 +159,7 @@ extension Runner.Plan {
     // zip() near the end of the function.
     testGraph = testGraph.mapValues { test in
       test.flatMap { test in
-        _isTestIncluded(test, using: configuration.testFilter) ? test : nil
+        configuration.testFilter(test) ? test : nil
       }
     }
 

--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -213,7 +213,7 @@ public enum XCTestScaffold: Sendable {
     if let tags {
       // Check if the test's tags intersect the set of selected tags. If there
       // was a previous filter function, it must also pass.
-      let oldTestFilter = configuration.testFilter ?? { _ in true }
+      let oldTestFilter = configuration.testFilter
       configuration.testFilter = { test in
         !tags.isDisjoint(with: test.tags) && oldTestFilter(test)
       }

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -49,7 +49,7 @@ struct NeverRunTests {
 final class RunnerTests: XCTestCase {
   func testDefaultInit() async throws {
     let runner = await Runner()
-    XCTAssertFalse(runner.tests.contains { $0.isHidden })
+    XCTAssertFalse(runner.tests.contains(where: \.isHidden))
   }
 
   func testTestsProperty() async throws {


### PR DESCRIPTION
Right now, we're checking if tests are hidden in multiple places during execution. This is somewhat inefficient, but it's also error-prone because it means that we can create new code paths that _don't_ correctly check for hidden tests.

This PR consolidates the checks for hidden tests to `Configuration.testFilter` itself. With this change, hidden tests are _always_ filtered out by that filtering function regardless of what value it's set to. The only escape hatch—which we need for our own unit tests only—is to explicitly call the internal-only `Configuration.setTestFilter(toMatch:includeHiddenTests:)` and pass `true`.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
