### PR TITLE
Don't shadow `VersionTupleSyntax.components`.

### DIFF
--- a/Sources/TestingMacros/Support/Additions/VersionTupleSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/VersionTupleSyntaxAdditions.swift
@@ -13,7 +13,7 @@ public import SwiftSyntax
 extension VersionTupleSyntax {
   /// A type describing the major, minor, and patch components of a version
   /// tuple.
-  struct Components: Comparable, CustomStringConvertible {
+  struct ComponentValues: Comparable, CustomStringConvertible {
     /// The major component.
     var major: UInt64
 
@@ -47,27 +47,23 @@ extension VersionTupleSyntax {
     }
   }
 
-  /// The major, minor, and patch components of this version tuple.
-  var components: Components {
-#if swift(<6.0)
-    let stringComponents = trimmedDescription.split(separator: "." as Character)
-    guard let major = stringComponents.first.flatMap({ UInt64($0) }) else {
-      return Components(major: 0)
-    }
-    var minor: UInt64?
-    var patch: UInt64?
-    if stringComponents.count > 1 {
-      minor = UInt64(stringComponents[1])
-      if stringComponents.count > 2 {
-        patch = UInt64(stringComponents[2])
-      }
-    }
-#else
-    let major = UInt64(major.text) ?? 0
-    let minor = minor.map(\.text).flatMap(UInt64.init)
-    let patch = patch.map(\.text).flatMap(UInt64.init)
-#endif
+  /// The numeric values of the major, minor, and patch components.
+  var componentValues: ComponentValues {
+    let components = components
+    let startIndex = components.startIndex
 
-    return Components(major: major, minor: minor, patch: patch)
+    let major = UInt64(major.text) ?? 0
+    let minor: UInt64? = if components.count > 0 {
+      UInt64(components[startIndex].number.text)
+    } else {
+      nil
+    }
+    let patch: UInt64? = if components.count > 1 {
+      UInt64(components[components.index(after: startIndex)].number.text)
+    } else {
+      nil
+    }
+
+    return ComponentValues(major: major, minor: minor, patch: patch)
   }
 }

--- a/Sources/TestingMacros/Support/AvailabilityGuards.swift
+++ b/Sources/TestingMacros/Support/AvailabilityGuards.swift
@@ -65,7 +65,7 @@ private func _createAvailabilityTraitExpr(
   when whenKeyword: Keyword,
   in context: some MacroExpansionContext
 ) -> ExprSyntax {
-  let version: ExprSyntax = availability.version.map(\.components).map { components in
+  let version: ExprSyntax = availability.version.map(\.componentValues).map { components in
     "(\(literal: components.major), \(literal: components.minor), \(literal: components.patch))"
   } ?? "nil"
   let message = availability.message.map(\.trimmed).map(ExprSyntax.init) ?? "nil"
@@ -227,11 +227,11 @@ func createSyntaxNode(
   do {
     let introducedVersion = decl.availability(when: .introduced).lazy
       .filter(\.isSwift)
-      .compactMap(\.version?.components)
+      .compactMap(\.version?.componentValues)
       .max()
     let obsoletedVersion = decl.availability(when: .obsoleted).lazy
       .filter(\.isSwift)
-      .compactMap(\.version?.components)
+      .compactMap(\.version?.componentValues)
       .min()
 
     let swiftVersionGuardExpr: ExprSyntax? = switch (introducedVersion, obsoletedVersion) {


### PR DESCRIPTION
Since we first wrote the code in VersionTupleSyntaxAdditions.swift, a `components` property has been added to `VersionTupleSyntax`. We shouldn't shadow it with our own property (and we should call it in order to more efficiently and correctly get version info than we do now.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
