### PR TITLE
Create a cross-module overlay target for Foundation.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -50,6 +50,7 @@ let package = Package(
       name: "TestingTests",
       dependencies: [
         "Testing",
+        "_Testing_Foundation",
       ],
       swiftSettings: .packageSettings
     ),
@@ -92,6 +93,15 @@ let package = Package(
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
       ]
+    ),
+
+    // Cross-module overlays (unsupported)
+    .target(
+      name: "_Testing_Foundation",
+      dependencies: [
+        "Testing",
+      ],
+      swiftSettings: .packageSettings
     ),
   ],
 

--- a/Sources/_Testing_Foundation/Events/Clock+Date.swift
+++ b/Sources/_Testing_Foundation/Events/Clock+Date.swift
@@ -1,0 +1,32 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+#if canImport(Foundation) && !SWT_NO_UTC_CLOCK
+@_spi(ExperimentalEventHandling) public import Testing
+public import Foundation
+
+extension Date {
+  /// Initialize this date to the equivalent of the same date on the testing
+  /// library's clock.
+  ///
+  /// - Parameters:
+  ///   - testClockInstant: The equivalent instant on ``Test/Clock``.
+  ///
+  /// The resulting instance is equivalent to the wall-clock time represented by
+  /// `testClockInstant`. For precise date/time calculations, convert instances
+  /// of ``Test/Clock/Instant`` to `SuspendingClock.Instant` instead of `Date`.
+  @_spi(ExperimentalEventHandling)
+  public init(_ testClockInstant: Test.Clock.Instant) {
+    let components = testClockInstant.timeComponentsSince1970
+    let secondsSince1970 = TimeInterval(components.seconds) + (TimeInterval(components.attoseconds) / TimeInterval(1_000_000_000_000_000_000))
+    self.init(timeIntervalSince1970: secondsSince1970)
+  }
+}
+#endif

--- a/Sources/_Testing_Foundation/ReexportTesting.swift
+++ b/Sources/_Testing_Foundation/ReexportTesting.swift
@@ -1,0 +1,11 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@_exported import Testing

--- a/Tests/TestingTests/_Testing_Foundation/FoundationTests.swift
+++ b/Tests/TestingTests/_Testing_Foundation/FoundationTests.swift
@@ -1,0 +1,24 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+#if canImport(Foundation)
+@testable @_spi(ExperimentalEventHandling) import _Testing_Foundation
+@_spi(ExperimentalEventHandling) import Testing
+import Foundation
+
+struct FoundationTests {
+  @Test("Casting Test.Clock.Instant to Date")
+  func castTestClockInstantToDate() {
+    let instant = Test.Clock.Instant.now
+    let date = Date(instant)
+    #expect(TimeInterval(instant.timeComponentsSince1970.seconds) == date.timeIntervalSince1970.rounded(.down))
+  }
+}
+#endif


### PR DESCRIPTION
This PR adds a small cross-module overlay (with Foundation) to the package and exposes SPI for casting a `Test.Clock.Instant` to `Date`. Additional interfaces can be added as needed in the future.

Cross-module overlays are not supported in packages at this time. This code is, therefore, experimental only.

Resolves rdar://120848506.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
