### PR TITLE
Mark `XCTestScaffold` to-be-deprecated.

### DIFF
--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -86,13 +86,14 @@ extension XCTIssue {
 /// A type providing temporary tools for integrating the testing library and
 /// the XCTest framework.
 ///
-/// - Warning: This type is provided temporarily to aid in integrating the
-///   testing library with existing tools such as Swift Package Manager. It
-///   will be removed in a future release.
-///
 /// ## See Also
 ///
 /// - <doc:TemporaryGettingStarted>
+#if SWIFT_PM_SUPPORTS_SWIFT_TESTING
+@available(*, deprecated, message: "This version of Swift Package Manager supports running swift-testing tests directly. This type will be removed in a future release.")
+#else
+@available(swift, deprecated: 100000.0, message: "This type is provided temporarily to aid in integrating the testing library with existing tools such as Swift Package Manager. It will be removed in a future release.")
+#endif
 public enum XCTestScaffold: Sendable {
   /// Run all tests found in the current process and write output to the
   /// standard error stream.
@@ -104,10 +105,6 @@ public enum XCTestScaffold: Sendable {
   /// Output from the testing library is written to the standard error stream.
   /// The format of the output is not meant to be machine-readable and is
   /// subject to change.
-  ///
-  /// - Warning: This function is provided temporarily to aid in integrating the
-  ///   testing library with existing tools such as Swift Package Manager. It
-  ///   will be removed in a future release.
   ///
   /// ### Filtering tests
   ///
@@ -167,7 +164,9 @@ public enum XCTestScaffold: Sendable {
   ///
   /// - <doc:TemporaryGettingStarted>
 #if SWIFT_PM_SUPPORTS_SWIFT_TESTING
-  @available(*, deprecated, message: "This version of Swift Package Manager supports running swift-testing tests directly. This function has no effect.")
+  @available(*, deprecated, message: "This version of Swift Package Manager supports running swift-testing tests directly. This function has no effect and will be removed in a future release.")
+#else
+  @available(swift, deprecated: 100000.0, message: "This function is provided temporarily to aid in integrating the testing library with existing tools such as Swift Package Manager. It will be removed in a future release.")
 #endif
   public static func runAllTests(hostedBy testCase: XCTestCase) async {
 #if SWIFT_PM_SUPPORTS_SWIFT_TESTING


### PR DESCRIPTION
Currently, the documentation for `XCTestScaffold` has a "warning" callout to indicate that it is a temporary interface. This PR replaces the callout with a formal deprecation attribute so that the type and its members show as deprecated in our documentation. They are marked as deprecated in Swift 100000.0, which is a "magic" version number used in Apple's SDK to indicate "to-be-deprecated" status.

This change does not cause new diagnostics to be emitted at compile-time; it affects documentation only.

#### Before

<img width="618" alt="Screenshot 2023-12-12 at 6 47 40 PM" src="https://github.com/apple/swift-testing/assets/4145863/0804b000-daef-405c-89e1-8efb9cb162ed">

#### After

<img width="623" alt="Screenshot 2023-12-12 at 6 51 36 PM" src="https://github.com/apple/swift-testing/assets/4145863/6a1aeb12-122b-44a0-ba06-2e0d1f5c9779">

And, when referenced from another article:

<img width="638" alt="Screenshot 2023-12-12 at 6 46 11 PM" src="https://github.com/apple/swift-testing/assets/4145863/935ce1e1-4c25-4387-9a04-f539ec3795fb">

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
