### PR TITLE
Update MigratingFromXCTest making it clear you must import Testing.

### DIFF
--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -29,7 +29,8 @@ Swift package or Xcode project. For more information on how to add it, see the
 
 ### Importing the testing library
 
-XCTest and the testing library are available from different modules. Instead of importing the XCTest module, import the Testing module:
+XCTest and the testing library are available from different modules. Instead of 
+importing the XCTest module, import the Testing module:
 
 @Row {
   @Column {
@@ -46,7 +47,9 @@ XCTest and the testing library are available from different modules. Instead of 
   }
 }
 
-A single source file can contain tests written with XCTest as well as other tests written with the testing library. Import both XCTest and Testing if a source file contains mixed test content.
+A single source file can contain tests written with XCTest as well as other 
+tests written with the testing library. Import both XCTest and Testing if a 
+source file contains mixed test content.
 
 ### Converting test classes
 

--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -27,6 +27,27 @@ Before the testing library can be used, it must be added as a dependency of your
 Swift package or Xcode project. For more information on how to add it, see the
 [Getting Started](doc:TemporaryGettingStarted) guide.
 
+### Importing the testing library
+
+XCTest and the testing library are available from different modules. Instead of importing the XCTest module, import the Testing module:
+
+@Row {
+  @Column {
+    ```swift
+    // Before
+    import XCTest
+    ```
+  }
+  @Column {
+    ```swift
+    // After
+    import Testing
+    ```
+  }
+}
+
+A single source file can contain tests written with XCTest as well as other tests written with the testing library. Import both XCTest and Testing if a source file contains mixed test content.
+
 ### Converting test classes
 
 XCTest groups related sets of test methods in test classes: classes that inherit


### PR DESCRIPTION
Update MigratingFromXCTest to make it clear one must `import Testing`

### Motivation:

Other guides mention that one has to `import Testing`, e.g. `DefiningTests`, but readers will see `MigratingFromXCTest` before they see `DefiningTests`, and "following along" while reading makes code not compile (since **must** import Testing).

### Modifications:

Made it clear that with XCTest one needs `import XCTest` and now with swift-testing one needs to `import Testing`.

### Result:

A more clear guide, that is easier to follow along.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
