### PR TITLE
Introduce snapshot types for Runner.Plan and its supporting types

### DIFF
--- a/Sources/Testing/Events/Event.swift
+++ b/Sources/Testing/Events/Event.swift
@@ -257,7 +257,7 @@ extension Event {
   }
 }
 
-// MARK: - Snapshot
+// MARK: - Snapshotting
 
 extension Event {
   /// A serializable event that occurred during testing.

--- a/Sources/Testing/Expectations/Expectation.swift
+++ b/Sources/Testing/Expectations/Expectation.swift
@@ -63,7 +63,7 @@ public struct ExpectationFailedError: Error {
   public var expectation: Expectation
 }
 
-// MARK: - Snapshot
+// MARK: - Snapshotting
 
 extension Expectation {
   /// A serializable type describing an expectation that has been evaluated.

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -180,7 +180,7 @@ extension Issue.Kind: CustomStringConvertible {
   }
 }
 
-// MARK: - Codable
+// MARK: - Snapshotting
 
 extension Issue {
   /// A serializable type describing a failure or warning which occurred during a test.

--- a/Sources/Testing/Running/SkipInfo.swift
+++ b/Sources/Testing/Running/SkipInfo.swift
@@ -48,6 +48,10 @@ public struct SkipInfo: Sendable {
 // custom trait can signal that the test it is attached to should be skipped.
 extension SkipInfo: Error {}
 
+// MARK: - Equatable, Hashable
+
+extension SkipInfo: Equatable, Hashable {}
+
 // MARK: - Codable
 
 extension SkipInfo: Codable {}

--- a/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
+++ b/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
@@ -1,0 +1,72 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable @_spi(ExperimentalSnapshotting) @_spi(ExperimentalTestRunning) import Testing
+
+#if canImport(Foundation)
+import Foundation
+#endif
+
+@Suite("Runner.Plan.Snapshot tests")
+struct Runner_Plan_SnapshotTests {
+#if canImport(Foundation)
+  @Test("Codable")
+  func codable() async throws {
+    let suite = try #require(await test(for: Runner_Plan_SnapshotFixtures.self))
+
+    var configuration = Configuration()
+    configuration.setTestFilter(toMatch: .init(testIDs: [suite.id]), includeHiddenTests: true)
+
+    let plan = await Runner.Plan(configuration: configuration)
+    let snapshot = await Runner.Plan.Snapshot(snapshotting: plan)
+    let decoded = try JSONDecoder().decode(Runner.Plan.Snapshot.self, from: JSONEncoder().encode(snapshot))
+
+    try #require(decoded.steps.count == snapshot.steps.count)
+
+    func sort(_ lhs: Runner.Plan.Step.Snapshot, _ rhs: Runner.Plan.Step.Snapshot) -> Bool {
+      String(describing: lhs.test.id) < String(describing: rhs.test.id)
+    }
+
+    for (decodedStep, snapshotStep) in zip(decoded.steps.sorted(by: sort), snapshot.steps.sorted(by: sort)) {
+      #expect(decodedStep.test.id == snapshotStep.test.id)
+
+      switch (decodedStep.action, snapshotStep.action) {
+      case (.run, .run):
+        break
+      case let (.skip(decodedSkipInfo), .skip(snapshotSkipInfo)):
+        #expect(decodedSkipInfo == snapshotSkipInfo)
+      case let (.recordIssue(decodedIssue), .recordIssue(snapshotIssue)):
+        #expect(String(describing: decodedIssue) == String(describing: snapshotIssue))
+      default:
+        Issue.record("Decoded step does not match the original snapshotted step: decodedStep: \(decodedStep), snapshotStep: \(snapshotStep)")
+      }
+    }
+  }
+#endif
+}
+
+// MARK: - Fixture tests
+
+@Suite(.hidden)
+private struct Runner_Plan_SnapshotFixtures {
+  @Test(.hidden)
+  func basicTest() {}
+
+  @Test(.hidden, .disabled("To validate skip action"))
+  func disabledTest() {}
+
+  private static func _erroneousCondition() throws -> Bool {
+    struct ContrivedError: Error {}
+    throw ContrivedError()
+  }
+
+  @Test(.hidden, .enabled(if: try _erroneousCondition(), "To demonstrate recordIssue action"))
+  func erroneousTest() {}
+}


### PR DESCRIPTION
This makes several of the types which represent runner plans serializable, to facilitate integration with tools.

### Modifications:

- Add the following snapshot types:
  - `Runner.Plan.Snapshot`
  - `Runner.Plan.Step.Snapshot`
  - `Runner.Plan.Action.Snapshot`
- Add direct conformance by `SkipInfo` to `Equatable` and `Codable` since it is a trivial type.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Resolves rdar://91900185
