### PR TITLE
Tweaks to some feature conditionals.

### DIFF
--- a/Sources/Testing/Events/Clock.swift
+++ b/Sources/Testing/Events/Clock.swift
@@ -71,9 +71,9 @@ extension SuspendingClock.Instant {
   }
 }
 
-#if !SWT_NO_UTC_CLOCK
 @_spi(ExperimentalEventHandling)
 extension Test.Clock.Instant {
+#if !SWT_NO_UTC_CLOCK
   /// The duration since 1970 represented by this instance as a tuple of seconds
   /// and attoseconds.
   ///
@@ -93,6 +93,7 @@ extension Test.Clock.Instant {
   public var durationSince1970: Duration {
     Duration(wall)
   }
+#endif
 
   /// Get the number of nanoseconds from this instance to another.
   ///
@@ -110,7 +111,6 @@ extension Test.Clock.Instant {
     return otherNanoseconds - selfNanoseconds
   }
 }
-#endif
 
 // MARK: - Sleeping
 

--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -137,6 +137,7 @@ func configurationForSwiftPMEntryPoint(withArguments args: [String]) throws -> C
     configuration.isParallelizationEnabled = true
   }
 
+#if !SWT_NO_FILE_IO
   // XML output
   if let xunitOutputIndex = args.firstIndex(of: "--xunit-output"), xunitOutputIndex < args.endIndex {
     let xunitOutputPath = args[args.index(after: xunitOutputIndex)]
@@ -167,6 +168,7 @@ func configurationForSwiftPMEntryPoint(withArguments args: [String]) throws -> C
       oldEventHandler(event, context)
     }
   }
+#endif
 
   // Filtering
   // NOTE: Regex is not marked Sendable, but because the regexes we use are
@@ -232,6 +234,7 @@ extension [Event.ConsoleOutputRecorder.Option] {
   static var forStandardError: Self {
     var result = Self()
 
+#if !SWT_NO_FILE_IO
     let useANSIEscapeCodes = _standardErrorSupportsANSIEscapeCodes
     if useANSIEscapeCodes {
       result.append(.useANSIEscapeCodes)
@@ -263,10 +266,12 @@ extension [Event.ConsoleOutputRecorder.Option] {
     if let tagColors = try? loadTagColors() {
       result.append(.useTagColors(tagColors))
     }
+#endif
 
     return result
   }
 
+#if !SWT_NO_FILE_IO
   /// Whether or not the current process's standard error stream is capable of
   /// accepting and rendering ANSI escape codes.
   private static var _standardErrorSupportsANSIEscapeCodes: Bool {
@@ -325,4 +330,5 @@ extension [Event.ConsoleOutputRecorder.Option] {
     true
 #endif
   }
+#endif
 }

--- a/Sources/Testing/Traits/Tag.Color+Loading.swift
+++ b/Sources/Testing/Traits/Tag.Color+Loading.swift
@@ -14,7 +14,7 @@ private import TestingInternals
 private import Foundation
 #endif
 
-#if !SWT_NO_TAG_COLORS
+#if !SWT_NO_FILE_IO
 #if os(macOS) || (os(iOS) && targetEnvironment(macCatalyst)) || os(Linux)
 /// The path to the current user's home directory, if known.
 private var _homeDirectoryPath: String? {
@@ -69,7 +69,6 @@ var swiftTestingDirectoryPath: String {
 #endif
   return ""
 }
-#endif
 
 /// Read tag colors out of the file `"tag-colors.json"` in a given directory.
 ///
@@ -88,7 +87,6 @@ var swiftTestingDirectoryPath: String {
 /// string values and the values represent tag colors. For a list of the
 /// supported formats for tag colors in this dictionary, see <doc:AddingTags>.
 func loadTagColors(fromFileInDirectoryAtPath swiftTestingDirectoryPath: String = swiftTestingDirectoryPath) throws -> [Tag: Tag.Color] {
-#if !SWT_NO_TAG_COLORS && canImport(Foundation)
   // Find the path to the tag-colors.json file and try to load its contents.
   let tagColorsURL = URL(fileURLWithPath: swiftTestingDirectoryPath, isDirectory: true)
     .appendingPathComponent("tag-colors.json", isDirectory: false)
@@ -103,7 +101,5 @@ func loadTagColors(fromFileInDirectoryAtPath swiftTestingDirectoryPath: String =
   // as an actual tag color, so we have a step here that filters it.
   return try JSONDecoder().decode([Tag: Tag.Color?].self, from: tagColorsData)
     .compactMapValues { $0 }
-#else
-  []
-#endif
 }
+#endif

--- a/Tests/TestingTests/Traits/TagListTests.swift
+++ b/Tests/TestingTests/Traits/TagListTests.swift
@@ -95,7 +95,7 @@ struct TagListTests {
     #expect(tagSourceCode.contains { String(describing: $0) == "Tag.functionCall(\"abc\")" })
   }
 
-#if !SWT_NO_TAG_COLORS && canImport(Foundation)
+#if !SWT_NO_FILE_IO
   @Test(
     "Colors are read from disk",
     .tags("alpha", "beta", "gamma", "delta", .namedConstant)


### PR DESCRIPTION
This PR replaces `SWT_NO_TAG_COLORS` with `SWT_NO_FILE_IO` and applies that conditional elsewhere in the package where we perform file I/O. It also fixes `!SWT_NO_UTC_CLOCK` gating availability of `Test.Clock.Instant.nanoseconds(until:)`, which was not intentional.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
