### PR TITLE
Make events and associated types move-only.

### DIFF
--- a/Sources/Testing/Events/Event.swift
+++ b/Sources/Testing/Events/Event.swift
@@ -10,7 +10,7 @@
 
 /// An event that occurred during testing.
 @_spi(ExperimentalEventHandling)
-public struct Event: Sendable {
+public struct Event: Sendable, ~Copyable {
   /// An enumeration describing the various kinds of event that can be observed.
   public enum Kind: Sendable {
     /// A test run started.
@@ -191,7 +191,7 @@ extension Event {
   ///
   /// An instance of this type is provided along with each ``Event`` that is
   /// passed to an ``Event/Handler``.
-  public struct Context: Sendable {
+  public struct Context: Sendable, ~Copyable {
     /// The test for which this instance's associated ``Event`` occurred, if
     /// any.
     ///
@@ -278,7 +278,7 @@ extension Event {
 
     /// Snapshots an ``Event``.
     /// - Parameter event: The original ``Event`` to snapshot.
-    public init(snapshotting event: Event) {
+    public init(snapshotting event: borrowing Event) {
       kind = Event.Kind.Snapshot(snapshotting: event.kind)
       testID = event.testID
       instant = event.instant

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -18,7 +18,7 @@ extension Event {
   /// The format of the output is not meant to be machine-readable and is
   /// subject to change. For machine-readable output, use ``JUnitXMLRecorder``.
   @_spi(ExperimentalEventRecording)
-  public struct HumanReadableOutputRecorder: Sendable {
+  public struct HumanReadableOutputRecorder: Sendable, ~Copyable {
     /// A type describing a human-readable message produced by an instance of
     /// ``Event/HumanReadableOutputRecorder``.
     public struct Message: Sendable {

--- a/Sources/Testing/Events/Recorder/Event.JUnitXMLRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.JUnitXMLRecorder.swift
@@ -12,7 +12,7 @@ extension Event {
   /// A type which handles ``Event`` instances and outputs representations of
   /// them as JUnit-compatible XML.
   @_spi(ExperimentalEventRecording)
-  public struct JUnitXMLRecorder: Sendable {
+  public struct JUnitXMLRecorder: Sendable, ~Copyable {
     /// The write function for this event recorder.
     var write: @Sendable (String) -> Void
 


### PR DESCRIPTION
This PR makes `Event`, `Event.Context`, `Event.ConsoleOutputRecorder`, and `Event.JUnitXMLRecorder` move-only (`~Copyable`.)

These types are fairly expensive to create and copy. By making them move-only, we teach the compiler to help us avoid making expensive copies.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
