### PR TITLE
Remove redundant `Codable` implementation from `Tag`.

### DIFF
--- a/Sources/Testing/Traits/Tag.swift
+++ b/Sources/Testing/Traits/Tag.swift
@@ -56,15 +56,7 @@ extension Tag: Equatable, Hashable, Comparable {
 
 // MARK: - Codable, CodingKeyRepresentable
 
-extension Tag: Codable, CodingKeyRepresentable {
-  public func encode(to encoder: any Encoder) throws {
-    try rawValue.encode(to: encoder)
-  }
-
-  public init(from decoder: any Decoder) throws {
-    try self.init(rawValue: String(from: decoder))
-  }
-}
+extension Tag: Codable, CodingKeyRepresentable {}
 
 // MARK: -
 


### PR DESCRIPTION
The default synthesized implementation of `Codable` is equivalent to what we've manually implemented for `Tag`, so we can delete the manual implementation.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
