### PR TITLE
Work around macro expansion bug in 2024-1-4 toolchain.

### DIFF
--- a/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
+++ b/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
@@ -19,6 +19,7 @@ struct Runner_Plan_SnapshotTests {
 #if canImport(Foundation)
   @Test("Codable")
   func codable() async throws {
+#if SWT_FIXED_120559184
     let suite = try #require(await test(for: Runner_Plan_SnapshotFixtures.self))
 
     var configuration = Configuration()
@@ -48,6 +49,7 @@ struct Runner_Plan_SnapshotTests {
         Issue.record("Decoded step does not match the original snapshotted step: decodedStep: \(decodedStep), snapshotStep: \(snapshotStep)")
       }
     }
+#endif
   }
 #endif
 }


### PR DESCRIPTION
The latest main toolchain has introduced a regression in macro expansion (tracked by rdar://120559184.) This PR works around the regression, which is causing a build failure in one test.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
