### PR TITLE
Work around a compiler regression on main.

### DIFF
--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -18,7 +18,9 @@ import Foundation
 import FoundationXML
 #endif
 
+#if FIXED_118452948
 @Suite("EventRecorder Tests")
+#endif
 struct EventRecorderTests {
   final class Stream: TextOutputStream, Sendable {
     let buffer = Locked<String>(wrappedValue: "")


### PR DESCRIPTION
This PR works around a compiler regression (tracked as rdar://118452948) on the main-branch toolchain.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
