### PR TITLE
Introduce snapshot types for Test, Test.Case, and related types

### DIFF
--- a/Sources/Testing/Parameterization/Test.Case.swift
+++ b/Sources/Testing/Parameterization/Test.Case.swift
@@ -127,8 +127,68 @@ extension Test {
 
 // MARK: - Codable
 
+extension Test.ParameterInfo: Codable {}
 extension Test.Case.Argument.ID: Codable {}
 
 // MARK: - Equatable, Hashable
 
+extension Test.ParameterInfo: Equatable {}
 extension Test.Case.Argument.ID: Hashable {}
+
+// MARK: - Snapshotting
+
+extension Test.Case {
+  /// A serializable snapshot of a ``Test/Case`` instance.
+  @_spi(ExperimentalSnapshotting)
+  public struct Snapshot: Sendable, Codable {
+    /// The ID of this test case.
+    public var id: ID
+
+    /// The arguments passed to this test case.
+    public var arguments: [Argument.Snapshot]
+
+    /// Initialize an instance of this type by snapshotting the specified test
+    /// case.
+    ///
+    /// - Parameters:
+    ///   - testCase: The original test case to snapshot.
+    init(snapshotting testCase: Test.Case) {
+      id = testCase.id
+      arguments = testCase.arguments.map(Test.Case.Argument.Snapshot.init)
+    }
+  }
+}
+
+extension Test.Case.Argument {
+  /// A serializable snapshot of a ``Test/Case/Argument`` instance.
+  @_spi(ExperimentalSnapshotting)
+  public struct Snapshot: Sendable, Codable {
+    /// The ID of this parameterized test argument, if any.
+    public var id: Test.Case.Argument.ID?
+
+    /// A description of this parameterized test argument's
+    /// ``Test/Case/Argument/value`` property, formatted using
+    /// `String(describingForTest:)`.
+    public var valueDescription: String
+
+    /// A debug description of this parameterized test argument's
+    /// ``Test/Case/Argument/value`` property, formatted using
+    /// `String(reflecting:)`.
+    public var valueDebugDescription: String?
+
+    /// The parameter of the test function to which this argument was passed.
+    public var parameter: Test.ParameterInfo
+
+    /// Initialize an instance of this type by snapshotting the specified test
+    /// case argument.
+    ///
+    /// - Parameters:
+    ///   - argument: The original test case argument to snapshot.
+    init(snapshotting argument: Test.Case.Argument) {
+      id = argument.id
+      valueDescription = String(describingForTest: argument.value)
+      valueDebugDescription = String(reflecting: argument.value)
+      parameter = argument.parameter
+    }
+  }
+}

--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -172,3 +172,60 @@ extension Test: Equatable, Hashable {
     hasher.combine(id)
   }
 }
+
+// MARK: - Snapshotting
+
+extension Test {
+  /// A serializable snapshot of a ``Test`` instance.
+  @_spi(ExperimentalSnapshotting)
+  public struct Snapshot: Sendable, Codable, Identifiable {
+    /// The ID of this test.
+    public var id: Test.ID
+
+    /// The name of this test.
+    ///
+    /// ## See Also
+    ///
+    /// - ``Test/name``
+    public var name: String
+
+    /// The customized display name of this test, if any.
+    public var displayName: String?
+
+    // FIXME: Include traits as well.
+
+    /// The source location of this test.
+    public var sourceLocation: SourceLocation
+
+    /// The set of test cases associated with this test, if any.
+    ///
+    /// ## See Also
+    ///
+    /// - ``Test/testCases``
+    @_spi(ExperimentalParameterizedTesting)
+    public var testCases: [Test.Case.Snapshot]?
+
+    /// The test function parameters, if any.
+    ///
+    /// ## See Also
+    ///
+    /// - ``Test/parameters``
+    @_spi(ExperimentalParameterizedTesting)
+    public var parameters: [ParameterInfo]?
+
+    /// Initialize an instance of this type by snapshotting the specified test.
+    ///
+    /// - Parameters:
+    ///   - test: The original test to snapshot.
+    public init(snapshotting test: Test) async {
+      id = test.id
+      name = test.name
+      displayName = test.displayName
+      sourceLocation = test.sourceLocation
+      // FIXME: Remove this `await` and make this function non-`async` once
+      // pending changes in #146 land.
+      testCases = await test.testCases?.map(Test.Case.Snapshot.init)
+      parameters = test.parameters
+    }
+  }
+}

--- a/Tests/TestingTests/Test.SnapshotTests.swift
+++ b/Tests/TestingTests/Test.SnapshotTests.swift
@@ -1,0 +1,34 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@_spi(ExperimentalSnapshotting) @_spi(ExperimentalParameterizedTesting) import Testing
+
+#if canImport(Foundation)
+import Foundation
+#endif
+
+@Suite("Test.Snapshot tests")
+struct Test_SnapshotTests {
+#if canImport(Foundation)
+  @Test("Codable")
+  func codable() async throws {
+    let test = try #require(Test.current)
+    let snapshot = await Test.Snapshot(snapshotting: test)
+    let decoded = try JSONDecoder().decode(Test.Snapshot.self, from: JSONEncoder().encode(snapshot))
+
+    #expect(decoded.id == snapshot.id)
+    #expect(decoded.name == snapshot.name)
+    #expect(decoded.displayName == snapshot.displayName)
+    #expect(decoded.sourceLocation == snapshot.sourceLocation)
+    // FIXME: Compare traits as well, once they are included.
+    #expect(decoded.parameters == snapshot.parameters)
+  }
+#endif
+}


### PR DESCRIPTION
This makes some of the core types which represent tests and their parameterized test cases serializable, to facilitate integration with tools.

### Modifications:

- Add the following snapshot types:
  - `Test.Snapshot`
  - `Test.Case.Snapshot`
  - `Test.Case.Argument.Snapshot`
- Add direct conformance by `Test.ParameterInfo` to `Equatable` and `Codable` since it is a trivial type.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Resolves rdar://91900185
