### PR TITLE
Refine `makeTestFilter()` further.

### DIFF
--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -177,29 +177,10 @@ public struct Configuration: Sendable {
 /// - Parameters:
 ///   - selection: A set of test IDs to be filtered.
 ///
-/// By default, all tests are run and no filter is set.
+/// - Returns: A test filter that filters tests to those specified by
+///   `selection`.
 @_spi(ExperimentalTestRunning)
 public func makeTestFilter(matching selection: some Collection<Test.ID>) -> Configuration.TestFilter {
   let selection = Test.ID.Selection(testIDs: selection)
-  return makeTestFilter(matching: selection, includeHiddenTests: false)
+  return selection.contains
 }
-
-/// Make a test filter that filters tests to those specified by a set of test
-/// IDs, optionally including or excluding hidden tests.
-///
-/// - Parameters:
-///   - selection: A selection of test IDs to be filtered.
-///   - includeHiddenTests: If false, a test annotated with the `.hidden`
-///     trait will not be included, even if its ID is present in `selection`.
-///
-/// By default, all tests are run and no filter is set.
-func makeTestFilter(matching selection: Test.ID.Selection, includeHiddenTests: Bool) -> Configuration.TestFilter {
-  if includeHiddenTests {
-    return selection.contains
-  } else {
-    return { test in
-      !test.isHidden && selection.contains(test)
-    }
-  }
-}
-

--- a/Tests/TestingTests/PlanTests.swift
+++ b/Tests/TestingTests/PlanTests.swift
@@ -26,7 +26,7 @@ struct PlanTests {
       testB,
     ]
 
-    let selection = Test.ID.Selection(testIDs: [innerTestType.id])
+    let selection = [innerTestType.id]
     var configuration = Configuration()
     configuration.uncheckedTestFilter = makeTestFilter(matching: selection)
 
@@ -52,7 +52,7 @@ struct PlanTests {
     ]
 
     var configuration = Configuration()
-    let selection = Test.ID.Selection(testIDs: [innerTestType.id, outerTestType.id])
+    let selection = [innerTestType.id, outerTestType.id]
     configuration.uncheckedTestFilter = makeTestFilter(matching: selection)
 
     let plan = await Runner.Plan(tests: tests, configuration: configuration)
@@ -72,7 +72,7 @@ struct PlanTests {
     let tests = [outerTestType, deeplyNestedTest]
 
     var configuration = Configuration()
-    let selection = Test.ID.Selection(testIDs: [outerTestType.id, deeplyNestedTest.id])
+    let selection = [outerTestType.id, deeplyNestedTest.id]
     configuration.uncheckedTestFilter = makeTestFilter(matching: selection)
 
     let plan = await Runner.Plan(tests: tests, configuration: configuration)
@@ -91,7 +91,7 @@ struct PlanTests {
     let tests = [testSuiteA, testSuiteB, testSuiteC, testFuncX]
 
     var configuration = Configuration()
-    let selection = Test.ID.Selection(testIDs: [testSuiteA.id])
+    let selection = [testSuiteA.id]
     configuration.uncheckedTestFilter = makeTestFilter(matching: selection)
 
     let plan = await Runner.Plan(tests: tests, configuration: configuration)

--- a/Tests/TestingTests/PlanTests.swift
+++ b/Tests/TestingTests/PlanTests.swift
@@ -28,7 +28,7 @@ struct PlanTests {
 
     let selection = Test.ID.Selection(testIDs: [innerTestType.id])
     var configuration = Configuration()
-    configuration.uncheckedTestFilter = makeTestFilter(matching: selection, includeHiddenTests: true)
+    configuration.uncheckedTestFilter = makeTestFilter(matching: selection)
 
     let plan = await Runner.Plan(tests: tests, configuration: configuration)
     #expect(plan.steps.contains(where: { $0.test == outerTestType }))
@@ -53,7 +53,7 @@ struct PlanTests {
 
     var configuration = Configuration()
     let selection = Test.ID.Selection(testIDs: [innerTestType.id, outerTestType.id])
-    configuration.uncheckedTestFilter = makeTestFilter(matching: selection, includeHiddenTests: true)
+    configuration.uncheckedTestFilter = makeTestFilter(matching: selection)
 
     let plan = await Runner.Plan(tests: tests, configuration: configuration)
     let planTests = plan.steps.map(\.test)
@@ -73,7 +73,7 @@ struct PlanTests {
 
     var configuration = Configuration()
     let selection = Test.ID.Selection(testIDs: [outerTestType.id, deeplyNestedTest.id])
-    configuration.uncheckedTestFilter = makeTestFilter(matching: selection, includeHiddenTests: true)
+    configuration.uncheckedTestFilter = makeTestFilter(matching: selection)
 
     let plan = await Runner.Plan(tests: tests, configuration: configuration)
 
@@ -92,7 +92,7 @@ struct PlanTests {
 
     var configuration = Configuration()
     let selection = Test.ID.Selection(testIDs: [testSuiteA.id])
-    configuration.uncheckedTestFilter = makeTestFilter(matching: selection, includeHiddenTests: true)
+    configuration.uncheckedTestFilter = makeTestFilter(matching: selection)
 
     let plan = await Runner.Plan(tests: tests, configuration: configuration)
     let testFuncXWithTraits = try #require(plan.steps.map(\.test).first { $0.name == "x()" })

--- a/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
+++ b/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
@@ -22,7 +22,7 @@ struct Runner_Plan_SnapshotTests {
     let suite = try #require(await test(for: Runner_Plan_SnapshotFixtures.self))
 
     var configuration = Configuration()
-    configuration.uncheckedTestFilter = makeTestFilter(matching: .init(testIDs: [suite.id]))
+    configuration.uncheckedTestFilter = makeTestFilter(matching: [suite.id])
 
     let plan = await Runner.Plan(configuration: configuration)
     let snapshot = Runner.Plan.Snapshot(snapshotting: plan)

--- a/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
+++ b/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
@@ -22,7 +22,7 @@ struct Runner_Plan_SnapshotTests {
     let suite = try #require(await test(for: Runner_Plan_SnapshotFixtures.self))
 
     var configuration = Configuration()
-    configuration.uncheckedTestFilter = makeTestFilter(matching: .init(testIDs: [suite.id]), includeHiddenTests: true)
+    configuration.uncheckedTestFilter = makeTestFilter(matching: .init(testIDs: [suite.id]))
 
     let plan = await Runner.Plan(configuration: configuration)
     let snapshot = Runner.Plan.Snapshot(snapshotting: plan)

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -251,7 +251,7 @@ final class RunnerTests: XCTestCase {
 
     var configuration = Configuration()
     let selection = Test.ID.Selection(testIDs: [testSuite.id])
-    configuration.uncheckedTestFilter = makeTestFilter(matching: selection, includeHiddenTests: true)
+    configuration.uncheckedTestFilter = makeTestFilter(matching: selection)
 
     let runner = await Runner(testing: [
       testSuite,
@@ -302,7 +302,7 @@ final class RunnerTests: XCTestCase {
 
     var configuration = Configuration()
     let selection = Test.ID.Selection(testIDs: selectedTestIDs)
-    configuration.uncheckedTestFilter = makeTestFilter(matching: selection, includeHiddenTests: true)
+    configuration.uncheckedTestFilter = makeTestFilter(matching: selection)
 
     let runner = await Runner(configuration: configuration)
     let plan = runner.plan
@@ -326,7 +326,7 @@ final class RunnerTests: XCTestCase {
     ]
 
     var configuration1 = Configuration()
-    configuration1.testFilter = makeTestFilter(matching: .init(testIDs: selectedTestIDs), includeHiddenTests: false)
+    configuration1.testFilter = makeTestFilter(matching: .init(testIDs: selectedTestIDs))
 
     var configuration2 = Configuration()
     configuration2.testFilter = makeTestFilter(matching: selectedTestIDs)

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -250,7 +250,7 @@ final class RunnerTests: XCTestCase {
     let testFunc = try #require(await testFunction(named: "duelingConditions()", in: NeverRunTests.self))
 
     var configuration = Configuration()
-    let selection = Test.ID.Selection(testIDs: [testSuite.id])
+    let selection = [testSuite.id]
     configuration.uncheckedTestFilter = makeTestFilter(matching: selection)
 
     let runner = await Runner(testing: [
@@ -301,8 +301,7 @@ final class RunnerTests: XCTestCase {
     XCTAssertFalse(selectedTestIDs.isEmpty)
 
     var configuration = Configuration()
-    let selection = Test.ID.Selection(testIDs: selectedTestIDs)
-    configuration.uncheckedTestFilter = makeTestFilter(matching: selection)
+    configuration.uncheckedTestFilter = makeTestFilter(matching: selectedTestIDs)
 
     let runner = await Runner(configuration: configuration)
     let plan = runner.plan
@@ -326,7 +325,7 @@ final class RunnerTests: XCTestCase {
     ]
 
     var configuration1 = Configuration()
-    configuration1.testFilter = makeTestFilter(matching: .init(testIDs: selectedTestIDs))
+    configuration1.testFilter = makeTestFilter(matching: selectedTestIDs)
 
     var configuration2 = Configuration()
     configuration2.testFilter = makeTestFilter(matching: selectedTestIDs)

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -68,7 +68,7 @@ func runTest(for containingType: Any.Type, configuration: Configuration = .init(
 func runTestFunction(named name: String, in containingType: Any.Type, configuration: Configuration = .init()) async {
   var configuration = configuration
   let selection = Test.ID.Selection(testIDs: [Test.ID(type: containingType).child(named: name)])
-  configuration.uncheckedTestFilter = makeTestFilter(matching: selection, includeHiddenTests: true)
+  configuration.uncheckedTestFilter = makeTestFilter(matching: selection)
 
   let runner = await Runner(configuration: configuration)
   await runner.run()
@@ -92,7 +92,7 @@ extension Runner {
 
     var configuration = configuration
     let selection = Test.ID.Selection(testIDs: [Test.ID(moduleName: moduleName, nameComponents: [testName], sourceLocation: nil)])
-    configuration.uncheckedTestFilter = makeTestFilter(matching: selection, includeHiddenTests: true)
+    configuration.uncheckedTestFilter = makeTestFilter(matching: selection)
 
     await self.init(configuration: configuration)
   }
@@ -107,7 +107,7 @@ extension Runner.Plan {
   init(selecting containingType: Any.Type, configuration: Configuration = .init()) async {
     var configuration = configuration
     let selection = Test.ID.Selection(testIDs: [Test.ID(type: containingType)])
-    configuration.uncheckedTestFilter = makeTestFilter(matching: selection, includeHiddenTests: true)
+    configuration.uncheckedTestFilter = makeTestFilter(matching: selection)
 
     await self.init(configuration: configuration)
   }
@@ -288,6 +288,10 @@ extension Test.ID.Selection {
   init(testIDs: some Collection<[String]>) {
     self.init(testIDs: testIDs.lazy.map(Test.ID.init(_:)))
   }
+}
+
+func makeTestFilter(matching selection: Test.ID.Selection) -> Configuration.TestFilter {
+  selection.contains
 }
 
 extension Configuration {

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -67,7 +67,7 @@ func runTest(for containingType: Any.Type, configuration: Configuration = .init(
 /// If no test is found representing `containingType`, nothing is run.
 func runTestFunction(named name: String, in containingType: Any.Type, configuration: Configuration = .init()) async {
   var configuration = configuration
-  let selection = Test.ID.Selection(testIDs: [Test.ID(type: containingType).child(named: name)])
+  let selection = [Test.ID(type: containingType).child(named: name)]
   configuration.uncheckedTestFilter = makeTestFilter(matching: selection)
 
   let runner = await Runner(configuration: configuration)
@@ -91,7 +91,7 @@ extension Runner {
     let moduleName = String(fileID[..<fileID.lastIndex(of: "/")!])
 
     var configuration = configuration
-    let selection = Test.ID.Selection(testIDs: [Test.ID(moduleName: moduleName, nameComponents: [testName], sourceLocation: nil)])
+    let selection = [Test.ID(moduleName: moduleName, nameComponents: [testName], sourceLocation: nil)]
     configuration.uncheckedTestFilter = makeTestFilter(matching: selection)
 
     await self.init(configuration: configuration)
@@ -106,7 +106,7 @@ extension Runner.Plan {
   ///   - configuration: The configuration to use for planning.
   init(selecting containingType: Any.Type, configuration: Configuration = .init()) async {
     var configuration = configuration
-    let selection = Test.ID.Selection(testIDs: [Test.ID(type: containingType)])
+    let selection = [Test.ID(type: containingType)]
     configuration.uncheckedTestFilter = makeTestFilter(matching: selection)
 
     await self.init(configuration: configuration)
@@ -288,10 +288,6 @@ extension Test.ID.Selection {
   init(testIDs: some Collection<[String]>) {
     self.init(testIDs: testIDs.lazy.map(Test.ID.init(_:)))
   }
-}
-
-func makeTestFilter(matching selection: Test.ID.Selection) -> Configuration.TestFilter {
-  selection.contains
 }
 
 extension Configuration {


### PR DESCRIPTION
This PR refines the previous PR for this issue, #153. It removes the internal overload of `makeTestFilter(matching:uncheckedTestFilter:)` because it is redundant: since the result needs to be passed to `uncheckedTestFilter` to preserve its lack of `isHidden`-checking, it doesn't _also_ need to impose its own check.

I did add an internal overload of `makeTestFilter()` to the test target that just returns `selection.contains` as a convenience.

Resolves rdar://119205417 (again.)

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
