### PR TITLE
(Tests only) Conditionalize imports of Foundation and always import TestingInternals as private.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,10 +43,7 @@ let package = Package(
         "TestingInternals",
         "TestingMacros",
       ],
-      swiftSettings: .packageSettings + [
-        .enableExperimentalFeature("AccessLevelOnImport"),
-        .enableUpcomingFeature("InternalImportsByDefault"),
-      ],
+      swiftSettings: .packageSettings,
       plugins: ["GitStatusPlugin"]
     ),
     .testTarget(
@@ -133,6 +130,8 @@ extension Array where Element == PackageDescription.SwiftSetting {
       ]),
       .enableExperimentalFeature("StrictConcurrency"),
       .enableUpcomingFeature("ExistentialAny"),
+      .enableExperimentalFeature("AccessLevelOnImport"),
+      .enableUpcomingFeature("InternalImportsByDefault"),
       .define("SWT_TARGET_OS_APPLE", .when(platforms: [.macOS, .iOS, .macCatalyst, .watchOS, .tvOS, .visionOS])),
     ]
   }

--- a/Tests/TestingTests/BacktraceTests.swift
+++ b/Tests/TestingTests/BacktraceTests.swift
@@ -9,7 +9,9 @@
 //
 
 @testable @_spi(ExperimentalEventHandling) @_spi(ExperimentalTestRunning) import Testing
+#if canImport(Foundation)
 import Foundation
+#endif
 
 struct BacktracedError: Error {}
 
@@ -45,6 +47,7 @@ struct BacktraceTests {
     #expect(Backtrace(forFirstThrowOf: BacktracedError()) == nil)
   }
 
+#if canImport(Foundation)
   @Test("Encoding/decoding")
   func encodingAndDecoding() throws {
     let original = Backtrace.current()
@@ -52,4 +55,5 @@ struct BacktraceTests {
     let copy = try JSONDecoder().decode(Backtrace.self, from: data)
     #expect(original == copy)
   }
+#endif
 }

--- a/Tests/TestingTests/ClockTests.swift
+++ b/Tests/TestingTests/ClockTests.swift
@@ -8,9 +8,11 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if canImport(Foundation)
 import Foundation
+#endif
 @testable @_spi(ExperimentalEventHandling) import Testing
-import TestingInternals
+private import TestingInternals
 
 @Suite("Clock API Tests")
 struct ClockTests {
@@ -121,6 +123,7 @@ struct ClockTests {
     #expect(duration == .nanoseconds(offsetNanoseconds))
   }
 
+#if canImport(Foundation)
   @available(_clockAPI, *)
   @Test("Codable")
   func codable() async throws {
@@ -132,6 +135,7 @@ struct ClockTests {
     #expect(instant == decoded)
     #expect(instant != now)
   }
+#endif
 
   @available(_clockAPI, *)
   @Test("Clock.Instant.nanoseconds(until:) method",

--- a/Tests/TestingTests/DumpTests.swift
+++ b/Tests/TestingTests/DumpTests.swift
@@ -9,7 +9,7 @@
 //
 
 @testable @_spi(InternalDiagnostics) @_spi(ExperimentalTestRunning) import Testing
-import TestingInternals
+private import TestingInternals
 
 // NOTE: The tests in this file are here to exercise Plan.dump(), but they are
 // not intended to actually test that the output is in a particular format since

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -12,9 +12,9 @@
 #if !os(Windows)
 import RegexBuilder
 #endif
-#if SWT_TARGET_OS_APPLE
+#if SWT_TARGET_OS_APPLE && canImport(Foundation)
 import Foundation
-#else
+#elseif canImport(FoundationXML)
 import FoundationXML
 #endif
 
@@ -210,6 +210,7 @@ struct EventRecorderTests {
   }
 #endif
 
+#if canImport(Foundation) || canImport(FoundationXML)
   @Test("JUnitXMLRecorder outputs valid XML")
   func junitXMLIsValid() async throws {
     let stream = Stream()
@@ -236,6 +237,7 @@ struct EventRecorderTests {
       throw error
     }
   }
+#endif
 }
 
 // MARK: - Fixtures

--- a/Tests/TestingTests/EventTests.swift
+++ b/Tests/TestingTests/EventTests.swift
@@ -8,11 +8,14 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if canImport(Foundation)
 import Foundation
+#endif
 @testable @_spi(ExperimentalEventHandling) @_spi(ExperimentalParameterizedTesting) @_spi(ExperimentalSnapshotting) @_spi(ExperimentalTestRunning) import Testing
-import TestingInternals
+private import TestingInternals
 
 struct EventTests {
+#if canImport(Foundation)
   @Test("Event's and Event.Kinds's Codable Conformances",
         arguments: [
           Event.Kind.expectationChecked(
@@ -63,4 +66,5 @@ struct EventTests {
 
     #expect(String(describing: decoded) == String(describing: eventSnapshot))
   }
+#endif
 }

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -9,7 +9,7 @@
 //
 
 @testable @_spi(ExperimentalEventHandling) @_spi(ExperimentalTestRunning) @_spi(ExperimentalSnapshotting) import Testing
-import TestingInternals
+private import TestingInternals
 
 #if canImport(XCTest)
 import XCTest

--- a/Tests/TestingTests/Support/CErrorTests.swift
+++ b/Tests/TestingTests/Support/CErrorTests.swift
@@ -9,7 +9,7 @@
 //
 
 @testable import Testing
-import TestingInternals
+private import TestingInternals
 
 @Suite("CError Tests")
 struct CErrorTests {

--- a/Tests/TestingTests/Support/EnvironmentTests.swift
+++ b/Tests/TestingTests/Support/EnvironmentTests.swift
@@ -9,12 +9,11 @@
 //
 
 @testable import Testing
-import TestingInternals
-import Foundation
+private import TestingInternals
 
 @Suite("Environment Tests")
 struct EnvironmentTests {
-  var name = "SWT_ENVIRONMENT_VARIABLE_\(UUID())"
+  var name = "SWT_ENVIRONMENT_VARIABLE_\(UInt64.random(in: 0 ... .max))"
 
   @Test("Read environment variable")
   func readEnvironmentVariable() throws {

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -9,7 +9,9 @@
 //
 
 @testable @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) import Testing
+#if canImport(Foundation)
 import Foundation
+#endif
 
 @Suite("Swift Package Manager Integration Tests")
 struct SwiftPMTests {
@@ -91,6 +93,7 @@ struct SwiftPMTests {
     #expect(!testFilter(test3))
   }
 
+#if !SWT_NO_FILE_IO
   @Test("--xunit-output argument (bad path)")
   func xunitOutputWithBadPath() {
     // Test that a bad path produces an error.
@@ -115,6 +118,7 @@ struct SwiftPMTests {
     }
     #expect(try temporaryFileURL.checkResourceIsReachable())
   }
+#endif
 
   @Test("list subcommand")
   func list() async throws {


### PR DESCRIPTION
This PR conditionalizes imports of Foundation and always import TestingInternals as private within our own test target. This is necessary because some environments may not have Foundation available during testing, and because the lack of `private` on `import TestingInternals` leads to ambiguity and a build error when our targets are statically linked together.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
