### PR TITLE
Clean up import access levels for latest main toolchain.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -130,8 +130,6 @@ extension Array where Element == PackageDescription.SwiftSetting {
       ]),
       .enableExperimentalFeature("StrictConcurrency"),
       .enableUpcomingFeature("ExistentialAny"),
-      .enableExperimentalFeature("AccessLevelOnImport"),
-      .enableUpcomingFeature("InternalImportsByDefault"),
       .define("SWT_TARGET_OS_APPLE", .when(platforms: [.macOS, .iOS, .macCatalyst, .watchOS, .tvOS, .visionOS])),
     ]
   }

--- a/Sources/Testing/Events/Clock.swift
+++ b/Sources/Testing/Events/Clock.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-private import TestingInternals
+@_implementationOnly import TestingInternals
 
 @_spi(ExperimentalEventHandling)
 extension Test {

--- a/Sources/Testing/Events/TimeValue.swift
+++ b/Sources/Testing/Events/TimeValue.swift
@@ -10,7 +10,7 @@
 
 // `internal` because `TimeValue.init(_ timespec:)` below is internal and
 // references a type (`timespec`) which comes from this import.
-internal import TestingInternals
+@_implementationOnly import TestingInternals
 
 /// A container type representing a time value that is suitable for storage,
 /// conversion, encoding, and decoding.

--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-private import TestingInternals
+@_implementationOnly import TestingInternals
 
 /// The entry point to the testing library used by Swift Package Manager.
 ///

--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -9,8 +9,8 @@
 //
 
 #if !SWT_NO_XCTEST_SCAFFOLDING
-private import TestingInternals
-public import XCTest
+@_implementationOnly import TestingInternals
+import XCTest
 
 #if SWT_TARGET_OS_APPLE
 extension XCTSourceCodeContext {

--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-private import TestingInternals
+@_implementationOnly import TestingInternals
 
 /// A type representing a backtrace or stack trace.
 public struct Backtrace: Sendable {

--- a/Sources/Testing/Support/CError.swift
+++ b/Sources/Testing/Support/CError.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-private import TestingInternals
+@_implementationOnly import TestingInternals
 
 /// A type representing an error from a C function such as `fopen()`.
 ///

--- a/Sources/Testing/Support/Environment.swift
+++ b/Sources/Testing/Support/Environment.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-private import TestingInternals
+@_implementationOnly import TestingInternals
 
 /// A type describing the environment of the current process.
 ///

--- a/Sources/Testing/Support/Locked.swift
+++ b/Sources/Testing/Support/Locked.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-private import TestingInternals
+@_implementationOnly import TestingInternals
 
 /// A property wrapper that wraps a value requiring access from a synchronous
 /// caller during concurrent execution.

--- a/Sources/Testing/Support/Versions.swift
+++ b/Sources/Testing/Support/Versions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-private import TestingInternals
+@_implementationOnly import TestingInternals
 
 /// A human-readable string describing the current operating system's version.
 ///

--- a/Sources/Testing/Test+Macro.swift
+++ b/Sources/Testing/Test+Macro.swift
@@ -8,10 +8,10 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-private import TestingInternals
+@_implementationOnly import TestingInternals
 
 #if _runtime(_ObjC)
-public import ObjectiveC
+import ObjectiveC
 
 /// An XCTest-compatible Objective-C selector.
 ///

--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -9,7 +9,7 @@
 //
 
 #if _runtime(_ObjC)
-public import ObjectiveC
+import ObjectiveC
 #endif
 
 /// A type representing a test or suite.

--- a/Sources/Testing/Traits/Tag.Color+Loading.swift
+++ b/Sources/Testing/Traits/Tag.Color+Loading.swift
@@ -8,10 +8,10 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-private import TestingInternals
+@_implementationOnly import TestingInternals
 
 #if canImport(Foundation)
-private import Foundation
+import Foundation
 #endif
 
 #if !SWT_NO_FILE_IO

--- a/Sources/Testing/Traits/Tag.Color+Loading.swift
+++ b/Sources/Testing/Traits/Tag.Color+Loading.swift
@@ -11,6 +11,7 @@
 @_implementationOnly import TestingInternals
 
 #if canImport(Foundation)
+// TODO: mark private when access levels on import are implemented and stable
 import Foundation
 #endif
 

--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -9,7 +9,7 @@
 //
 
 public import SwiftSyntax
-import SwiftSyntaxMacros
+public import SwiftSyntaxMacros
 
 /// A protocol containing the common implementation for the expansions of the
 /// `#expect()` and `#require()` macros.
@@ -34,7 +34,7 @@ import SwiftSyntaxMacros
 /// The `__check()` function that implements expansions of these macros must
 /// take any developer-supplied arguments _before_ the ones inserted during
 /// macro expansion (starting with the `"sourceCode"` argument.)
-private protocol _ConditionMacro: ExpressionMacro, Sendable {
+@usableFromInline protocol ConditionMacro: ExpressionMacro, Sendable {
   /// Whether or not the macro's expansion may throw an error.
   static var isThrowing: Bool { get }
 }
@@ -49,8 +49,8 @@ private let _sourceLocationLabel = TokenSyntax.identifier("sourceLocation")
 /// with `#expect()` or `#require()`.
 private let _trailingClosureLabel = TokenSyntax.identifier("performing")
 
-extension _ConditionMacro {
-  public static func expansion(
+extension ConditionMacro {
+  @usableFromInline static func expansion(
     of macro: some FreestandingMacroExpansionSyntax,
     in context: some MacroExpansionContext
   ) throws -> ExprSyntax {
@@ -188,8 +188,8 @@ extension _ConditionMacro {
 // MARK: -
 
 /// A type describing the expansion of the `#expect()` macro.
-public struct ExpectMacro: _ConditionMacro {
-  fileprivate static var isThrowing: Bool {
+@usableFromInline struct ExpectMacro: ConditionMacro {
+  @usableFromInline static var isThrowing: Bool {
     false
   }
 }
@@ -197,8 +197,8 @@ public struct ExpectMacro: _ConditionMacro {
 // MARK: -
 
 /// A type describing the expansion of the `#require()` macro.
-public struct RequireMacro: _ConditionMacro {
-  fileprivate static var isThrowing: Bool {
+@usableFromInline struct RequireMacro: ConditionMacro {
+  @usableFromInline static var isThrowing: Bool {
     true
   }
 }

--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -8,8 +8,8 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-public import SwiftSyntax
-public import SwiftSyntaxMacros
+import SwiftSyntax
+import SwiftSyntaxMacros
 
 /// A protocol containing the common implementation for the expansions of the
 /// `#expect()` and `#require()` macros.
@@ -34,7 +34,7 @@ public import SwiftSyntaxMacros
 /// The `__check()` function that implements expansions of these macros must
 /// take any developer-supplied arguments _before_ the ones inserted during
 /// macro expansion (starting with the `"sourceCode"` argument.)
-@usableFromInline protocol ConditionMacro: ExpressionMacro, Sendable {
+private protocol _ConditionMacro: ExpressionMacro, Sendable {
   /// Whether or not the macro's expansion may throw an error.
   static var isThrowing: Bool { get }
 }
@@ -49,8 +49,8 @@ private let _sourceLocationLabel = TokenSyntax.identifier("sourceLocation")
 /// with `#expect()` or `#require()`.
 private let _trailingClosureLabel = TokenSyntax.identifier("performing")
 
-extension ConditionMacro {
-  @usableFromInline static func expansion(
+extension _ConditionMacro {
+  public static func expansion(
     of macro: some FreestandingMacroExpansionSyntax,
     in context: some MacroExpansionContext
   ) throws -> ExprSyntax {
@@ -188,8 +188,8 @@ extension ConditionMacro {
 // MARK: -
 
 /// A type describing the expansion of the `#expect()` macro.
-@usableFromInline struct ExpectMacro: ConditionMacro {
-  @usableFromInline static var isThrowing: Bool {
+public struct ExpectMacro: _ConditionMacro {
+  fileprivate static var isThrowing: Bool {
     false
   }
 }
@@ -197,8 +197,8 @@ extension ConditionMacro {
 // MARK: -
 
 /// A type describing the expansion of the `#require()` macro.
-@usableFromInline struct RequireMacro: ConditionMacro {
-  @usableFromInline static var isThrowing: Bool {
+public struct RequireMacro: _ConditionMacro {
+  fileprivate static var isThrowing: Bool {
     true
   }
 }

--- a/Sources/TestingMacros/SuiteDeclarationMacro.swift
+++ b/Sources/TestingMacros/SuiteDeclarationMacro.swift
@@ -9,14 +9,14 @@
 //
 
 public import SwiftSyntax
-import SwiftSyntaxMacros
+public import SwiftSyntaxMacros
 
 /// A type describing the expansion of the `@Suite` attribute macro.
 ///
 /// This type is used to implement the `@Suite` attribute macro. Do not use it
 /// directly.
-public struct SuiteDeclarationMacro: MemberMacro, PeerMacro, Sendable {
-  public static func expansion(
+@usableFromInline struct SuiteDeclarationMacro: MemberMacro, PeerMacro, Sendable {
+  @usableFromInline static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
     in context: some MacroExpansionContext
@@ -25,7 +25,7 @@ public struct SuiteDeclarationMacro: MemberMacro, PeerMacro, Sendable {
     return _createTestContainerDecls(for: declaration, suiteAttribute: node, in: context)
   }
 
-  public static func expansion(
+  @usableFromInline static func expansion(
     of node: AttributeSyntax,
     providingPeersOf declaration: some DeclSyntaxProtocol,
     in context: some MacroExpansionContext
@@ -157,8 +157,8 @@ public struct SuiteDeclarationMacro: MemberMacro, PeerMacro, Sendable {
     result.append(
       """
       @available(*, deprecated, message: "This type is an implementation detail of the testing library. Do not use it directly.")
-      @frozen public enum \(enumName): Testing.__TestContainer {
-        public static var __tests: [Testing.Test] {
+      @frozen enum \(enumName): Testing.__TestContainer {
+        static var __tests: [Testing.Test] {
           get async {[
             .__type(
               \(declaration.type.trimmed).self,

--- a/Sources/TestingMacros/SuiteDeclarationMacro.swift
+++ b/Sources/TestingMacros/SuiteDeclarationMacro.swift
@@ -8,15 +8,15 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-public import SwiftSyntax
-public import SwiftSyntaxMacros
+import SwiftSyntax
+import SwiftSyntaxMacros
 
 /// A type describing the expansion of the `@Suite` attribute macro.
 ///
 /// This type is used to implement the `@Suite` attribute macro. Do not use it
 /// directly.
-@usableFromInline struct SuiteDeclarationMacro: MemberMacro, PeerMacro, Sendable {
-  @usableFromInline static func expansion(
+public struct SuiteDeclarationMacro: MemberMacro, PeerMacro, Sendable {
+  public static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
     in context: some MacroExpansionContext
@@ -25,7 +25,7 @@ public import SwiftSyntaxMacros
     return _createTestContainerDecls(for: declaration, suiteAttribute: node, in: context)
   }
 
-  @usableFromInline static func expansion(
+  public static func expansion(
     of node: AttributeSyntax,
     providingPeersOf declaration: some DeclSyntaxProtocol,
     in context: some MacroExpansionContext

--- a/Sources/TestingMacros/Support/Additions/DeclGroupSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/DeclGroupSyntaxAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-public import SwiftSyntax
+import SwiftSyntax
 
 extension DeclGroupSyntax {
   /// The type declared or extended by this instance.

--- a/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-public import SwiftSyntax
+import SwiftSyntax
 import SwiftSyntaxMacros
 
 extension FunctionDeclSyntax {

--- a/Sources/TestingMacros/Support/Additions/TokenSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/TokenSyntaxAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-public import SwiftSyntax
+import SwiftSyntax
 
 extension TokenSyntax {
   /// The text of this instance with all backticks removed.

--- a/Sources/TestingMacros/Support/Additions/TriviaPieceAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/TriviaPieceAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-public import SwiftSyntax
+import SwiftSyntax
 
 extension TriviaPiece {
   /// The number of newline characters represented by this trivia piece.

--- a/Sources/TestingMacros/Support/Additions/TypeSyntaxProtocolAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/TypeSyntaxProtocolAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-public import SwiftSyntax
+import SwiftSyntax
 
 extension TypeSyntaxProtocol {
   /// Whether or not this type is an optional type (`T?`, `Optional<T>`, etc.)

--- a/Sources/TestingMacros/Support/Additions/VersionTupleSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/VersionTupleSyntaxAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-public import SwiftSyntax
+import SwiftSyntax
 
 extension VersionTupleSyntax {
   /// A type describing the major, minor, and patch components of a version

--- a/Sources/TestingMacros/Support/Additions/WithAttributesSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/WithAttributesSyntaxAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-public import SwiftSyntax
+import SwiftSyntax
 import SwiftSyntaxMacros
 
 extension WithAttributesSyntax {

--- a/Sources/TestingMacros/Support/Argument.swift
+++ b/Sources/TestingMacros/Support/Argument.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-public import SwiftSyntax
+import SwiftSyntax
 
 /// A type describing an argument to a function, closure, etc.
 ///

--- a/Sources/TestingMacros/Support/AttributeDiscovery.swift
+++ b/Sources/TestingMacros/Support/AttributeDiscovery.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-public import SwiftSyntax
+import SwiftSyntax
 import SwiftSyntaxMacros
 
 /// A syntax rewriter that removes leading `Self.` tokens from member access

--- a/Sources/TestingMacros/Support/AvailabilityGuards.swift
+++ b/Sources/TestingMacros/Support/AvailabilityGuards.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-public import SwiftSyntax
+import SwiftSyntax
 import SwiftSyntaxMacros
 
 /// A structure describing a single platform/version pair from an `@available()`

--- a/Sources/TestingMacros/Support/CommentParsing.swift
+++ b/Sources/TestingMacros/Support/CommentParsing.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-public import SwiftSyntax
+import SwiftSyntax
 
 /// Find a common whitespace prefix among all lines in a string and trim it.
 ///

--- a/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
+++ b/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-public import SwiftSyntax
+import SwiftSyntax
 import SwiftSyntaxMacros
 
 /// The result of parsing the condition argument passed to `#expect()` or

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -9,7 +9,7 @@
 //
 
 import SwiftDiagnostics
-public import SwiftSyntax
+import SwiftSyntax
 import SwiftSyntaxMacros
 
 /// A type describing diagnostic messages emitted by this module's macro during

--- a/Sources/TestingMacros/Support/SourceCodeCapturing.swift
+++ b/Sources/TestingMacros/Support/SourceCodeCapturing.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-public import SwiftSyntax
+import SwiftSyntax
 
 /// Get an expression initializing an instance of ``SourceCode`` from an
 /// arbitrary syntax node.

--- a/Sources/TestingMacros/Support/SourceLocationGeneration.swift
+++ b/Sources/TestingMacros/Support/SourceLocationGeneration.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-public import SwiftSyntax
+import SwiftSyntax
 import SwiftSyntaxMacros
 
 /// Get an expression initializing an instance of ``SourceLocation`` from an

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -8,15 +8,15 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-public import SwiftSyntax
-public import SwiftSyntaxMacros
+import SwiftSyntax
+import SwiftSyntaxMacros
 
 /// A type describing the expansion of the `@Test` attribute macro.
 ///
 /// This type is used to implement the `@Test` attribute macro. Do not use it
 /// directly.
-@usableFromInline struct TestDeclarationMacro: PeerMacro, Sendable {
-  @usableFromInline static func expansion(
+public struct TestDeclarationMacro: PeerMacro, Sendable {
+  public static func expansion(
     of node: AttributeSyntax,
     providingPeersOf declaration: some DeclSyntaxProtocol,
     in context: some MacroExpansionContext

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -9,14 +9,14 @@
 //
 
 public import SwiftSyntax
-import SwiftSyntaxMacros
+public import SwiftSyntaxMacros
 
 /// A type describing the expansion of the `@Test` attribute macro.
 ///
 /// This type is used to implement the `@Test` attribute macro. Do not use it
 /// directly.
-public struct TestDeclarationMacro: PeerMacro, Sendable {
-  public static func expansion(
+@usableFromInline struct TestDeclarationMacro: PeerMacro, Sendable {
+  @usableFromInline static func expansion(
     of node: AttributeSyntax,
     providingPeersOf declaration: some DeclSyntaxProtocol,
     in context: some MacroExpansionContext
@@ -474,8 +474,8 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
     result.append(
       """
       @available(*, deprecated, message: "This type is an implementation detail of the testing library. Do not use it directly.")
-      @frozen public enum \(enumName): Testing.__TestContainer {
-        public static var __tests: [Testing.Test] {
+      @frozen enum \(enumName): Testing.__TestContainer {
+        static var __tests: [Testing.Test] {
           get async {[
             .__function(
               named: \(literal: functionDecl.completeName),

--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -14,7 +14,7 @@ import Testing
 import SwiftDiagnostics
 import SwiftOperators
 import SwiftParser
-public import SwiftSyntax
+import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -13,7 +13,7 @@ import Testing
 
 import SwiftDiagnostics
 import SwiftParser
-public import SwiftSyntax
+import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 

--- a/Tests/TestingMacrosTests/TestSupport/Parse.swift
+++ b/Tests/TestingMacrosTests/TestSupport/Parse.swift
@@ -13,7 +13,7 @@
 import SwiftDiagnostics
 import SwiftOperators
 import SwiftParser
-public import SwiftSyntax
+import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 import SwiftSyntaxMacroExpansion

--- a/Tests/TestingMacrosTests/UniqueIdentifierTests.swift
+++ b/Tests/TestingMacrosTests/UniqueIdentifierTests.swift
@@ -14,7 +14,7 @@ import Testing
 import SwiftDiagnostics
 import SwiftOperators
 import SwiftParser
-public import SwiftSyntax
+import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 import SwiftSyntaxMacroExpansion

--- a/Tests/TestingTests/ClockTests.swift
+++ b/Tests/TestingTests/ClockTests.swift
@@ -12,7 +12,7 @@
 import Foundation
 #endif
 @testable @_spi(ExperimentalEventHandling) import Testing
-private import TestingInternals
+@_implementationOnly import TestingInternals
 
 @Suite("Clock API Tests")
 struct ClockTests {

--- a/Tests/TestingTests/DumpTests.swift
+++ b/Tests/TestingTests/DumpTests.swift
@@ -9,7 +9,7 @@
 //
 
 @testable @_spi(InternalDiagnostics) @_spi(ExperimentalTestRunning) import Testing
-private import TestingInternals
+@_implementationOnly import TestingInternals
 
 // NOTE: The tests in this file are here to exercise Plan.dump(), but they are
 // not intended to actually test that the output is in a particular format since

--- a/Tests/TestingTests/EventTests.swift
+++ b/Tests/TestingTests/EventTests.swift
@@ -12,7 +12,7 @@
 import Foundation
 #endif
 @testable @_spi(ExperimentalEventHandling) @_spi(ExperimentalParameterizedTesting) @_spi(ExperimentalSnapshotting) @_spi(ExperimentalTestRunning) import Testing
-private import TestingInternals
+@_implementationOnly import TestingInternals
 
 struct EventTests {
 #if canImport(Foundation)

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -9,7 +9,7 @@
 //
 
 @testable @_spi(ExperimentalEventHandling) @_spi(ExperimentalTestRunning) @_spi(ExperimentalSnapshotting) import Testing
-private import TestingInternals
+@_implementationOnly import TestingInternals
 
 #if canImport(XCTest)
 import XCTest

--- a/Tests/TestingTests/Support/CErrorTests.swift
+++ b/Tests/TestingTests/Support/CErrorTests.swift
@@ -9,7 +9,7 @@
 //
 
 @testable import Testing
-private import TestingInternals
+@_implementationOnly import TestingInternals
 
 @Suite("CError Tests")
 struct CErrorTests {

--- a/Tests/TestingTests/Support/EnvironmentTests.swift
+++ b/Tests/TestingTests/Support/EnvironmentTests.swift
@@ -9,7 +9,7 @@
 //
 
 @testable import Testing
-private import TestingInternals
+@_implementationOnly import TestingInternals
 
 @Suite("Environment Tests")
 struct EnvironmentTests {


### PR DESCRIPTION
~This PR modifies the access levels of import statements and of macro types so that they compile cleanly with the latest (2023-11-27) main Swift toolchain.~

This PR _disables_ the access-levels-on-import feature for now. Once the feature has stabilized more, we can adopt it.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
