### PR TITLE
Avoid constructing a `Test` for an unavailable parameterized test function.

### DIFF
--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -171,7 +171,7 @@ extension Runner {
       }
     }
 
-    if let step = stepGraph.value, case .run = step.action, let testCases = await step.test.testCases {
+    if let step = stepGraph.value, case .run = step.action, let testCases = step.test.testCases {
       try await Test.withCurrent(step.test) {
         try await _withErrorHandling(for: step, sourceLocation: step.test.sourceLocation) {
           try await _runTestCases(testCases, within: step)

--- a/Sources/Testing/Test+Macro.swift
+++ b/Sources/Testing/Test+Macro.swift
@@ -235,7 +235,7 @@ extension Test {
     xcTestCompatibleSelector: __XCTestCompatibleSelector?,
     displayName: String? = nil,
     traits: [any TestTrait],
-    arguments collection: @escaping @Sendable () async -> C,
+    arguments collection: C,
     sourceLocation: SourceLocation,
     parameters paramTuples: [__ParameterInfo],
     testFunction: @escaping @Sendable (C.Element) async throws -> Void
@@ -363,7 +363,7 @@ extension Test {
     xcTestCompatibleSelector: __XCTestCompatibleSelector?,
     displayName: String? = nil,
     traits: [any TestTrait],
-    arguments collection1: @escaping @Sendable () async -> C1, _ collection2: @escaping @Sendable () async -> C2,
+    arguments collection1: C1, _ collection2: C2,
     sourceLocation: SourceLocation,
     parameters paramTuples: [__ParameterInfo],
     testFunction: @escaping @Sendable (C1.Element, C2.Element) async throws -> Void
@@ -386,7 +386,7 @@ extension Test {
     xcTestCompatibleSelector: __XCTestCompatibleSelector?,
     displayName: String? = nil,
     traits: [any TestTrait],
-    arguments collection: @escaping @Sendable () async -> C,
+    arguments collection: C,
     sourceLocation: SourceLocation,
     parameters paramTuples: [__ParameterInfo],
     testFunction: @escaping @Sendable ((E1, E2)) async throws -> Void
@@ -412,7 +412,7 @@ extension Test {
     xcTestCompatibleSelector: __XCTestCompatibleSelector?,
     displayName: String? = nil,
     traits: [any TestTrait],
-    arguments dictionary: @escaping @Sendable () async -> Dictionary<Key, Value>,
+    arguments dictionary: Dictionary<Key, Value>,
     sourceLocation: SourceLocation,
     parameters paramTuples: [__ParameterInfo],
     testFunction: @escaping @Sendable ((Key, Value)) async throws -> Void
@@ -432,7 +432,7 @@ extension Test {
     xcTestCompatibleSelector: __XCTestCompatibleSelector?,
     displayName: String? = nil,
     traits: [any TestTrait],
-    arguments zippedCollections: @escaping @Sendable () async -> Zip2Sequence<C1, C2>,
+    arguments zippedCollections: Zip2Sequence<C1, C2>,
     sourceLocation: SourceLocation,
     parameters paramTuples: [__ParameterInfo],
     testFunction: @escaping @Sendable (C1.Element, C2.Element) async throws -> Void

--- a/Sources/TestingMacros/Support/AttributeDiscovery.swift
+++ b/Sources/TestingMacros/Support/AttributeDiscovery.swift
@@ -218,10 +218,7 @@ struct AttributeInfo {
         ArrayElementSyntax(expression: traitExpr)
       }
     }))
-    // TODO: extract arguments: ... here, rather than assuming all "other" arguments are parameterized inputs
-    arguments += otherArguments.map { argument in
-      Argument(label: argument.label, expression: "{ \(argument.expression.trimmed) }")
-    }
+    arguments += otherArguments
     arguments.append(Argument(label: "sourceLocation", expression: sourceLocation))
 
     return LabeledExprListSyntax(arguments)

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -246,7 +246,7 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
   ///
   /// - Returns: A token representing the `static` keyword, or one representing
   ///   nothing if `typeName` is `nil`.
-  private static func staticKeyword(for typeName: TypeSyntax?) -> TokenSyntax {
+  private static func _staticKeyword(for typeName: TypeSyntax?) -> TokenSyntax {
     (typeName != nil) ? .keyword(.static) : .unknown("")
   }
 
@@ -378,7 +378,7 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
     let thunkName = context.makeUniqueName(thunking: functionDecl)
     let thunkDecl: DeclSyntax = """
     @available(*, deprecated, message: "This function is an implementation detail of the testing library. Do not use it directly.")
-    @Sendable private \(staticKeyword(for: typeName)) func \(thunkName)\(thunkParamsExpr) async throws -> Void {
+    @Sendable private \(_staticKeyword(for: typeName)) func \(thunkName)\(thunkParamsExpr) async throws -> Void {
       \(thunkBody)
     }
     """
@@ -486,7 +486,7 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
       result.append(
         """
         @available(*, deprecated, message: "This property is an implementation detail of the testing library. Do not use it directly.")
-        private \(staticKeyword(for: typeName)) nonisolated func \(unavailableTestName)() async -> [Testing.Test] {
+        private \(_staticKeyword(for: typeName)) nonisolated func \(unavailableTestName)() async -> [Testing.Test] {
           [
             .__function(
               named: \(literal: functionDecl.completeName),

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -145,16 +145,14 @@ struct TestDeclarationMacroTests {
       #"@available(moofOS 9, dogCow 30, *) @Test func f() {}"#:
         [
           #".__available("moofOS", introduced: (9, nil, nil), "#,
-          #"guard #available (moofOS 9, *) else"#,
           #".__available("dogCow", introduced: (30, nil, nil), "#,
-          #"guard #available (dogCow 30, *) else"#,
+          #"guard #available (moofOS 9, *), #available (dogCow 30, *) else"#,
         ],
       #"@available(moofOS, introduced: 9) @available(dogCow, introduced: 30) @Test func f() {}"#:
         [
           #".__available("moofOS", introduced: (9, nil, nil), "#,
-          #"guard #available (moofOS 9, *) else"#,
           #".__available("dogCow", introduced: (30, nil, nil), "#,
-          #"guard #available (dogCow 30, *) else"#,
+          #"guard #available (moofOS 9, *), #available (dogCow 30, *) else"#,
         ],
       #"@available(*, unavailable, message: "Clarus!") @Test func f() {}"#:
         [#".__unavailable(message: "Clarus!", "#],

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -309,6 +309,41 @@ struct MiscellaneousTests {
     await valueGrid.validateCells()
   }
 
+  @Test("Test.underestimatedCaseCount property")
+  func underestimatedCaseCount() async throws {
+    do {
+      let test = try #require(await testFunction(named: "parameterized(i:)", in: NonSendableTests.self))
+      #expect(test.underestimatedCaseCount == FixtureData.zeroUpTo100.count)
+    }
+    do {
+      let test = try #require(await testFunction(named: "parameterized2(i:j:)", in: NonSendableTests.self))
+      #expect(test.underestimatedCaseCount == FixtureData.zeroUpTo100.count * FixtureData.smallStringArray.count)
+    }
+    do {
+      let test = try #require(await testFunction(named: "parameterized(i:)", in: SendableTests.self))
+      #expect(test.underestimatedCaseCount == FixtureData.zeroUpTo100.count)
+    }
+#if !SWT_NO_GLOBAL_ACTORS
+    do {
+      let test = try #require(await testFunction(named: "parameterized(i:)", in: MainActorIsolatedTests.self))
+      #expect(test.underestimatedCaseCount == FixtureData.zeroUpTo100.count)
+    }
+    do {
+      let test = try #require(await testFunction(named: "parameterizedNonisolated(i:)", in: MainActorIsolatedTests.self))
+      #expect(test.underestimatedCaseCount == FixtureData.zeroUpTo100.count)
+    }
+#endif
+
+    do {
+      let thisTest = try #require(await testFunction(named: "succeeds()", in: SendableTests.self))
+      #expect(thisTest.underestimatedCaseCount == 1)
+    }
+    do {
+      let thisTest = try #require(await test(for: SendableTests.self))
+      #expect(thisTest.underestimatedCaseCount == nil)
+    }
+  }
+
   @Test("Test.parameters property")
   func parametersProperty() async throws {
     do {
@@ -394,19 +429,19 @@ struct MiscellaneousTests {
   func parameterizationRelatedProperties() async throws {
     let typeTest = Test.__type(SendableTests.self, displayName: "", traits: [], sourceLocation: .init())
     #expect(!typeTest.isParameterized)
-    #expect(await typeTest.testCases == nil)
+    #expect(typeTest.testCases == nil)
     #expect(typeTest.parameters == nil)
 
     let monomorphicTestFunction = Test {}
     #expect(!monomorphicTestFunction.isParameterized)
-    let monomorphicTestFunctionTestCases = try #require(await monomorphicTestFunction.testCases)
+    let monomorphicTestFunctionTestCases = try #require(monomorphicTestFunction.testCases)
     #expect(monomorphicTestFunctionTestCases.underestimatedCount == 1)
     let monomorphicTestFunctionParameters = try #require(monomorphicTestFunction.parameters)
     #expect(monomorphicTestFunctionParameters.isEmpty)
 
     let parameterizedTestFunction = Test(arguments: 0 ..< 100, parameters: [Test.ParameterInfo(index: 0, firstName: "i")]) { _ in }
     #expect(parameterizedTestFunction.isParameterized)
-    let parameterizedTestFunctionTestCases = try #require(await parameterizedTestFunction.testCases)
+    let parameterizedTestFunctionTestCases = try #require(parameterizedTestFunction.testCases)
     #expect(parameterizedTestFunctionTestCases.underestimatedCount == 100)
     let parameterizedTestFunctionParameters = try #require(parameterizedTestFunction.parameters)
     #expect(parameterizedTestFunctionParameters.count == 1)
@@ -418,7 +453,7 @@ struct MiscellaneousTests {
       Test.ParameterInfo(index: 1, firstName: "j", secondName: "value"),
     ]) { _, _ in }
     #expect(parameterizedTestFunction2.isParameterized)
-    let parameterizedTestFunction2TestCases = try #require(await parameterizedTestFunction2.testCases)
+    let parameterizedTestFunction2TestCases = try #require(parameterizedTestFunction2.testCases)
     #expect(parameterizedTestFunction2TestCases.underestimatedCount == 100 * 100)
     let parameterizedTestFunction2Parameters = try #require(parameterizedTestFunction2.parameters)
     #expect(parameterizedTestFunction2Parameters.count == 2)

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -738,42 +738,6 @@ final class RunnerTests: XCTestCase {
     await fulfillment(of: [testStarted], timeout: 0.0)
   }
 
-#if SWT_TARGET_OS_APPLE
-  @Suite(.hidden) struct AvailabilityOfArguments {
-    @available(macOS 999.0, iOS 999.0, watchOS 999.0, tvOS 999.0, *)
-    struct Arg: Sendable {
-      init() {
-        XCTFail("Unexpectedly initialized an instance of \(Self.self)")
-      }
-    }
-
-    @available(macOS 999.0, iOS 999.0, watchOS 999.0, tvOS 999.0, *)
-    @Test(.hidden, arguments: [Arg(), Arg(), Arg()])
-    func f(arg: Arg) {}
-  }
-
-  func testAvailabilityOfArguments() async throws {
-    let suiteStarted = expectation(description: "Test suite started")
-    let testStarted = expectation(description: "Test suite started")
-    testStarted.isInverted = true
-    var configuration = Configuration()
-    configuration.eventHandler = { event, context in
-      switch event.kind {
-      case .testStarted:
-        if true == context.test?.isSuite {
-          suiteStarted.fulfill()
-        } else {
-          testStarted.fulfill()
-        }
-      default:
-        break
-      }
-    }
-    await runTest(for: AvailabilityOfArguments.self, configuration: configuration)
-    await fulfillment(of: [suiteStarted, testStarted], timeout: 0.0)
-  }
-#endif
-
 #if !SWT_NO_GLOBAL_ACTORS
   @TaskLocal static var isMainActorIsolationEnforced = false
 

--- a/Tests/TestingTests/Test.Case.Argument.IDTests.swift
+++ b/Tests/TestingTests/Test.Case.Argument.IDTests.swift
@@ -21,7 +21,7 @@ struct Test_Case_Argument_IDTests {
       arguments: [123],
       parameters: [Test.ParameterInfo(index: 0, firstName: "value")]
     ) { _ in }
-    let testCases = try #require(await test.testCases)
+    let testCases = try #require(test.testCases)
     let testCase = try #require(testCases.first { _ in true })
     #expect(testCase.arguments.count == 1)
     let argument = try #require(testCase.arguments.first)
@@ -35,7 +35,7 @@ struct Test_Case_Argument_IDTests {
       arguments: [MyCustomTestArgument(x: 123, y: "abc")],
       parameters: [Test.ParameterInfo(index: 0, firstName: "value")]
     ) { _ in }
-    let testCases = try #require(await test.testCases)
+    let testCases = try #require(test.testCases)
     let testCase = try #require(testCases.first { _ in true })
     #expect(testCase.arguments.count == 1)
     let argument = try #require(testCase.arguments.first)
@@ -52,7 +52,7 @@ struct Test_Case_Argument_IDTests {
       arguments: [MyIdentifiableArgument(id: "abc")],
       parameters: [Test.ParameterInfo(index: 0, firstName: "value")]
     ) { _ in }
-    let testCases = try #require(await test.testCases)
+    let testCases = try #require(test.testCases)
     let testCase = try #require(testCases.first { _ in true })
     #expect(testCase.arguments.count == 1)
     let argument = try #require(testCase.arguments.first)

--- a/Tests/TestingTests/TestCaseSelectionTests.swift
+++ b/Tests/TestingTests/TestCaseSelectionTests.swift
@@ -18,7 +18,7 @@ struct TestCaseSelectionTests {
       #expect(value == "a")
     }
 
-    let firstTestCase = try #require(await fixtureTest.testCases?.first { _ in true })
+    let firstTestCase = try #require(fixtureTest.testCases?.first { _ in true })
 
     var configuration = Configuration()
     configuration.testCaseFilter = { testCase, _ in
@@ -45,7 +45,7 @@ struct TestCaseSelectionTests {
       #expect(value != "b")
     }
 
-    let testCases = Array(try #require(await fixtureTest.testCases))
+    let testCases = Array(try #require(fixtureTest.testCases))
     let firstTestCaseID = try #require(testCases.first?.id)
     let lastTestCaseID = try #require(testCases.last?.id)
 
@@ -84,7 +84,7 @@ struct TestCaseSelectionTests {
       #expect(stringValue == "b" && intValue == 2)
     }
 
-    let selectedTestCase = try #require(await fixtureTest.testCases?.first { testCase in
+    let selectedTestCase = try #require(fixtureTest.testCases?.first { testCase in
       guard let firstArg = testCase.arguments.first?.value as? String,
             let secondArg = testCase.arguments.last?.value as? Int
       else {
@@ -121,7 +121,7 @@ struct TestCaseSelectionTests {
       #expect(arg.x == 1 && arg.y == "a")
     }
 
-    let firstTestCase = try #require(await fixtureTest.testCases?.first { _ in true })
+    let firstTestCase = try #require(fixtureTest.testCases?.first { _ in true })
 
     var configuration = Configuration()
     configuration.testCaseFilter = { testCase, _ in
@@ -151,7 +151,7 @@ struct TestCaseSelectionTests {
       #expect(arg.id == "a")
     }
 
-    let selectedTestCase = try #require(await fixtureTest.testCases?.first { _ in true })
+    let selectedTestCase = try #require(fixtureTest.testCases?.first { _ in true })
 
     var configuration = Configuration()
     configuration.testCaseFilter = { testCase, _ in

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -163,7 +163,7 @@ extension Test {
     testFunction: @escaping @Sendable (C.Element) async throws -> Void
   ) where C: Collection & Sendable, C.Element: Sendable {
     let sourceLocation = SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column)
-    let caseGenerator = Case.Generator(arguments: { collection }, parameters: parameters, testFunction: testFunction)
+    let caseGenerator = Case.Generator(arguments: collection, parameters: parameters, testFunction: testFunction)
     self.init(name: name, displayName: name, traits: traits, sourceLocation: sourceLocation, containingType: nil, testCases: caseGenerator, parameters: parameters)
   }
 
@@ -195,7 +195,7 @@ extension Test {
     testFunction: @escaping @Sendable (C1.Element, C2.Element) async throws -> Void
   ) where C1: Collection & Sendable, C1.Element: Sendable, C2: Collection & Sendable, C2.Element: Sendable {
     let sourceLocation = SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column)
-    let caseGenerator = Case.Generator(arguments: { collection1 }, { collection2 }, parameters: parameters, testFunction: testFunction)
+    let caseGenerator = Case.Generator(arguments: collection1, collection2, parameters: parameters, testFunction: testFunction)
     self.init(name: name, displayName: name, traits: traits, sourceLocation: sourceLocation, containingType: nil, testCases: caseGenerator, parameters: parameters)
   }
 
@@ -222,7 +222,7 @@ extension Test {
     testFunction: @escaping @Sendable ((C1.Element, C2.Element)) async throws -> Void
   ) where C1: Collection & Sendable, C1.Element: Sendable, C2: Collection & Sendable, C2.Element: Sendable {
     let sourceLocation = SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column)
-    let caseGenerator = Case.Generator(arguments: { zippedCollections }, parameters: parameters, testFunction: testFunction)
+    let caseGenerator = Case.Generator(arguments: zippedCollections, parameters: parameters, testFunction: testFunction)
     self.init(name: name, displayName: name, traits: traits, sourceLocation: sourceLocation, containingType: nil, testCases: caseGenerator, parameters: parameters)
   }
 }


### PR DESCRIPTION


This PR rethinks the work in https://github.com/apple/swift-testing/pull/133. Instead of lazily evaluating individual arguments, we can instead lazily evaluate the entire test. In the event the test is unavailable, we substitute a zero-argument no-op function so that there is no opportunity for us to touch unavailable type metadata. 🤞🏻

Resolves rdar://118996437.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
