### PR TITLE
Revert "Work around macro expansion bug in 2024-4-1 toolchain."

### DIFF
--- a/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
+++ b/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
@@ -19,7 +19,6 @@ struct Runner_Plan_SnapshotTests {
 #if canImport(Foundation)
   @Test("Codable")
   func codable() async throws {
-#if SWT_FIXED_120559184
     let suite = try #require(await test(for: Runner_Plan_SnapshotFixtures.self))
 
     var configuration = Configuration()
@@ -49,7 +48,6 @@ struct Runner_Plan_SnapshotTests {
         Issue.record("Decoded step does not match the original snapshotted step: decodedStep: \(decodedStep), snapshotStep: \(snapshotStep)")
       }
     }
-#endif
   }
 #endif
 }


### PR DESCRIPTION
This reverts commit 95b3df5fa401f0b4a2f395abf46b11b2371aa6dc.

Yesterday's toolchain (2024-01-07) resolves rdar://120559184 with https://github.com/apple/swift/pull/70740, so we don't need the workaround anymore.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
