### PR TITLE
Report an error when attempting to use --filter or --skip in unsupported environments

### DIFF
--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -42,6 +42,7 @@ struct SwiftPMTests {
   }
 
   @Test("--filter argument")
+  @available(_regexAPI, *)
   func filter() throws {
     let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--filter", "hello"])
     let testFilter = try #require(configuration.testFilter)
@@ -62,6 +63,7 @@ struct SwiftPMTests {
   }
 
   @Test("--skip argument")
+  @available(_regexAPI, *)
   func skip() throws {
     let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--skip", "hello"])
     let testFilter = try #require(configuration.testFilter)
@@ -82,6 +84,7 @@ struct SwiftPMTests {
   }
 
   @Test("--filter/--skip arguments and .hidden trait")
+  @available(_regexAPI, *)
   func filterAndSkipAndHidden() throws {
     let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--filter", "hello", "--skip", "hello2"])
     let testFilter = try #require(configuration.testFilter)


### PR DESCRIPTION
This modifies the SwiftPM entry point argument parsing logic to ensure that if a user passes the `--filter` or `--skip` flags on an OS version which does not support those features, an error is reported.

### Motivation:

Currently, we silently ignore these flags on unsupported OS versions but that can cause problems if the user was only expecting certain tests to run, so this ensures that we either honor the user's request or report a meaningful failure message.

### Modifications:

- Implement the `else` branch of `if #available(...)` conditions which guard the implementations of these CLI flags.
- Adjust tests accordingly.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Resolves rdar://119837856
