### PR TITLE
Remove unnecessary 'await' in calls to Test.testCases

### DIFF
--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -296,13 +296,9 @@ extension Runner.Plan {
     ///
     /// - Parameters:
     ///   - plan: The original plan to snapshot.
-    public init(snapshotting plan: Runner.Plan) async {
-      await plan.stepGraph.forEach { keyPath, step in
-        let step: Runner.Plan.Step.Snapshot? = if let step {
-          await Step.Snapshot(snapshotting: step)
-        } else {
-          nil
-        }
+    public init(snapshotting plan: Runner.Plan) {
+      plan.stepGraph.forEach { keyPath, step in
+        let step = step.map(Step.Snapshot.init(snapshotting:))
         _stepGraph.insertValue(step, at: keyPath)
       }
     }
@@ -365,8 +361,8 @@ extension Runner.Plan.Step {
     ///
     /// - Parameters:
     ///   - step: The original step to snapshot.
-    init(snapshotting step: Runner.Plan.Step) async {
-      test = await Test.Snapshot(snapshotting: step.test)
+    init(snapshotting step: Runner.Plan.Step) {
+      test = Test.Snapshot(snapshotting: step.test)
       action = Runner.Plan.Action.Snapshot(snapshotting: step.action)
     }
   }

--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -236,14 +236,12 @@ extension Test {
     ///
     /// - Parameters:
     ///   - test: The original test to snapshot.
-    public init(snapshotting test: Test) async {
+    public init(snapshotting test: Test) {
       id = test.id
       name = test.name
       displayName = test.displayName
       sourceLocation = test.sourceLocation
-      // FIXME: Remove this `await` and make this function non-`async` once
-      // pending changes in #146 land.
-      testCases = await test.testCases?.map(Test.Case.Snapshot.init)
+      testCases = test.testCases?.map(Test.Case.Snapshot.init)
       parameters = test.parameters
     }
   }

--- a/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
+++ b/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
@@ -25,7 +25,7 @@ struct Runner_Plan_SnapshotTests {
     configuration.setTestFilter(toMatch: .init(testIDs: [suite.id]), includeHiddenTests: true)
 
     let plan = await Runner.Plan(configuration: configuration)
-    let snapshot = await Runner.Plan.Snapshot(snapshotting: plan)
+    let snapshot = Runner.Plan.Snapshot(snapshotting: plan)
     let decoded = try JSONDecoder().decode(Runner.Plan.Snapshot.self, from: JSONEncoder().encode(snapshot))
 
     try #require(decoded.steps.count == snapshot.steps.count)

--- a/Tests/TestingTests/Test.SnapshotTests.swift
+++ b/Tests/TestingTests/Test.SnapshotTests.swift
@@ -18,9 +18,9 @@ import Foundation
 struct Test_SnapshotTests {
 #if canImport(Foundation)
   @Test("Codable")
-  func codable() async throws {
+  func codable() throws {
     let test = try #require(Test.current)
-    let snapshot = await Test.Snapshot(snapshotting: test)
+    let snapshot = Test.Snapshot(snapshotting: test)
     let decoded = try JSONDecoder().decode(Test.Snapshot.self, from: JSONEncoder().encode(snapshot))
 
     #expect(decoded.id == snapshot.id)


### PR DESCRIPTION
Now that #146 has landed, this removes some unnecessary `await` and `async` keywords from recently-added snapshot types.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
