### PR TITLE
Remove `--enable-experimental-swift-testing` from the Getting Started doc.

### DIFF
--- a/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
+++ b/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
@@ -97,13 +97,17 @@ be presented with a name such as "Swift Development Toolchain 2023-01-01 (a)".
 Navigate to the directory containing your package and run the following command:
 
 ```sh
-swift test --enable-experimental-swift-testing
+swift test
 ```
 
 Swift Package Manager will build and run a test target that uses the testing
 library as well as a separate target that uses XCTest. To only run tests written
 using the testing library, pass `--disable-xctest` as an additional argument to
 the `swift test` command.
+
+- Note: If your package does not explicitly list the testing library as a
+  dependency, pass `--enable-experimental-swift-testing` to the `swift test`
+  command to ensure your tests are run.
 
 #### Swift 5.10
 


### PR DESCRIPTION
As of the January 11 daily toolchain, SwiftPM detects if a package includes swift-testing as a dependency and, if so, does not require a developer to pass `--enable-experimental-swift-testing`. This PR updates the package's Getting Started document to reflect that.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
