### PR TITLE
Fix an incomplete comment.

### DIFF
--- a/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
+++ b/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
@@ -276,9 +276,9 @@ private func _exprFromOptionalChainedExpr(_ expr: some ExprSyntaxProtocol) -> (E
     questionMarkCount += 1
   }
 
-  // If the rightmost expression Check if any of the member accesses in the expression use optional
-  // chaining and, if one does, ensure we preserve optional chaining in the
-  // macro expansion.
+  // If the rightmost expression is not itself optional-chained, check if any of
+  // the member accesses in the expression use optional chaining and, if one
+  // does, ensure we preserve optional chaining in the macro expansion.
   if questionMarkCount == 0 {
     func isOptionalChained(_ expr: some ExprSyntaxProtocol) -> Bool {
       if expr.is(OptionalChainingExprSyntax.self) {


### PR DESCRIPTION
Fixes an incompletely-typed comment in ConditionArgumentParsing.swift that was previously committed.

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
