### PR TITLE
[WIP] Remove "`swt_`" and "`SWT`" prefixes from C/C++ symbols in Swift.

### DIFF
--- a/Documentation/StyleGuide.md
+++ b/Documentation/StyleGuide.md
@@ -49,24 +49,32 @@ a leading underscore (except for those `public` symbols mentioned above.)
 Exported C and C++ symbols that are exported should be given the prefix `swt_`
 and should otherwise be named using the same lowerCamelCase naming rules as in
 Swift. Use the `SWT_EXTERN` macro to ensure that symbols are consistently
-visible in C, C++, and Swift. For example:
+visible in C, C++, and Swift. Use the `SWT_SWIFT_NAME()` macro if the symbol
+will be used from Swift to refine the name and remove the prefix. For example:
 
 ```c
-SWT_EXTERN bool swt_isDebugModeEnabled(void);
+SWT_EXTERN bool swt_getGriddleTemperature(void) SWT_SWIFT_NAME(griddleTemperature());
 
-SWT_EXTERN void swt_setDebugModeEnabled(bool isEnabled);
+SWT_EXTERN void swt_sell(food_t food, toppings_t toppings) SWT_SWIFT_NAME(sell(_:toppedWith:)) {
+  ...
+}
 ```
 
 C and C++ types should be given the prefix `SWT` and should otherwise be named
-using the same UpperCamelCase naming rules as in Swift. For example:
+using the same UpperCamelCase naming rules as in Swift. `SWT_SWIFT_NAME()`
+should be used to remove the prefix for types visible in Swift. For example:
 
 ```c
-typedef intmax_t SWTBigInteger;
+typedef intmax_t SWTEmployeeCount SWT_SWIFT_NAME(EmployeeCount);
 
-typedef struct SWTContainer {
+typedef struct SWTDeepFryer {
+  float temperature;
   ...
-} SWTContainer;
+} SWTDeepFryer SWT_SWIFT_NAME(DeepFryer);
 ```
+
+The use of `SWT_SWIFT_NAME()` is not required for symbols that are neither
+visible to nor used in Swift code. 
 
 #### Documenting symbols
 

--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -173,7 +173,6 @@ public enum XCTestScaffold: Sendable {
 #if SWIFT_PM_SUPPORTS_SWIFT_TESTING
     let message = warning("This version of Swift Package Manager supports running swift-testing tests directly. Ignoring call to \(#function).", options: .forStandardError)
 #if SWT_TARGET_OS_APPLE
-    let stderr = swt_stderr()
     fputs(message, stderr)
     fflush(stderr)
 #else

--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -148,7 +148,7 @@ extension Backtrace {
 
   /// The previous `swift_willThrow` handler, if any.
   @Locked
-  private static var _oldWillThrowHandler: SWTWillThrowHandler?
+  private static var _oldWillThrowHandler: WillThrowHandler?
 
   /// Handle a thrown error.
   ///
@@ -177,7 +177,7 @@ extension Backtrace {
   /// only once.
   private static let _startCachingForThrownErrors: Void = {
     $_oldWillThrowHandler.withLock { oldWillThrowHandler in
-      oldWillThrowHandler = swt_setWillThrowHandler { _willThrow($0) }
+      oldWillThrowHandler = setWillThrowHandler { _willThrow($0) }
     }
   }()
 

--- a/Sources/Testing/Test+Discovery.swift
+++ b/Sources/Testing/Test+Discovery.swift
@@ -48,7 +48,7 @@ extension Test {
   private static var _all: some Sequence<Self> {
     get async {
       await withTaskGroup(of: [Self].self) { taskGroup in
-        swt_enumerateTypes(&taskGroup) { type, context in
+        enumerateTypes(&taskGroup) { type, context in
           if let type = unsafeBitCast(type, to: Any.Type.self) as? any __TestContainer.Type {
             let taskGroup = context!.assumingMemoryBound(to: TaskGroup<[Self]>.self)
             taskGroup.pointee.addTask {

--- a/Sources/TestingInternals/include/Discovery.h
+++ b/Sources/TestingInternals/include/Discovery.h
@@ -23,7 +23,7 @@ SWT_ASSUME_NONNULL_BEGIN
 ///   - typeMetadata: A type metadata pointer that can be bitcast to `Any.Type`.
 ///   - context: An arbitrary pointer passed by the caller to
 ///     `swt_enumerateTypes()`.
-typedef void (* SWTTypeEnumerator)(void *typeMetadata, void *_Null_unspecified context);
+typedef void (* SWTTypeEnumerator)(void *typeMetadata, void *_Null_unspecified context) SWT_SWIFT_NAME(TypeEnumerator);
 
 /// The type name filter that is called by `swt_enumerateTypes()`.
 ///
@@ -34,7 +34,7 @@ typedef void (* SWTTypeEnumerator)(void *typeMetadata, void *_Null_unspecified c
 ///
 /// - Returns: Whether or not the type named by `typeName` should be passed to
 ///   the corresponding enumerator function.
-typedef bool (* SWTTypeNameFilter)(const char *typeName, void *_Null_unspecified context);
+typedef bool (* SWTTypeNameFilter)(const char *typeName, void *_Null_unspecified context) SWT_SWIFT_NAME(TypeNameFilter);
 
 /// Enumerate all types known to Swift found in the current process.
 ///
@@ -53,7 +53,7 @@ SWT_EXTERN void swt_enumerateTypes(
   void *_Null_unspecified context,
   SWTTypeEnumerator body,
   SWTTypeNameFilter _Nullable nameFilter
-) SWT_SWIFT_NAME(swt_enumerateTypes(_:_:withNamesMatching:));
+) SWT_SWIFT_NAME(enumerateTypes(_:_:withNamesMatching:));
 
 SWT_ASSUME_NONNULL_END
 

--- a/Sources/TestingInternals/include/Stubs.h
+++ b/Sources/TestingInternals/include/Stubs.h
@@ -21,14 +21,14 @@ SWT_ASSUME_NONNULL_BEGIN
 /// This typedef is necessary because `FILE *` may be imported into Swift as
 /// either `OpaquePointer` or `UnsafeMutablePointer<FILE>` depending on the
 /// current platform.
-typedef FILE *SWT_FILEHandle;
+typedef FILE *SWT_FILE SWT_SWIFT_NAME(FILE);
 
 /// Get the standard error stream.
 ///
 /// This function is provided because directly accessing `stderr` from Swift
 /// triggers concurrency warnings on some platforms about accessing shared
 /// mutable state.
-static SWT_FILEHandle swt_stderr(void) {
+static inline SWT_FILE swt_stderr(void) SWT_SWIFT_NAME(getter:stderr()) {
   return stderr;
 }
 
@@ -36,7 +36,7 @@ static SWT_FILEHandle swt_stderr(void) {
 ///
 /// This function is provided because `errno` is a complex macro on some
 /// platforms and cannot be imported directly into Swift.
-static int swt_errno(void) {
+static inline int swt_errno(void) SWT_SWIFT_NAME(getter:errno()) {
   return errno;
 }
 
@@ -46,7 +46,7 @@ static int swt_errno(void) {
 /// This function is exactly equivalent to the `S_ISFIFO()` macro. It is
 /// necessary because the mode flag macros are not imported into Swift
 /// consistently across platforms.
-static bool swt_S_ISFIFO(mode_t mode) {
+static inline bool swt_S_ISFIFO(mode_t mode) SWT_SWIFT_NAME(S_ISFIFO(_:)) {
   return S_ISFIFO(mode);
 }
 #endif

--- a/Sources/TestingInternals/include/WillThrow.h
+++ b/Sources/TestingInternals/include/WillThrow.h
@@ -21,7 +21,7 @@ SWT_ASSUME_NONNULL_BEGIN
 ///   - error: The error that is about to be thrown. This pointer refers to an
 ///     instance of `SwiftError` or (on platforms with Objective-C interop) an
 ///     instance of `NSError`.
-typedef void (* SWT_SENDABLE SWTWillThrowHandler)(void *error);
+typedef void (* SWT_SENDABLE SWTWillThrowHandler)(void *error) SWT_SWIFT_NAME(WillThrowHandler);
 
 /// Set the callback function that fires when an instance of `Swift.Error` is
 /// thrown.
@@ -39,7 +39,7 @@ typedef void (* SWT_SENDABLE SWTWillThrowHandler)(void *error);
 /// ## See Also
 ///
 /// ``SWTWillThrowHandler``
-SWT_EXTERN SWTWillThrowHandler SWT_SENDABLE _Nullable swt_setWillThrowHandler(SWTWillThrowHandler SWT_SENDABLE _Nullable handler);
+SWT_EXTERN SWTWillThrowHandler SWT_SENDABLE _Nullable swt_setWillThrowHandler(SWTWillThrowHandler SWT_SENDABLE _Nullable handler) SWT_SWIFT_NAME(setWillThrowHandler(_:));
 
 SWT_ASSUME_NONNULL_END
 


### PR DESCRIPTION
This PR adopts `SWT_SWIFT_NAME()` across TestingInternals so that symbols imported into Swift from that module do not have to be called with the "SWT" prefix.

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
