### PR TITLE
Fix access levels of import statements to ensure compatbility with latest 'main' snapshot toolchains

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -130,8 +130,21 @@ extension Array where Element == PackageDescription.SwiftSetting {
       ]),
       .enableExperimentalFeature("StrictConcurrency"),
       .enableUpcomingFeature("ExistentialAny"),
+
+      // FIXME: In a certain range of Swift toolchains, this feature causes
+      // warnings to be emitted such as:
+      //
+      // ```
+      // warning: public import of 'SwiftSyntax' was not used in public declarations or inlinable code
+      // ```
+      //
+      // Once this package only builds using new-enough toolchains where that
+      // problem is resolved, we should remove the `public` access level from
+      // the `import` declarations in the `TestingMacros` target which do not
+      // require it, to resolve these warnings.
       .enableExperimentalFeature("AccessLevelOnImport"),
       .enableUpcomingFeature("InternalImportsByDefault"),
+
       .define("SWT_TARGET_OS_APPLE", .when(platforms: [.macOS, .iOS, .macCatalyst, .watchOS, .tvOS, .visionOS])),
     ]
   }

--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -9,7 +9,7 @@
 //
 
 public import SwiftSyntax
-import SwiftSyntaxMacros
+public import SwiftSyntaxMacros
 
 /// A protocol containing the common implementation for the expansions of the
 /// `#expect()` and `#require()` macros.

--- a/Sources/TestingMacros/SuiteDeclarationMacro.swift
+++ b/Sources/TestingMacros/SuiteDeclarationMacro.swift
@@ -9,7 +9,7 @@
 //
 
 public import SwiftSyntax
-import SwiftSyntaxMacros
+public import SwiftSyntaxMacros
 
 /// A type describing the expansion of the `@Suite` attribute macro.
 ///
@@ -157,8 +157,8 @@ public struct SuiteDeclarationMacro: MemberMacro, PeerMacro, Sendable {
     result.append(
       """
       @available(*, deprecated, message: "This type is an implementation detail of the testing library. Do not use it directly.")
-      @frozen public enum \(enumName): Testing.__TestContainer {
-        public static var __tests: [Testing.Test] {
+      @frozen enum \(enumName): Testing.__TestContainer {
+        static var __tests: [Testing.Test] {
           get async {[
             .__type(
               \(declaration.type.trimmed).self,

--- a/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
@@ -9,7 +9,7 @@
 //
 
 public import SwiftSyntax
-import SwiftSyntaxMacros
+public import SwiftSyntaxMacros
 
 extension FunctionDeclSyntax {
   /// Whether or not this function a `static` or `class` function.

--- a/Sources/TestingMacros/Support/Additions/WithAttributesSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/WithAttributesSyntaxAdditions.swift
@@ -9,7 +9,7 @@
 //
 
 public import SwiftSyntax
-import SwiftSyntaxMacros
+public import SwiftSyntaxMacros
 
 extension WithAttributesSyntax {
   /// The set of availability attributes on this instance.

--- a/Sources/TestingMacros/Support/AttributeDiscovery.swift
+++ b/Sources/TestingMacros/Support/AttributeDiscovery.swift
@@ -9,7 +9,7 @@
 //
 
 public import SwiftSyntax
-import SwiftSyntaxMacros
+public import SwiftSyntaxMacros
 
 /// A syntax rewriter that removes leading `Self.` tokens from member access
 /// expressions in a syntax tree.

--- a/Sources/TestingMacros/Support/AvailabilityGuards.swift
+++ b/Sources/TestingMacros/Support/AvailabilityGuards.swift
@@ -9,7 +9,7 @@
 //
 
 public import SwiftSyntax
-import SwiftSyntaxMacros
+public import SwiftSyntaxMacros
 
 /// A structure describing a single platform/version pair from an `@available()`
 /// attribute.

--- a/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
+++ b/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
@@ -9,7 +9,7 @@
 //
 
 public import SwiftSyntax
-import SwiftSyntaxMacros
+public import SwiftSyntaxMacros
 
 /// The result of parsing the condition argument passed to `#expect()` or
 /// `#require()`.

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -10,7 +10,7 @@
 
 import SwiftDiagnostics
 public import SwiftSyntax
-import SwiftSyntaxMacros
+public import SwiftSyntaxMacros
 
 /// A type describing diagnostic messages emitted by this module's macro during
 /// evaluation.

--- a/Sources/TestingMacros/Support/SourceLocationGeneration.swift
+++ b/Sources/TestingMacros/Support/SourceLocationGeneration.swift
@@ -9,7 +9,7 @@
 //
 
 public import SwiftSyntax
-import SwiftSyntaxMacros
+public import SwiftSyntaxMacros
 
 /// Get an expression initializing an instance of ``SourceLocation`` from an
 /// arbitrary expression value.

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -9,7 +9,7 @@
 //
 
 public import SwiftSyntax
-import SwiftSyntaxMacros
+public import SwiftSyntaxMacros
 
 /// A type describing the expansion of the `@Test` attribute macro.
 ///
@@ -474,8 +474,8 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
     result.append(
       """
       @available(*, deprecated, message: "This type is an implementation detail of the testing library. Do not use it directly.")
-      @frozen public enum \(enumName): Testing.__TestContainer {
-        public static var __tests: [Testing.Test] {
+      @frozen enum \(enumName): Testing.__TestContainer {
+        static var __tests: [Testing.Test] {
           get async {[
             .__function(
               named: \(literal: functionDecl.completeName),

--- a/Sources/TestingMacros/TestingMacrosMain.swift
+++ b/Sources/TestingMacros/TestingMacrosMain.swift
@@ -10,7 +10,7 @@
 
 #if canImport(SwiftCompilerPlugin)
 import SwiftCompilerPlugin
-import SwiftSyntaxMacros
+public import SwiftSyntaxMacros
 
 /// The main entry point for the compiler plugin executable that provides macros
 /// for the `swift-testing` package.

--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -14,7 +14,7 @@ import Testing
 import SwiftDiagnostics
 import SwiftOperators
 import SwiftParser
-public import SwiftSyntax
+import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -13,7 +13,7 @@ import Testing
 
 import SwiftDiagnostics
 import SwiftParser
-public import SwiftSyntax
+import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 

--- a/Tests/TestingMacrosTests/TestSupport/Parse.swift
+++ b/Tests/TestingMacrosTests/TestSupport/Parse.swift
@@ -13,7 +13,7 @@
 import SwiftDiagnostics
 import SwiftOperators
 import SwiftParser
-public import SwiftSyntax
+import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 import SwiftSyntaxMacroExpansion

--- a/Tests/TestingMacrosTests/UniqueIdentifierTests.swift
+++ b/Tests/TestingMacrosTests/UniqueIdentifierTests.swift
@@ -14,7 +14,7 @@ import Testing
 import SwiftDiagnostics
 import SwiftOperators
 import SwiftParser
-public import SwiftSyntax
+import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 import SwiftSyntaxMacroExpansion


### PR DESCRIPTION
This PR modifies the access levels of `import` declarations in our macro target and its test target, so that they compile cleanly with the latest (2023-11-27) main Swift toolchain. It also removes `public` access level from the code expanded by the `@Test` and `@Suite` attached macros, because these cause new diagnostics in that newer toolchain since the expanded code references declarations in the `Testing` module and typically that module is not imported in client code using `public`.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
