### PR TITLE
Expand property accesses in `#expect()` and `#require()`.

### DIFF
--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -277,6 +277,67 @@ public func __checkInoutFunctionCall<T, /*each*/ U, R>(
   )
 }
 
+// MARK: - Property access
+
+/// Check that an expectation has passed after a condition has been evaluated
+/// and throw an error if it failed.
+///
+/// This overload is used by property accesses:
+///
+/// ```swift
+/// #expect(x.isFoodTruck)
+/// ```
+///
+/// - Warning: This function is used to implement the `#expect()` and
+///   `#require()` macros. Do not call it directly.
+public func __checkPropertyAccess<T>(
+  _ lhs: T, getting memberAccess: (T) -> Bool,
+  sourceCode: SourceCode,
+  comments: @autoclosure () -> [Comment],
+  isRequired: Bool,
+  sourceLocation: SourceLocation
+) -> Result<Void, any Error> {
+  let condition = memberAccess(lhs)
+  return __checkValue(
+    condition,
+    sourceCode: sourceCode,
+    expandedExpressionDescription: sourceCode.expandWithOperands(lhs, condition),
+    comments: comments(),
+    isRequired: isRequired,
+    sourceLocation: sourceLocation
+  )
+}
+
+/// Check that an expectation has passed after a condition has been evaluated
+/// and throw an error if it failed.
+///
+/// This overload is used to conditionally unwrap optional values produced from
+/// expanded property accesses:
+///
+/// ```swift
+/// let z = try #require(x.nearestFoodTruck)
+/// ```
+///
+/// - Warning: This function is used to implement the `#expect()` and
+///   `#require()` macros. Do not call it directly.
+public func __checkPropertyAccess<T, U>(
+  _ lhs: T, getting memberAccess: (T) -> U?,
+  sourceCode: SourceCode,
+  comments: @autoclosure () -> [Comment],
+  isRequired: Bool,
+  sourceLocation: SourceLocation
+) -> Result<U, any Error> {
+  let optionalValue = memberAccess(lhs)
+  return __checkValue(
+    optionalValue,
+    sourceCode: sourceCode,
+    expandedExpressionDescription: sourceCode.expandWithOperands(lhs, optionalValue),
+    comments: comments(),
+    isRequired: isRequired,
+    sourceLocation: sourceLocation
+  )
+}
+
 // MARK: - Collection diffing
 
 /// Check that an expectation has passed after a condition has been evaluated

--- a/Sources/Testing/SourceAttribution/SourceCode+Macro.swift
+++ b/Sources/Testing/SourceAttribution/SourceCode+Macro.swift
@@ -45,4 +45,16 @@ extension SourceCode {
   public static func __functionCall(_ value: String?, _ functionName: String, _ arguments: (label: String?, value: String)...) -> Self {
     Self(kind: .functionCall(value: value, functionName: functionName, arguments: arguments))
   }
+
+  /// Create an instance of ``SourceCode`` representing a property access.
+  ///
+  /// - Parameters:
+  ///   - value: The value whose property was accessed.
+  ///   - keyPath: The key path, relative to `value`, that was accessed, not
+  ///     including a leading backslash or period.
+  ///
+  /// - Returns: A new instance of ``SourceCode``.
+  public static func __fromPropertyAccess(_ value: String, _ keyPath: String) -> Self {
+    Self(kind: .propertyAccess(value: value, keyPath: keyPath))
+  }
 }

--- a/Sources/Testing/SourceAttribution/SourceCode.swift
+++ b/Sources/Testing/SourceAttribution/SourceCode.swift
@@ -37,6 +37,14 @@ public struct SourceCode: Sendable {
     ///   - functionName: The name of the function that was called.
     ///   - arguments: The arguments passed to the function.
     case functionCall(value: String?, functionName: String, arguments: [(label: String?, value: String)])
+
+    /// The source code represets a property access.
+    ///
+    /// - Parameters:
+    ///   - value: The value whose property was accessed.
+    ///   - keyPath: The key path, relative to `value`, that was accessed, not
+    ///     including a leading backslash or period.
+    case propertyAccess(value: String, keyPath: String)
   }
 
   /// The kind of syntax node represented by this instance.
@@ -105,6 +113,9 @@ public struct SourceCode: Sendable {
         return "\(sourceCodeAndValue(value, lhs)).\(functionName)(\(argumentList))"
       }
       return "\(functionName)(\(argumentList))"
+    case let .propertyAccess(value, keyPath):
+      let rhs = additionalValuesArray.first
+      return "\(sourceCodeAndValue(value, lhs)).\(sourceCodeAndValue(keyPath, rhs ?? nil, includeParenthesesIfNeeded: false))"
     }
   }
 }
@@ -143,6 +154,8 @@ extension SourceCode: CustomStringConvertible, CustomDebugStringConvertible {
         return "\(value).\(functionName)(\(argumentList))"
       }
       return "\(functionName)(\(argumentList))"
+    case let .propertyAccess(value, keyPath):
+      return "\(value).\(keyPath)"
     }
   }
 

--- a/Sources/TestingMacros/Support/SourceCodeCapturing.swift
+++ b/Sources/TestingMacros/Support/SourceCodeCapturing.swift
@@ -75,3 +75,12 @@ func createSourceCodeExprForFunctionCall(_ value: (some SyntaxProtocol)?, _ func
 
   return ".__functionCall(\(arguments))"
 }
+
+func createSourceCodeExprForPropertyAccess(_ value: ExprSyntax, _ keyPath: DeclReferenceExprSyntax) -> ExprSyntax {
+  let arguments = LabeledExprListSyntax {
+    LabeledExprSyntax(expression: StringLiteralExprSyntax(content: value.trimmedDescription))
+    LabeledExprSyntax(expression: StringLiteralExprSyntax(content: keyPath.baseName.trimmedDescription))
+  }
+
+  return ".__fromPropertyAccess(\(arguments))"
+}

--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -66,6 +66,12 @@ struct ConditionMacroTests {
         ##"Testing.__checkValue(a.b(&c, d), sourceCode: .__fromSyntaxNode("a.b(&c, d)"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(a.b(try c()))"##:
         ##"Testing.__checkValue(a.b(try c()), sourceCode: .__fromSyntaxNode("a.b(try c())"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+      ##"#expect(a?.b(c))"##:
+        ##"Testing.__checkFunctionCall(a.self, calling: { $0?.b($1) }, c, sourceCode: .__functionCall("a", "b", (nil, "c")), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+      ##"#expect(a???.b(c))"##:
+        ##"Testing.__checkFunctionCall(a.self, calling: { $0???.b($1) }, c, sourceCode: .__functionCall("a", "b", (nil, "c")), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+      ##"#expect(a?.b.c(d))"##:
+        ##"Testing.__checkFunctionCall(a?.b.self, calling: { $0?.c($1) }, d, sourceCode: .__functionCall("a?.b", "c", (nil, "d")), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect({}())"##:
         ##"Testing.__checkValue({}(), sourceCode: .__fromSyntaxNode("{}()"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(a.b(c: d))"##:
@@ -74,6 +80,12 @@ struct ConditionMacroTests {
         ##"Testing.__checkValue(a.b { c }, sourceCode: .__fromSyntaxNode("a.b { c }"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(a, sourceLocation: someValue)"##:
         ##"Testing.__checkValue(a, sourceCode: .__fromSyntaxNode("a"), comments: [], isRequired: false, sourceLocation: someValue).__expected()"##,
+      ##"#expect(a.isB)"##:
+        ##"Testing.__checkPropertyAccess(a.self, getting: { $0.isB }, sourceCode: .__fromPropertyAccess("a", "isB"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+      ##"#expect(a???.isB)"##:
+        ##"Testing.__checkPropertyAccess(a.self, getting: { $0???.isB }, sourceCode: .__fromPropertyAccess("a", "isB"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+      ##"#expect(a?.b.isB)"##:
+        ##"Testing.__checkPropertyAccess(a?.b.self, getting: { $0?.isB }, sourceCode: .__fromPropertyAccess("a?.b", "isB"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
     ]
   )
   func expectMacro(input: String, expectedOutput: String) throws {
@@ -128,6 +140,12 @@ struct ConditionMacroTests {
         ##"Testing.__checkValue(a.b(&c, d), sourceCode: .__fromSyntaxNode("a.b(&c, d)"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(a.b(try c()))"##:
         ##"Testing.__checkValue(a.b(try c()), sourceCode: .__fromSyntaxNode("a.b(try c())"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+      ##"#require(a?.b(c))"##:
+        ##"Testing.__checkFunctionCall(a.self, calling: { $0?.b($1) }, c, sourceCode: .__functionCall("a", "b", (nil, "c")), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+      ##"#require(a???.b(c))"##:
+        ##"Testing.__checkFunctionCall(a.self, calling: { $0???.b($1) }, c, sourceCode: .__functionCall("a", "b", (nil, "c")), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+      ##"#require(a?.b.c(d))"##:
+        ##"Testing.__checkFunctionCall(a?.b.self, calling: { $0?.c($1) }, d, sourceCode: .__functionCall("a?.b", "c", (nil, "d")), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require({}())"##:
         ##"Testing.__checkValue({}(), sourceCode: .__fromSyntaxNode("{}()"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(a.b(c: d))"##:
@@ -136,6 +154,12 @@ struct ConditionMacroTests {
         ##"Testing.__checkValue(a.b { c }, sourceCode: .__fromSyntaxNode("a.b { c }"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(a, sourceLocation: someValue)"##:
         ##"Testing.__checkValue(a, sourceCode: .__fromSyntaxNode("a"), comments: [], isRequired: true, sourceLocation: someValue).__required()"##,
+      ##"#require(a.isB)"##:
+        ##"Testing.__checkPropertyAccess(a.self, getting: { $0.isB }, sourceCode: .__fromPropertyAccess("a", "isB"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+      ##"#require(a???.isB)"##:
+        ##"Testing.__checkPropertyAccess(a.self, getting: { $0???.isB }, sourceCode: .__fromPropertyAccess("a", "isB"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+      ##"#require(a?.b.isB)"##:
+        ##"Testing.__checkPropertyAccess(a?.b.self, getting: { $0?.isB }, sourceCode: .__fromPropertyAccess("a?.b", "isB"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
     ]
   )
   func requireMacro(input: String, expectedOutput: String) throws {
@@ -147,7 +171,7 @@ struct ConditionMacroTests {
   @Test("Unwrapping #require() macro",
     arguments: [
       ##"#require(Optional<Int>.none)"##:
-        ##"Testing.__checkValue(Optional<Int>.none, sourceCode: .__fromSyntaxNode("Optional<Int>.none"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkPropertyAccess(Optional<Int>.self, getting: { $0.none }, sourceCode: .__fromPropertyAccess("Optional<Int>", "none"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(nil ?? 123)"##:
         ##"Testing.__checkBinaryOperation(nil, { $0 ?? $1() }, 123, sourceCode: .__fromBinaryOperation("nil", "??", "123"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(123 ?? nil)"##:


### PR DESCRIPTION
Currently, swift-testing is able to expand member function accesses like `foo.bar()` into `foo` and `bar()` so that it can provide the values of both subexpressions on expectation failure. This PR enables the same sort of functionality for property accesses (`foo.isBar`).

This PR also ensures that optional chaining in either member function calls or property accesses is observed so that an expression like `foo?.bar()` will not fail to compile.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
