### PR TITLE
Console output should prefix messages with "Suite" instead of "Test" for suites

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -142,12 +142,17 @@ extension Event.HumanReadableOutputRecorder {
   }
 }
 
-extension Test {
-  /// A title for this test (either "Test" or "Suite"), capitalized and suitable
-  /// for use as the leading word of a human-readable message string.
-  fileprivate var capitalizedTitle: String {
-    isSuite ? "Suite" : "Test"
-  }
+/// Generate a title for the specified test (either "Test" or "Suite"),
+/// capitalized and suitable for use as the leading word of a human-readable
+/// message string.
+///
+/// - Parameters:
+///   - test: The test to generate a description for, if any.
+///
+/// - Returns: A human-readable title for the specified test. Defaults to "Test"
+///   if `test` is `nil`.
+private func _capitalizedTitle(for test: Test?) -> String {
+  test?.isSuite == true ? "Suite" : "Test"
 }
 
 extension Test.Case {
@@ -232,7 +237,7 @@ extension Event.HumanReadableOutputRecorder {
       return [
         Message(
           symbol: .default,
-          stringValue: "\(test.capitalizedTitle) \(testName) started."
+          stringValue: "\(_capitalizedTitle(for: test)) \(testName) started."
         )
       ]
 
@@ -247,14 +252,14 @@ extension Event.HumanReadableOutputRecorder {
         CollectionOfOne(
           Message(
             symbol: .fail,
-            stringValue: "\(test.capitalizedTitle) \(testName) failed after \(duration)\(issues.description)."
+            stringValue: "\(_capitalizedTitle(for: test)) \(testName) failed after \(duration)\(issues.description)."
           )
         ) + _formattedComments(for: test)
       } else {
          [
           Message(
             symbol: .pass(knownIssueCount: issues.knownIssueCount),
-            stringValue: "\(test.capitalizedTitle) \(testName) passed after \(duration)\(issues.description)."
+            stringValue: "\(_capitalizedTitle(for: test)) \(testName) passed after \(duration)\(issues.description)."
           )
         ]
       }
@@ -270,11 +275,11 @@ extension Event.HumanReadableOutputRecorder {
       }
       return if let comment = skipInfo.comment {
         [
-          Message(symbol: .skip, stringValue: "\(test.capitalizedTitle) \(testName) skipped: \"\(comment.rawValue)\"")
+          Message(symbol: .skip, stringValue: "\(_capitalizedTitle(for: test)) \(testName) skipped: \"\(comment.rawValue)\"")
         ]
       } else {
         [
-          Message(symbol: .skip, stringValue: "\(test.capitalizedTitle) \(testName) skipped.")
+          Message(symbol: .skip, stringValue: "\(_capitalizedTitle(for: test)) \(testName) skipped.")
         ]
       }
 
@@ -284,7 +289,6 @@ extension Event.HumanReadableOutputRecorder {
       break
 
     case let .issueRecorded(issue):
-      let title: String
       if let test {
         let id = test.id.keyPathRepresentation
         $_context.withLock { context in
@@ -296,11 +300,6 @@ extension Event.HumanReadableOutputRecorder {
           }
           context.testData[id] = testData
         }
-        title = test.capitalizedTitle
-      } else {
-        // Assume a test here, although we cannot know reliably for issues
-        // recorded from detached tasks.
-        title = "Test"
       }
       let parameterCount = if let parameters = test?.parameters {
         parameters.count
@@ -332,12 +331,12 @@ extension Event.HumanReadableOutputRecorder {
       let primaryMessage: Message = if parameterCount == 0 {
         Message(
           symbol: symbol,
-          stringValue: "\(title) \(testName) recorded a\(known) issue\(atSourceLocation): \(issue.kind)"
+          stringValue: "\(_capitalizedTitle(for: test)) \(testName) recorded a\(known) issue\(atSourceLocation): \(issue.kind)"
         )
       } else {
         Message(
           symbol: symbol,
-          stringValue: "\(title) \(testName) recorded a\(known) issue with \(parameterCount.counting("argument")) \(labeledArguments)\(atSourceLocation): \(issue.kind)"
+          stringValue: "\(_capitalizedTitle(for: test)) \(testName) recorded a\(known) issue with \(parameterCount.counting("argument")) \(labeledArguments)\(atSourceLocation): \(issue.kind)"
         )
       }
       return CollectionOfOne(primaryMessage) + additionalMessages


### PR DESCRIPTION
This changes the console output to prefix messages with the word "Suite" instead of "Test" for events representing suites.

### Motivation:

It's helpful to users to distinguish between test functions (aka "tests") and suite types (aka "suites") in the human-readable console output shown while running tests, to clarify the role each item plays.

### Modifications:

- Change logic in `Event.HumanReadableOutputRecorder` to check for suites and use the appropriate word.
- Add new test and adjust others.

### Result:

Console output now shows "Suite" for suites.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Resolves rdar://120962053
