### PR TITLE
Import SwiftSyntax as `public`.

### DIFF
--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 import SwiftSyntaxMacros
 
 /// A protocol containing the common implementation for the expansions of the

--- a/Sources/TestingMacros/SuiteDeclarationMacro.swift
+++ b/Sources/TestingMacros/SuiteDeclarationMacro.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 import SwiftSyntaxMacros
 
 /// A type describing the expansion of the `@Suite` attribute macro.

--- a/Sources/TestingMacros/Support/Additions/DeclGroupSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/DeclGroupSyntaxAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension DeclGroupSyntax {
   /// The type declared or extended by this instance.

--- a/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 import SwiftSyntaxMacros
 
 extension FunctionDeclSyntax {

--- a/Sources/TestingMacros/Support/Additions/TokenSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/TokenSyntaxAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension TokenSyntax {
   /// The text of this instance with all backticks removed.

--- a/Sources/TestingMacros/Support/Additions/TriviaPieceAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/TriviaPieceAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension TriviaPiece {
   /// The number of newline characters represented by this trivia piece.

--- a/Sources/TestingMacros/Support/Additions/TypeSyntaxProtocolAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/TypeSyntaxProtocolAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension TypeSyntaxProtocol {
   /// Whether or not this type is an optional type (`T?`, `Optional<T>`, etc.)

--- a/Sources/TestingMacros/Support/Additions/VersionTupleSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/VersionTupleSyntaxAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension VersionTupleSyntax {
   /// A type describing the major, minor, and patch components of a version

--- a/Sources/TestingMacros/Support/Additions/WithAttributesSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/WithAttributesSyntaxAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 import SwiftSyntaxMacros
 
 extension WithAttributesSyntax {

--- a/Sources/TestingMacros/Support/Argument.swift
+++ b/Sources/TestingMacros/Support/Argument.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 /// A type describing an argument to a function, closure, etc.
 ///

--- a/Sources/TestingMacros/Support/AttributeDiscovery.swift
+++ b/Sources/TestingMacros/Support/AttributeDiscovery.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 import SwiftSyntaxMacros
 
 /// A syntax rewriter that removes leading `Self.` tokens from member access

--- a/Sources/TestingMacros/Support/AvailabilityGuards.swift
+++ b/Sources/TestingMacros/Support/AvailabilityGuards.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 import SwiftSyntaxMacros
 
 /// A structure describing a single platform/version pair from an `@available()`

--- a/Sources/TestingMacros/Support/CommentParsing.swift
+++ b/Sources/TestingMacros/Support/CommentParsing.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 /// Find a common whitespace prefix among all lines in a string and trim it.
 ///

--- a/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
+++ b/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 import SwiftSyntaxMacros
 
 /// The result of parsing the condition argument passed to `#expect()` or

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -9,7 +9,7 @@
 //
 
 import SwiftDiagnostics
-import SwiftSyntax
+public import SwiftSyntax
 import SwiftSyntaxMacros
 
 /// A type describing diagnostic messages emitted by this module's macro during

--- a/Sources/TestingMacros/Support/SourceCodeCapturing.swift
+++ b/Sources/TestingMacros/Support/SourceCodeCapturing.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 /// Get an expression initializing an instance of ``SourceCode`` from an
 /// arbitrary syntax node.

--- a/Sources/TestingMacros/Support/SourceLocationGeneration.swift
+++ b/Sources/TestingMacros/Support/SourceLocationGeneration.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 import SwiftSyntaxMacros
 
 /// Get an expression initializing an instance of ``SourceLocation`` from an

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 import SwiftSyntaxMacros
 
 /// A type describing the expansion of the `@Test` attribute macro.

--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -14,7 +14,7 @@ import Testing
 import SwiftDiagnostics
 import SwiftOperators
 import SwiftParser
-import SwiftSyntax
+public import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -13,7 +13,7 @@ import Testing
 
 import SwiftDiagnostics
 import SwiftParser
-import SwiftSyntax
+public import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 

--- a/Tests/TestingMacrosTests/TestSupport/Parse.swift
+++ b/Tests/TestingMacrosTests/TestSupport/Parse.swift
@@ -13,7 +13,7 @@
 import SwiftDiagnostics
 import SwiftOperators
 import SwiftParser
-import SwiftSyntax
+public import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 import SwiftSyntaxMacroExpansion

--- a/Tests/TestingMacrosTests/UniqueIdentifierTests.swift
+++ b/Tests/TestingMacrosTests/UniqueIdentifierTests.swift
@@ -14,7 +14,7 @@ import Testing
 import SwiftDiagnostics
 import SwiftOperators
 import SwiftParser
-import SwiftSyntax
+public import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 import SwiftSyntaxMacroExpansion


### PR DESCRIPTION
We have adopted the upcoming [access levels on imports](https://github.com/apple/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md) feature in swift-testing. We use some types from the SwiftSyntax module in our macro target (as part of our conformances to the various macro protocols.)

We saw some build failures locally:

```
[...]/Sources/TestingMacros/SuiteDeclarationMacro.swift:28:22: error: static method cannot be declared public because its generic parameter uses an internal type
public static func expansion(
                   ^
 [...]/.build/checkouts/swift-syntax/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift:22:17: note: type declared here
public protocol DeclSyntaxProtocol: SyntaxProtocol {}
                ^
```

We can mark our `import SwiftSyntax` statements as `public` to avoid this issue. This change is only necessary in the macros target (not our tests or the GitStatus plugin), but must occur in every file in that target that imports SwiftSyntax.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
