### PR TITLE
Remove the old SPI-annotated SwiftPM entry point.

### DIFF
--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -71,18 +71,6 @@ public func __swiftPMEntryPoint() async -> Never {
   exit(exitCode)
 }
 
-/// Call `__swiftPMEntryPoint()`.
-///
-/// This function is an old alias of `__swiftPMEntryPoint()`. It will be removed
-/// in the near future.
-///
-/// - Warning: This function is used by Swift Package Manager. Do not call it
-///   directly.
-@_spi(SwiftPackageManagerSupport)
-public func swiftPMEntryPoint() async -> Never {
-  await __swiftPMEntryPoint()
-}
-
 // MARK: -
 
 /// List all of the given tests in the "specifier" format used by Swift Package


### PR DESCRIPTION
This PR removes the `@_spi(SwiftPackageManagerSupport)`-annotated `swiftPMEntryPoint()` function now that SwiftPM has adopted the newer synonym, `__swiftPMEntryPoint()`.

Blocked by https://github.com/apple/swift-package-manager/pull/7137.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
