### PR TITLE
Fix a build warning in the git status plugin.

### DIFF
--- a/Sources/GitStatus/main.swift
+++ b/Sources/GitStatus/main.swift
@@ -56,17 +56,13 @@ func _runGit(passing arguments: String..., readingUpToCount maxOutputCount: Int)
   defer {
     process.terminate()
   }
-  if #available(macOS 10.15.4, *) {
-    guard let output = try? stdoutPipe.fileHandleForReading.read(upToCount: maxOutputCount) else {
-      return nil
-    }
-    return String(data: output, encoding: .utf8)
+
+  let output = if #available(macOS 10.15.4, *) {
+    try? stdoutPipe.fileHandleForReading.read(upToCount: maxOutputCount)
   } else {
-    guard let output = try? stdoutPipe.fileHandleForReading.readData(ofLength: maxOutputCount) else {
-      return nil
-    }
-    return String(data: output, encoding: .utf8)
+    stdoutPipe.fileHandleForReading.readData(ofLength: maxOutputCount)
   }
+  return output.flatMap { String(data: $0, encoding: .utf8) }
 #else
   return nil
 #endif


### PR DESCRIPTION
 #102 introduced a warning when building the GitStatus executable, which we use to get repo information during building:

> [!WARNING]
> ```
> swift-testing/Sources/GitStatus/main.swift:65:24: warning: no calls to throwing functions occur within 'try' expression
>     guard let output = try? stdoutPipe.fileHandleForReading.readData(ofLength: maxOutputCount) else {
>                        ^
> ```

This PR resolves the warning.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
