### PR TITLE
Make sure events are borrowed when snapshotting.

### DIFF
--- a/Sources/Testing/Events/Event.swift
+++ b/Sources/Testing/Events/Event.swift
@@ -278,7 +278,7 @@ extension Event {
 
     /// Snapshots an ``Event``.
     /// - Parameter event: The original ``Event`` to snapshot.
-    public init(snapshotting event: Event) {
+    public init(snapshotting event: borrowing Event) {
       kind = Event.Kind.Snapshot(snapshotting: event.kind)
       testID = event.testID
       instant = event.instant


### PR DESCRIPTION
`Event.Snapshot.init(snapshotting:)` needs to borrow its argument (since we want to explicitly avoid copying `Event` instances.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
