### PR TITLE
Expose isParameterized and isSuite on Test.Snapshot, and Test.Case.Argument.ID.init, as SPI

### DIFF
--- a/Sources/Testing/Parameterization/Test.Case.swift
+++ b/Sources/Testing/Parameterization/Test.Case.swift
@@ -24,6 +24,11 @@ extension Test {
       public struct ID: Sendable {
         /// The raw bytes of this instance's identifier.
         public var bytes: [UInt8]
+
+        @_spi(ExperimentalTestRunning)
+        public init(bytes: [UInt8]) {
+          self.bytes = bytes
+        }
       }
 
       /// The ID of this parameterized test argument, if any.

--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -244,5 +244,27 @@ extension Test {
       testCases = test.testCases?.map(Test.Case.Snapshot.init)
       parameters = test.parameters
     }
+
+    /// Whether or not this test is parameterized.
+    ///
+    /// ## See Also
+    ///
+    /// - ``Test/isParameterized``
+    @_spi(ExperimentalParameterizedTesting)
+    public var isParameterized: Bool {
+      guard let parameterCount = parameters?.count else {
+        return false
+      }
+      return parameterCount != 0
+    }
+
+    /// Whether or not this instance is a test suite containing other tests.
+    ///
+    /// ## See Also
+    ///
+    /// - ``Test/isSuite``
+    public var isSuite: Bool {
+      testCases == nil
+    }
   }
 }

--- a/Tests/TestingTests/Test.SnapshotTests.swift
+++ b/Tests/TestingTests/Test.SnapshotTests.swift
@@ -31,4 +31,42 @@ struct Test_SnapshotTests {
     #expect(decoded.parameters == snapshot.parameters)
   }
 #endif
+
+  @Test("isParameterized property")
+  func isParameterized() async throws {
+    do {
+      let test = try #require(Test.current)
+      let snapshot = Test.Snapshot(snapshotting: test)
+      #expect(!snapshot.isParameterized)
+    }
+    do {
+      let test = try #require(await testFunction(named: "parameterized(i:)", in: MainActorIsolatedTests.self))
+      let snapshot = Test.Snapshot(snapshotting: test)
+      #expect(snapshot.isParameterized)
+    }
+    do {
+      let suite = try #require(await test(for: Self.self))
+      let snapshot = Test.Snapshot(snapshotting: suite)
+      #expect(!snapshot.isParameterized)
+    }
+  }
+
+  @Test("isSuite property")
+  func isSuite() async throws {
+    do {
+      let test = try #require(Test.current)
+      let snapshot = Test.Snapshot(snapshotting: test)
+      #expect(!snapshot.isSuite)
+    }
+    do {
+      let test = try #require(await testFunction(named: "parameterized(i:)", in: MainActorIsolatedTests.self))
+      let snapshot = Test.Snapshot(snapshotting: test)
+      #expect(!snapshot.isSuite)
+    }
+    do {
+      let suite = try #require(await test(for: Self.self))
+      let snapshot = Test.Snapshot(snapshotting: suite)
+      #expect(snapshot.isSuite)
+    }
+  }
 }


### PR DESCRIPTION
This exposes a couple convenience querying properties (`isParameterized` and `isSuite`) on `Test.Snapshot`, as well as `Test.Case.Argument.ID.init(bytes:)`, as SPI.

### Motivation:

Exposing these helps facilitate further integration of the testing library with supporting tools.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Resolves rdar://119614246
