### PR TITLE
Do not evaluate unavailable test function parameters.

### DIFF
--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -171,7 +171,7 @@ extension Runner {
       }
     }
 
-    if let step = stepGraph.value, case .run = step.action, let testCases = step.test.testCases {
+    if let step = stepGraph.value, case .run = step.action, let testCases = await step.test.testCases {
       try await Test.withCurrent(step.test) {
         try await _withErrorHandling(for: step, sourceLocation: step.test.sourceLocation) {
           try await _runTestCases(testCases, within: step)

--- a/Sources/Testing/Test+Macro.swift
+++ b/Sources/Testing/Test+Macro.swift
@@ -237,7 +237,7 @@ extension Test {
     xcTestCompatibleSelector: __XCTestCompatibleSelector?,
     displayName: String? = nil,
     traits: [any TestTrait],
-    arguments collection: C,
+    arguments collection: @escaping @Sendable () async -> C,
     sourceLocation: SourceLocation,
     parameters paramTuples: [__ParameterInfo],
     testFunction: @escaping @Sendable (C.Element) async throws -> Void
@@ -365,7 +365,7 @@ extension Test {
     xcTestCompatibleSelector: __XCTestCompatibleSelector?,
     displayName: String? = nil,
     traits: [any TestTrait],
-    arguments collection1: C1, _ collection2: C2,
+    arguments collection1: @escaping @Sendable () async -> C1, _ collection2: @escaping @Sendable () async -> C2,
     sourceLocation: SourceLocation,
     parameters paramTuples: [__ParameterInfo],
     testFunction: @escaping @Sendable (C1.Element, C2.Element) async throws -> Void
@@ -388,7 +388,7 @@ extension Test {
     xcTestCompatibleSelector: __XCTestCompatibleSelector?,
     displayName: String? = nil,
     traits: [any TestTrait],
-    arguments collection: C,
+    arguments collection: @escaping @Sendable () async -> C,
     sourceLocation: SourceLocation,
     parameters paramTuples: [__ParameterInfo],
     testFunction: @escaping @Sendable ((E1, E2)) async throws -> Void
@@ -414,7 +414,7 @@ extension Test {
     xcTestCompatibleSelector: __XCTestCompatibleSelector?,
     displayName: String? = nil,
     traits: [any TestTrait],
-    arguments dictionary: Dictionary<Key, Value>,
+    arguments dictionary: @escaping @Sendable () async -> Dictionary<Key, Value>,
     sourceLocation: SourceLocation,
     parameters paramTuples: [__ParameterInfo],
     testFunction: @escaping @Sendable ((Key, Value)) async throws -> Void
@@ -434,7 +434,7 @@ extension Test {
     xcTestCompatibleSelector: __XCTestCompatibleSelector?,
     displayName: String? = nil,
     traits: [any TestTrait],
-    arguments zippedCollections: Zip2Sequence<C1, C2>,
+    arguments zippedCollections: @escaping @Sendable () async -> Zip2Sequence<C1, C2>,
     sourceLocation: SourceLocation,
     parameters paramTuples: [__ParameterInfo],
     testFunction: @escaping @Sendable (C1.Element, C2.Element) async throws -> Void

--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -53,32 +53,6 @@ public struct Test: Sendable {
   /// The source location of this test.
   public var sourceLocation: SourceLocation
 
-  /// The (underestimated) number of iterations that will need to occur during
-  /// testing.
-  ///
-  /// The value of this property is inherently capped at `Int.max`. In practice,
-  /// the number of iterations that can run in a reasonable timespan will be
-  /// significantly lower.
-  ///
-  /// For instances of ``Test`` that represent non-parameterized test functions
-  /// (that is, test functions that do not iterate over a sequence of inputs),
-  /// the value of this property is always `1`. For instances of ``Test`` that
-  /// represent test suite types, the value of this property is always `nil`.
-  ///
-  /// For more information about underestimated counts, see the documentation
-  /// for [`Sequence`](https://developer.apple.com/documentation/swift/array/underestimatedcount-4ggqp).
-  @_spi(ExperimentalParameterizedTesting)
-  public var underestimatedCaseCount: Int? {
-    // NOTE: it is important that we only expose an _underestimated_ count for
-    // two reasons:
-    // 1. If the total number of cases exceeds `.max` due to combinatoric
-    //    complexity, `count` would be too low; and
-    // 2. We reserve the right to support async sequences as input in the
-    //    future, and async sequences do not have `count` properties (but an
-    //    underestimated count of `0` is still technically correct.)
-    testCases?.underestimatedCount
-  }
-
   /// The type containing this test, if any.
   ///
   /// If a test is associated with a free function or static function, the value
@@ -96,12 +70,12 @@ public struct Test: Sendable {
 
   /// Storage for the ``testCases`` property.
   ///
-  /// This use of `UncheckedSendable` and of `AnySequence` is necessary because
-  /// it is not currently possible to express `Sequence<Test.Case> & Sendable`
-  /// as an existential (`any`) ([96960993](rdar://96960993)). It is also not
-  /// possible to have a value of an underlying generic sequence type without
-  /// specifying its generic parameters.
-  private var _testCases: UncheckedSendable<AnySequence<Test.Case>>?
+  /// This use of `AnySequence` is necessary because it is not currently
+  /// possible to express `Sequence<Test.Case> & Sendable` as an existential
+  /// (`any`) ([96960993](rdar://96960993)). It is also not possible to have a
+  /// value of an underlying generic sequence type without specifying its
+  /// generic parameters.
+  private var _testCases: (@Sendable () async -> AnySequence<Test.Case>)?
 
   /// The set of test cases associated with this test, if any.
   ///
@@ -109,9 +83,16 @@ public struct Test: Sendable {
   /// combination of parameterized inputs. For non-parameterized tests, a single
   /// test case is synthesized. For test suite types (as opposed to test
   /// functions), the value of this property is `nil`.
+  ///
+  /// - Warning: The parameterized inputs to a test may have limited
+  ///   availability if the test has the `@available` attribute applied to it.
+  ///   This property does not evaluate availability, and the effect of reading
+  ///   it on a platform where the inputs are unavailable is undefined.
   @_spi(ExperimentalParameterizedTesting)
   public var testCases: (some Sequence<Test.Case> & Sendable)? {
-    _testCases?.rawValue
+    get async {
+      await _testCases?()
+    }
   }
 
   /// Whether or not this test is parameterized.
@@ -140,7 +121,7 @@ public struct Test: Sendable {
   ///
   /// A test suite can be declared using the ``Suite(_:_:)`` macro.
   public var isSuite: Bool {
-    containingType != nil && testCases == nil
+    containingType != nil && _testCases == nil
   }
 
   /// Initialize an instance of this type representing a test suite type.
@@ -175,7 +156,7 @@ public struct Test: Sendable {
     self.sourceLocation = sourceLocation
     self.containingType = containingType
     self.xcTestCompatibleSelector = xcTestCompatibleSelector
-    self._testCases = .init(rawValue: .init(testCases))
+    self._testCases = { await .init(testCases.generate()) }
     self.parameters = parameters
   }
 }

--- a/Sources/TestingMacros/Support/AttributeDiscovery.swift
+++ b/Sources/TestingMacros/Support/AttributeDiscovery.swift
@@ -218,7 +218,10 @@ struct AttributeInfo {
         ArrayElementSyntax(expression: traitExpr)
       }
     }))
-    arguments += otherArguments
+    // TODO: extract arguments: ... here, rather than assuming all "other" arguments are parameterized inputs
+    arguments += otherArguments.map { argument in
+      Argument(label: argument.label, expression: "{ \(argument.expression.trimmed) }")
+    }
     arguments.append(Argument(label: "sourceLocation", expression: sourceLocation))
 
     return LabeledExprListSyntax(arguments)

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -309,41 +309,6 @@ struct MiscellaneousTests {
     await valueGrid.validateCells()
   }
 
-  @Test("Test.underestimatedCaseCount property")
-  func underestimatedCaseCount() async throws {
-    do {
-      let test = try #require(await testFunction(named: "parameterized(i:)", in: NonSendableTests.self))
-      #expect(test.underestimatedCaseCount == FixtureData.zeroUpTo100.count)
-    }
-    do {
-      let test = try #require(await testFunction(named: "parameterized2(i:j:)", in: NonSendableTests.self))
-      #expect(test.underestimatedCaseCount == FixtureData.zeroUpTo100.count * FixtureData.smallStringArray.count)
-    }
-    do {
-      let test = try #require(await testFunction(named: "parameterized(i:)", in: SendableTests.self))
-      #expect(test.underestimatedCaseCount == FixtureData.zeroUpTo100.count)
-    }
-#if !SWT_NO_GLOBAL_ACTORS
-    do {
-      let test = try #require(await testFunction(named: "parameterized(i:)", in: MainActorIsolatedTests.self))
-      #expect(test.underestimatedCaseCount == FixtureData.zeroUpTo100.count)
-    }
-    do {
-      let test = try #require(await testFunction(named: "parameterizedNonisolated(i:)", in: MainActorIsolatedTests.self))
-      #expect(test.underestimatedCaseCount == FixtureData.zeroUpTo100.count)
-    }
-#endif
-
-    do {
-      let thisTest = try #require(await testFunction(named: "succeeds()", in: SendableTests.self))
-      #expect(thisTest.underestimatedCaseCount == 1)
-    }
-    do {
-      let thisTest = try #require(await test(for: SendableTests.self))
-      #expect(thisTest.underestimatedCaseCount == nil)
-    }
-  }
-
   @Test("Test.parameters property")
   func parametersProperty() async throws {
     do {
@@ -429,19 +394,19 @@ struct MiscellaneousTests {
   func parameterizationRelatedProperties() async throws {
     let typeTest = Test.__type(SendableTests.self, displayName: "", traits: [], sourceLocation: .init())
     #expect(!typeTest.isParameterized)
-    #expect(typeTest.testCases == nil)
+    #expect(await typeTest.testCases == nil)
     #expect(typeTest.parameters == nil)
 
     let monomorphicTestFunction = Test {}
     #expect(!monomorphicTestFunction.isParameterized)
-    let monomorphicTestFunctionTestCases = try #require(monomorphicTestFunction.testCases)
+    let monomorphicTestFunctionTestCases = try #require(await monomorphicTestFunction.testCases)
     #expect(monomorphicTestFunctionTestCases.underestimatedCount == 1)
     let monomorphicTestFunctionParameters = try #require(monomorphicTestFunction.parameters)
     #expect(monomorphicTestFunctionParameters.isEmpty)
 
     let parameterizedTestFunction = Test(arguments: 0 ..< 100, parameters: [Test.ParameterInfo(index: 0, firstName: "i")]) { _ in }
     #expect(parameterizedTestFunction.isParameterized)
-    let parameterizedTestFunctionTestCases = try #require(parameterizedTestFunction.testCases)
+    let parameterizedTestFunctionTestCases = try #require(await parameterizedTestFunction.testCases)
     #expect(parameterizedTestFunctionTestCases.underestimatedCount == 100)
     let parameterizedTestFunctionParameters = try #require(parameterizedTestFunction.parameters)
     #expect(parameterizedTestFunctionParameters.count == 1)
@@ -453,7 +418,7 @@ struct MiscellaneousTests {
       Test.ParameterInfo(index: 1, firstName: "j", secondName: "value"),
     ]) { _, _ in }
     #expect(parameterizedTestFunction2.isParameterized)
-    let parameterizedTestFunction2TestCases = try #require(parameterizedTestFunction2.testCases)
+    let parameterizedTestFunction2TestCases = try #require(await parameterizedTestFunction2.testCases)
     #expect(parameterizedTestFunction2TestCases.underestimatedCount == 100 * 100)
     let parameterizedTestFunction2Parameters = try #require(parameterizedTestFunction2.parameters)
     #expect(parameterizedTestFunction2Parameters.count == 2)

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -738,6 +738,7 @@ final class RunnerTests: XCTestCase {
     await fulfillment(of: [testStarted], timeout: 0.0)
   }
 
+#if SWT_TARGET_OS_APPLE
   @Suite(.hidden) struct AvailabilityOfArguments {
     @available(macOS 999.0, iOS 999.0, watchOS 999.0, tvOS 999.0, *)
     struct Arg: Sendable {
@@ -771,6 +772,7 @@ final class RunnerTests: XCTestCase {
     await runTest(for: AvailabilityOfArguments.self, configuration: configuration)
     await fulfillment(of: [suiteStarted, testStarted], timeout: 0.0)
   }
+#endif
 
 #if !SWT_NO_GLOBAL_ACTORS
   @TaskLocal static var isMainActorIsolationEnforced = false

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -738,6 +738,40 @@ final class RunnerTests: XCTestCase {
     await fulfillment(of: [testStarted], timeout: 0.0)
   }
 
+  @Suite(.hidden) struct AvailabilityOfArguments {
+    @available(macOS 999.0, iOS 999.0, watchOS 999.0, tvOS 999.0, *)
+    struct Arg: Sendable {
+      init() {
+        XCTFail("Unexpectedly initialized an instance of \(Self.self)")
+      }
+    }
+
+    @available(macOS 999.0, iOS 999.0, watchOS 999.0, tvOS 999.0, *)
+    @Test(.hidden, arguments: [Arg(), Arg(), Arg()])
+    func f(arg: Arg) {}
+  }
+
+  func testAvailabilityOfArguments() async throws {
+    let suiteStarted = expectation(description: "Test suite started")
+    let testStarted = expectation(description: "Test suite started")
+    testStarted.isInverted = true
+    var configuration = Configuration()
+    configuration.eventHandler = { event, context in
+      switch event.kind {
+      case .testStarted:
+        if true == context.test?.isSuite {
+          suiteStarted.fulfill()
+        } else {
+          testStarted.fulfill()
+        }
+      default:
+        break
+      }
+    }
+    await runTest(for: AvailabilityOfArguments.self, configuration: configuration)
+    await fulfillment(of: [suiteStarted, testStarted], timeout: 0.0)
+  }
+
 #if !SWT_NO_GLOBAL_ACTORS
   @TaskLocal static var isMainActorIsolationEnforced = false
 

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -163,7 +163,7 @@ extension Test {
     testFunction: @escaping @Sendable (C.Element) async throws -> Void
   ) where C: Collection & Sendable, C.Element: Sendable {
     let sourceLocation = SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column)
-    let caseGenerator = Case.Generator(arguments: collection, parameters: parameters, testFunction: testFunction)
+    let caseGenerator = Case.Generator(arguments: { collection }, parameters: parameters, testFunction: testFunction)
     self.init(name: name, displayName: name, traits: traits, sourceLocation: sourceLocation, containingType: nil, testCases: caseGenerator, parameters: parameters)
   }
 
@@ -195,7 +195,7 @@ extension Test {
     testFunction: @escaping @Sendable (C1.Element, C2.Element) async throws -> Void
   ) where C1: Collection & Sendable, C1.Element: Sendable, C2: Collection & Sendable, C2.Element: Sendable {
     let sourceLocation = SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column)
-    let caseGenerator = Case.Generator(arguments: collection1, collection2, parameters: parameters, testFunction: testFunction)
+    let caseGenerator = Case.Generator(arguments: { collection1 }, { collection2 }, parameters: parameters, testFunction: testFunction)
     self.init(name: name, displayName: name, traits: traits, sourceLocation: sourceLocation, containingType: nil, testCases: caseGenerator, parameters: parameters)
   }
 
@@ -222,7 +222,7 @@ extension Test {
     testFunction: @escaping @Sendable ((C1.Element, C2.Element)) async throws -> Void
   ) where C1: Collection & Sendable, C1.Element: Sendable, C2: Collection & Sendable, C2.Element: Sendable {
     let sourceLocation = SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column)
-    let caseGenerator = Case.Generator(arguments: zippedCollections, parameters: parameters, testFunction: testFunction)
+    let caseGenerator = Case.Generator(arguments: { zippedCollections }, parameters: parameters, testFunction: testFunction)
     self.init(name: name, displayName: name, traits: traits, sourceLocation: sourceLocation, containingType: nil, testCases: caseGenerator, parameters: parameters)
   }
 }


### PR DESCRIPTION
This PR causes swift-testing to capture the arguments to parameterized tests as closures (returning sequences) rather than as sequences. These closures are then lazily evaluated during test execution. This has two broad effects:

1. The cost of evaluating these properties is deferred to after the start of a test instead of during the planning stage (a good thing, probably!); and
2. If a test's parameters are unavailable on the current system (due to appropriate `@available` attributes), they are not evaluated, avoiding a crash. This crash would not normally happen in pure Swift code, but can happen when using swift-testing because we go "off the rails" to discover test content at runtime (see Discovery.cpp).

Resolves rdar://118518234.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
