### PR TITLE
Avoid runtime casts to parameterized protocol types, which require newer OS versions

### DIFF
--- a/Sources/Testing/Test+Macro.swift
+++ b/Sources/Testing/Test+Macro.swift
@@ -113,7 +113,7 @@ extension Test {
     sourceLocation: SourceLocation
   ) -> Self {
     let typeName = _typeName(containingType, qualified: false)
-    return Self(name: typeName, displayName: displayName, traits: traits, sourceLocation: sourceLocation, containingType: containingType, testCases: nil)
+    return Self(name: typeName, displayName: displayName, traits: traits, sourceLocation: sourceLocation, containingType: containingType)
   }
 }
 

--- a/Sources/Testing/Test.Case.swift
+++ b/Sources/Testing/Test.Case.swift
@@ -96,12 +96,3 @@ extension Test {
     public var secondName: String?
   }
 }
-
-/// A type-erased protocol describing a sequence of ``Test/Case`` instances.
-///
-/// This protocol is necessary because it is not currently possible to express
-/// `Sequence<Test.Case> & Sendable` as an existential (`any`)
-/// ([96960993](rdar://96960993)). It is also not possible to have a value of
-/// an underlying generic sequence type without specifying its generic
-/// parameters.
-protocol TestCases: Sequence<Test.Case> & Sendable {}


### PR DESCRIPTION
This fixes a build failure seen when attempting to build for macOS/iOS versions older than 13.0/16.0, respectively, which was introduced in #104. This introduces a type-erasing wrapper, which fixes the failure and also improves the `Test.testCases` derived property by allowing it to use `some` instead of `any` and further constraining the return type to `Sendable`.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
