### PR TITLE
Remove deprecated `Event.Kind.testBypassed` enum case

### DIFF
--- a/Sources/Testing/Events/Event.swift
+++ b/Sources/Testing/Events/Event.swift
@@ -93,12 +93,6 @@ public struct Event: Sendable {
     /// available from this event's ``Event/testID`` property.
     case testSkipped(_ skipInfo: SkipInfo)
 
-#if !SWIFT_PACKAGE
-    @_documentation(visibility: private)
-    @available(*, deprecated, renamed: "testSkipped")
-    case testBypassed(_ bypassInfo: BypassInfo)
-#endif
-
     /// A step in the runner plan ended.
     ///
     /// - Parameters:

--- a/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
@@ -593,12 +593,6 @@ extension Event.ConsoleOutputRecorder: EventRecorder {
         return "\(symbol) Test \(testName) skipped.\n"
       }
 
-#if !SWIFT_PACKAGE
-    case .testBypassed:
-      // Deprecated, replaced by `.testSkipped` above.
-      break
-#endif
-
     case .expectationChecked:
       // Suppress events of this kind from output as they are not generally
       // interesting in human-readable output.


### PR DESCRIPTION
This removes an earlier spelling of the enum case `Event.Kind.testSkipped` which is no longer used and can be safely removed.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
