### PR TITLE
Update Getting Started docs to use Swift main branch features

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,23 +59,11 @@ and install a toolchain.
 
 #### Installing a toolchain
 
-<!--
-  - Bug: A compiler bug in the Swift main branch is temporarily preventing its
-    use with the testing library. ([swift-#69096](https://github.com/apple/swift/issues/69096))
--->
-
-<!--
 1. Download a toolchain. A recent **development snapshot** toolchain is required
    to build the testing library. Visit
    [swift.org](https://www.swift.org/download/#trunk-development-main) and
    download the most recent toolchain from the section titled
    **Snapshots — Trunk Development (main)**.
--->
-
-1. A recent **Swift 5.10 development snapshot** toolchain is required to build
-   the testing library. Visit [swift.org](https://www.swift.org/download/#swift-510-development)
-   to download and install a toolchain from the section titled
-   **Snapshots — Swift 5.10 Development**.
 
    Be aware that development snapshot toolchains are not intended for day-to-day
    development and may contain defects that affect the programs built with them.

--- a/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
+++ b/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
@@ -17,12 +17,12 @@ Start running tests in a new or existing XCTest-based test target.
 
 ## Overview
 
-The testing library is integrated with Swift Package Manager's `swift test`
-command and can be used to write and run tests alongside, or in place of,
-tests written using XCTest.
+The testing library has experimental integration with Swift Package Manager's
+`swift test` command and can be used to write and run tests alongside, or in
+place of, tests written using XCTest. This document describes how to start using
+the testing library to write and run tests.
 
-This document describes how to start using the testing library to write and run
-tests. To learn how to contribute to the testing library itself, see
+To learn how to contribute to the testing library itself, see
 [Contributing to `swift-testing`](https://github.com/apple/swift-testing/blob/main/CONTRIBUTING.md).
 
 ### Downloading a development toolchain

--- a/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
+++ b/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
@@ -17,33 +17,20 @@ Start running tests in a new or existing XCTest-based test target.
 
 ## Overview
 
-The testing library is not (yet) integrated into Swift Package Manager, but a
-temporary mechanism is provided for developers who want to start using it with
-their Swift packages.
+The testing library is integrated with Swift Package Manager's `swift test`
+command and can be used to write and run tests alongside, or in place of,
+tests written using XCTest.
 
-- Warning: This functionality is provided temporarily to aid in integrating the
-  testing library with existing tools such as Swift Package Manager. It will be
-  removed in a future release.
-
-To learn how to contribute to the testing library itself, see
+This document describes how to start using the testing library to write and run
+tests. To learn how to contribute to the testing library itself, see
 [Contributing to `swift-testing`](https://github.com/apple/swift-testing/blob/main/CONTRIBUTING.md).
 
 ### Downloading a development toolchain
 
-A recent **Swift 5.10 development snapshot** toolchain is required to use the
-testing library. Visit [swift.org](https://www.swift.org/download/#swift-510-development)
-to download and install a toolchain from the section titled
-**Snapshots — Swift 5.10 Development**.
-
-@Comment {
-  - Bug: A compiler bug in the Swift main branch is temporarily preventing its
-    use with the testing library. ([swift-#69096](https://github.com/apple/swift/issues/69096))
-}
-
-<!--A recent **development snapshot** toolchain is required to use the testing
+A recent **development snapshot** toolchain is required to use the testing
 library. Visit [swift.org](https://www.swift.org/download/#trunk-development-main)
 to download and install a toolchain from the section titled
-**Snapshots — Trunk Development (main)**.-->
+**Snapshots — Trunk Development (main)**.
 
 Be aware that development snapshot toolchains are not intended for day-to-day
 development and may contain defects that affect the programs built with them.
@@ -81,22 +68,6 @@ Then, add the testing library as a dependency of your existing test target:
 )
 ```
 
-### Adding test scaffolding
-
-Add a new Swift source file to your package's test target named
-"Scaffolding.swift". Add the following to it:
-
-```swift
-import XCTest
-import Testing
-
-final class AllTests: XCTestCase {
-  func testAll() async {
-    await XCTestScaffold.runAllTests(hostedBy: self)
-  }
-}
-```
-
 You can now add additional Swift source files to your package's test target that
 contain those tests, written using the testing library, that you want to run
 when you invoke `swift test` from the command line or click the
@@ -119,17 +90,56 @@ export TOOLCHAINS=swift
 
 In Xcode, open the **Xcode** menu, then the Toolchains submenu, and select the
 development toolchain from the list of toolchains presented to you&mdash;it will
-<!--be presented with a name such as "Swift Development Toolchain 2023-01-01 (a)".-->
-be presented with a name such as "Swift 5.10 Development Snapshot 2023-01-01 (a)".
+be presented with a name such as "Swift Development Toolchain 2023-01-01 (a)".
 
 ### Running tests
 
+Navigate to the directory containing your package and run the following command:
+
+```sh
+swift test --enable-experimental-swift-testing
+```
+
+Swift Package Manager will build and run a test target that uses the testing
+library as well as a separate target that uses XCTest. To only run tests written
+using the testing library, pass `--disable-xctest` as an additional argument to
+the `swift test` command.
+
+#### Swift 5.10
+
+As of Swift 5.10, the testing library is not integrated into Swift Package
+Manager, but a temporary mechanism is provided for developers who want to start
+using it with their Swift packages and the Swift 5.10 toolchain.
+
+- Warning: This functionality is provided temporarily to aid in integrating the
+testing library with existing tools such as Swift Package Manager. It will be
+removed in a future release.
+
+To use the testing library with Swift 5.10, add a new Swift source
+file to your package's test target named "Scaffolding.swift". Add the following
+code to it:
+
+```swift
+import XCTest
+import Testing
+
+final class AllTests: XCTestCase {
+  func testAll() async {
+    await XCTestScaffold.runAllTests(hostedBy: self)
+  }
+}
+```
+
 Navigate to the directory containing your package, and either run `swift test`
 from the command line or click the Product&nbsp;&rarr;&nbsp;Test menu item in
-Xcode. You're done!
+Xcode.
 
 Tests will run embedded in an `XCTestCase`-based test function named
 `testAll()`. If a test fails, `testAll()` will report the failure as its own.
+
+#### Swift 5.9 or earlier
+
+The testing library does not support Swift 5.9 or earlier.
 
 ## Topics
 


### PR DESCRIPTION
We now have functional support for swift-testing in Swift Package Manager (as of https://github.com/apple/swift-package-manager/pull/7047). We should update our documentation:

- Point developers to the main branch instead of 5.10 again;
- Show developers how to invoke `swift test` in a way that triggers swift-testing; and
- Show developers how to use `XCTestScaffold` _only_ when using an older toolchain (with the appropriate caveats and nuances emphasized.)

Resolves #126.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
