### PR TITLE
Remove synthesized `@available(*, unavailable)` attributes from test types.

### DIFF
--- a/Sources/TestingMacros/SuiteDeclarationMacro.swift
+++ b/Sources/TestingMacros/SuiteDeclarationMacro.swift
@@ -156,12 +156,7 @@ public struct SuiteDeclarationMacro: MemberMacro, PeerMacro, Sendable {
     let enumName = context.makeUniqueName("__🟠$test_container__suite__\(typeName)")
     result.append(
       """
-      #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-      @available(*, unavailable, message: "This type is an implementation detail of the testing library. It cannot be used directly.")
-      @available(*, deprecated)
-      #else
       @available(*, deprecated, message: "This type is an implementation detail of the testing library. Do not use it directly.")
-      #endif
       @frozen public enum \(enumName): Testing.__TestContainer {
         public static var __tests: [Testing.Test] {
           get async {[

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -473,12 +473,7 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
     let enumName = context.makeUniqueName(thunking: functionDecl, withPrefix: "__🟠$test_container__function__")
     result.append(
       """
-      #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-      @available(*, unavailable, message: "This type is an implementation detail of the testing library. It cannot be used directly.")
-      @available(*, deprecated)
-      #else
       @available(*, deprecated, message: "This type is an implementation detail of the testing library. Do not use it directly.")
-      #endif
       @frozen public enum \(enumName): Testing.__TestContainer {
         public static var __tests: [Testing.Test] {
           get async {[


### PR DESCRIPTION
This PR removes the `@available(*, unavailable)` attribute we add to synthesized `__TestContainer`-conforming types. Although we don't intend for these symbols to be usable outside the testing library, when building a test executable instead of a .xctest bundle on Darwin, this attribute causes us to crash with an error cascade:

```
Fatal error: Unavailable code reached
Fatal error: Unavailable code reached
Fatal error: Unavailable code reached
Fatal error: Unavailable code reached
Fatal error: Unavailable code reached
Fatal error: Unavailable code reached
error: Exited with unexpected signal code 5
error: ExitCode(rawValue: 1)
```

Darwin now behaves the same as Linux/etc. here, which avoids the fatal error.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
