### PR TITLE
Fix syntax of `#expect(throws:)` example in documentation

### DIFF
--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -76,7 +76,7 @@
 /// - Parameters:
 ///   - errorType: The type of error that is expected to be thrown. If
 ///     `expression` could throw _any_ error, or the specific type of thrown
-///     error is unimportant, pass `any Error.self`.
+///     error is unimportant, pass `(any Error).self`.
 ///   - comment: A comment describing the expectation.
 ///   - sourceLocation: The source location to which recorded expectations and
 ///     issues should be attributed.
@@ -153,7 +153,7 @@
 /// - Parameters:
 ///   - errorType: The type of error that is expected to be thrown. If
 ///     `expression` could throw _any_ error, or the specific type of thrown
-///     error is unimportant, pass `any Error.self`.
+///     error is unimportant, pass `(any Error).self`.
 ///   - comment: A comment describing the expectation.
 ///   - sourceLocation: The source location to which recorded expectations and
 ///     issues should be attributed.

--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -349,7 +349,7 @@ their equivalents in the testing library:
 | `XCTAssertGreaterThanOrEqual(x, y)` | `#expect(x >= y)` |
 | `XCTAssertLessThanOrEqual(x, y)` | `#expect(x <= y)` |
 | `XCTAssertLessThan(x, y)` | `#expect(x < y)` |
-| `XCTAssertThrowsError(try f())` | `#expect(throws: any Error.self) { try f() }` |
+| `XCTAssertThrowsError(try f())` | `#expect(throws: (any Error).self) { try f() }` |
 | `XCTAssertNoThrow(try f())` | `#expect(throws: Never.self) { try f() }` |
 | `try XCTUnwrap(x)` | `try #require(x)` |
 | `XCTFail("…")` | `Issue.record("…")` |


### PR DESCRIPTION
Fix syntax of `#expect(throws:)` example in documentation

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
