### PR TITLE
Fix a missing newline when emitting a warning diagnostic to the console.

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
@@ -293,6 +293,6 @@ extension Event.ConsoleOutputRecorder {
   /// The caller is responsible for presenting this message to the user.
   static func warning(_ message: String, options: [Event.ConsoleOutputRecorder.Option]) -> String {
     let symbol = Event.Symbol.warning.stringValue(options: Set(options))
-    return "\(symbol) \(message)"
+    return "\(symbol) \(message)\n"
   }
 }


### PR DESCRIPTION
Accidentally omitted said newline in #145. This PR restores it. Currently, we use this code path when `XCTestScaffold` and `--enable-experimental-swift-testing` are used together.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
