### PR TITLE
Remove `Test.underestimatedCaseCount` SPI

### DIFF
--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -53,32 +53,6 @@ public struct Test: Sendable {
   /// The source location of this test.
   public var sourceLocation: SourceLocation
 
-  /// The (underestimated) number of iterations that will need to occur during
-  /// testing.
-  ///
-  /// The value of this property is inherently capped at `Int.max`. In practice,
-  /// the number of iterations that can run in a reasonable timespan will be
-  /// significantly lower.
-  ///
-  /// For instances of ``Test`` that represent non-parameterized test functions
-  /// (that is, test functions that do not iterate over a sequence of inputs),
-  /// the value of this property is always `1`. For instances of ``Test`` that
-  /// represent test suite types, the value of this property is always `nil`.
-  ///
-  /// For more information about underestimated counts, see the documentation
-  /// for [`Sequence`](https://developer.apple.com/documentation/swift/array/underestimatedcount-4ggqp).
-  @_spi(ExperimentalParameterizedTesting)
-  public var underestimatedCaseCount: Int? {
-    // NOTE: it is important that we only expose an _underestimated_ count for
-    // two reasons:
-    // 1. If the total number of cases exceeds `.max` due to combinatoric
-    //    complexity, `count` would be too low; and
-    // 2. We reserve the right to support async sequences as input in the
-    //    future, and async sequences do not have `count` properties (but an
-    //    underestimated count of `0` is still technically correct.)
-    testCases?.underestimatedCount
-  }
-
   /// The type containing this test, if any.
   ///
   /// If a test is associated with a free function or static function, the value

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -309,41 +309,6 @@ struct MiscellaneousTests {
     await valueGrid.validateCells()
   }
 
-  @Test("Test.underestimatedCaseCount property")
-  func underestimatedCaseCount() async throws {
-    do {
-      let test = try #require(await testFunction(named: "parameterized(i:)", in: NonSendableTests.self))
-      #expect(test.underestimatedCaseCount == FixtureData.zeroUpTo100.count)
-    }
-    do {
-      let test = try #require(await testFunction(named: "parameterized2(i:j:)", in: NonSendableTests.self))
-      #expect(test.underestimatedCaseCount == FixtureData.zeroUpTo100.count * FixtureData.smallStringArray.count)
-    }
-    do {
-      let test = try #require(await testFunction(named: "parameterized(i:)", in: SendableTests.self))
-      #expect(test.underestimatedCaseCount == FixtureData.zeroUpTo100.count)
-    }
-#if !SWT_NO_GLOBAL_ACTORS
-    do {
-      let test = try #require(await testFunction(named: "parameterized(i:)", in: MainActorIsolatedTests.self))
-      #expect(test.underestimatedCaseCount == FixtureData.zeroUpTo100.count)
-    }
-    do {
-      let test = try #require(await testFunction(named: "parameterizedNonisolated(i:)", in: MainActorIsolatedTests.self))
-      #expect(test.underestimatedCaseCount == FixtureData.zeroUpTo100.count)
-    }
-#endif
-
-    do {
-      let thisTest = try #require(await testFunction(named: "succeeds()", in: SendableTests.self))
-      #expect(thisTest.underestimatedCaseCount == 1)
-    }
-    do {
-      let thisTest = try #require(await test(for: SendableTests.self))
-      #expect(thisTest.underestimatedCaseCount == nil)
-    }
-  }
-
   @Test("Test.parameters property")
   func parametersProperty() async throws {
     do {


### PR DESCRIPTION
This removes the `Test.underestimatedCaseCount` SPI property.

### Motivation:

We originally thought this property might be needed or useful but it hasn't been necessary. Nowadays, `Test` has another property named `isParameterized` which can be used to more directly query whether a test is parameterized, and there are no usages within the testing library's own implementation.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
