### PR TITLE
Update .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -4,4 +4,4 @@ metadata:
 builder:
   configs:
     - documentation_targets: [Testing]
-      swift_version: 5.9
+      scheme: Testing


### PR DESCRIPTION
Fixes https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2807 - failures with the `xcodebuild`-based builds. The problem was that our package scheme heuristics failed and tried to build the scheme 'swift-test-Package'. This adds a hint for us which scheme to pick.

It also removes the `swift_version: 5.9` attributes which pinned doc builds to use Swift 5.9. This is now the defaut, so this setting is superfluous (and would keep doc gen using 5.9 even after 5.10+ come out).