### PR TITLE
Parallelize tests by default.

### DIFF
--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -129,9 +129,10 @@ func configurationForSwiftPMEntryPoint(withArguments args: [String]) throws -> C
   // Do not consider the executable path AKA argv[0].
   let args = args.dropFirst()
 
-  // Parallelization
-  if args.contains("--parallel") {
-    configuration.isParallelizationEnabled = true
+  // Parallelization (on by default)
+  configuration.isParallelizationEnabled = true
+  if args.contains("--no-parallel") {
+    configuration.isParallelizationEnabled = false
   }
 
 #if !SWT_NO_FILE_IO

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -22,13 +22,16 @@ struct SwiftPMTests {
     #expect(!CommandLine.arguments().isEmpty)
   }
 
-  @Test("--parallel argument")
+  @Test("--parallel/--no-parallel argument")
   func parallel() throws {
     var configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH"])
-    #expect(!configuration.isParallelizationEnabled)
+    #expect(configuration.isParallelizationEnabled)
     
     configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--parallel"])
     #expect(configuration.isParallelizationEnabled)
+
+    configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--no-parallel"])
+    #expect(!configuration.isParallelizationEnabled)
   }
 
   @Test("No --filter or --skip argument")


### PR DESCRIPTION
This PR enables parallelization by default when using `swift test` and enables support for the `--no-parallel` flag in `swift test` added in https://github.com/apple/swift-package-manager/pull/7231.

The default value of `Configuration.isParallelizationEnabled` remains `false`. Other adopters are free to enable or disable parallelization by default.

`XCTestScaffold` is not affected. It is a shim used with XCTest in Swift 5.10 only and expects serial execution of tests.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
