### PR TITLE
`Locked` shouldn't be a property wrapper.

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.JUnitXMLRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.JUnitXMLRecorder.swift
@@ -51,7 +51,7 @@ extension Event {
 
     /// This event recorder's mutable context about events it has received,
     /// which may be used to inform how subsequent events are written.
-    @Locked private var _context = _Context()
+    private var _context = Locked(rawValue: _Context())
 
     /// Initialize a new event recorder.
     ///
@@ -82,7 +82,7 @@ extension Event.JUnitXMLRecorder {
 
     switch event.kind {
     case .runStarted:
-      $_context.withLock { context in
+      _context.withLock { context in
         context.runStartInstant = instant
       }
       return #"""
@@ -93,14 +93,14 @@ extension Event.JUnitXMLRecorder {
     case .testStarted where false == test?.isSuite:
       let id = test!.id
       let keyPath = id.keyPathRepresentation
-      $_context.withLock { context in
+      _context.withLock { context in
         context.testData[keyPath] = _Context.TestData(id: id, startInstant: instant)
       }
       return nil
     case .testEnded where false == test?.isSuite:
       let id = test!.id
       let keyPath = id.keyPathRepresentation
-      $_context.withLock { context in
+      _context.withLock { context in
         context.testData[keyPath]?.endInstant = instant
       }
       return nil
@@ -114,12 +114,12 @@ extension Event.JUnitXMLRecorder {
         return nil // FIXME: handle issues without known tests
       }
       let keyPath = id.keyPathRepresentation
-      $_context.withLock { context in
+      _context.withLock { context in
         context.testData[keyPath]?.issues.append(issue)
       }
       return nil
     case .runEnded:
-      return $_context.withLock { context in
+      return _context.withLock { context in
         let issueCount = context.testData
           .compactMap(\.value?.issues.count)
           .reduce(into: 0, +=)

--- a/Sources/Testing/Issues/Confirmation.swift
+++ b/Sources/Testing/Issues/Confirmation.swift
@@ -14,8 +14,7 @@ public struct Confirmation: Sendable {
   ///
   /// This property is fileprivate because it may be mutated asynchronously and
   /// callers may be tempted to use it in ways that result in data races.
-  @Locked
-  fileprivate var count = 0
+  fileprivate var count = Locked(rawValue: 0)
 
   /// Confirm this confirmation.
   ///
@@ -26,7 +25,7 @@ public struct Confirmation: Sendable {
   /// directly.
   public func confirm(count: Int = 1) {
     precondition(count > 0)
-    $count.add(count)
+    self.count.add(count)
   }
 }
 
@@ -101,7 +100,7 @@ public func confirmation<R>(
 ) async rethrows -> R {
   let confirmation = Confirmation()
   defer {
-    let actualCount = confirmation.count
+    let actualCount = confirmation.count.rawValue
     if actualCount != expectedCount {
       Issue.record(
         .confirmationMiscounted(actual: actualCount, expected: expectedCount),

--- a/Sources/Testing/Issues/KnownIssue.swift
+++ b/Sources/Testing/Issues/KnownIssue.swift
@@ -64,7 +64,7 @@ private func _matchError(_ error: any Error, using issueMatcher: KnownIssueMatch
 ///   - sourceLocation: The source location to which the issue should be
 ///     attributed.
 private func _handleMiscount(by matchCounter: Locked<Int>, comment: Comment?, sourceLocation: SourceLocation) {
-  if matchCounter.wrappedValue == 0 {
+  if matchCounter.rawValue == 0 {
     Issue.record(
       .knownIssueNotRecorded,
       comments: Array(comment),
@@ -182,12 +182,12 @@ public func withKnownIssue(
   guard precondition() else {
     return try body()
   }
-  @Locked var matchCounter = 0
+  let matchCounter = Locked(rawValue: 0)
   let sourceLocation = SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column)
-  let issueMatcher = _combineIssueMatcher(issueMatcher, matchesCountedBy: $matchCounter)
+  let issueMatcher = _combineIssueMatcher(issueMatcher, matchesCountedBy: matchCounter)
   defer {
     if !isIntermittent {
-      _handleMiscount(by: $matchCounter, comment: comment, sourceLocation: sourceLocation)
+      _handleMiscount(by: matchCounter, comment: comment, sourceLocation: sourceLocation)
     }
   }
   try Issue.$currentKnownIssueMatcher.withValue(issueMatcher) {
@@ -297,12 +297,12 @@ public func withKnownIssue(
   guard await precondition() else {
     return try await body()
   }
-  @Locked var matchCounter = 0
+  let matchCounter = Locked(rawValue: 0)
   let sourceLocation = SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column)
-  let issueMatcher = _combineIssueMatcher(issueMatcher, matchesCountedBy: $matchCounter)
+  let issueMatcher = _combineIssueMatcher(issueMatcher, matchesCountedBy: matchCounter)
   defer {
     if !isIntermittent {
-      _handleMiscount(by: $matchCounter, comment: comment, sourceLocation: sourceLocation)
+      _handleMiscount(by: matchCounter, comment: comment, sourceLocation: sourceLocation)
     }
   }
   try await Issue.$currentKnownIssueMatcher.withValue(issueMatcher) {

--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -21,7 +21,7 @@ private import TestingInternals
 /// - Warning: This function is used by Swift Package Manager. Do not call it
 ///   directly.
 @_disfavoredOverload public func __swiftPMEntryPoint() async -> CInt {
-  @Locked var exitCode = EXIT_SUCCESS
+  let exitCode = Locked(rawValue: EXIT_SUCCESS)
 
   do {
     let args = CommandLine.arguments()
@@ -34,7 +34,7 @@ private import TestingInternals
       let oldEventHandler = configuration.eventHandler
       configuration.eventHandler = { event, context in
         if case let .issueRecorded(issue) = event.kind, !issue.isKnown {
-          $exitCode.withLock { exitCode in
+          exitCode.withLock { exitCode in
             exitCode = EXIT_FAILURE
           }
         }
@@ -48,12 +48,12 @@ private import TestingInternals
     fputs(String(describing: error), stderr)
     fflush(stderr)
 
-    $exitCode.withLock { exitCode in
+    exitCode.withLock { exitCode in
       exitCode = EXIT_FAILURE
     }
   }
 
-  return exitCode
+  return exitCode.rawValue
 }
 
 /// The entry point to the testing library used by Swift Package Manager.

--- a/Sources/Testing/Running/Runner.RuntimeState.swift
+++ b/Sources/Testing/Running/Runner.RuntimeState.swift
@@ -27,7 +27,7 @@ extension Runner {
 
     /// The runtime state related to the runner running on the current task.
     @TaskLocal
-    static var current: Self = .init()
+    static var current = Self()
   }
 }
 
@@ -91,8 +91,7 @@ extension Configuration {
   }
 
   /// Mutable storage for ``Configuration/all``.
-  @Locked
-  private static var _all = _All()
+  private static let _all = Locked(rawValue: _All())
 
   /// A collection containing all instances of this type that are currently set
   /// as the current configuration for a task.
@@ -100,7 +99,7 @@ extension Configuration {
   /// This property is used when an event is posted in a context where the value
   /// of ``Configuration/current`` is `nil`, such as from a detached task.
   static var all: some Collection<Self> {
-    _all.instances.values
+    _all.rawValue.instances.values
   }
 
   /// Add this instance to ``Configuration/all``.
@@ -108,7 +107,7 @@ extension Configuration {
   /// - Returns: A unique number identifying `self` that can be
   ///   passed to `_removeFromAll(identifiedBy:)`` to unregister it.
   private func _addToAll() -> UInt64 {
-    Self.$_all.withLock { all in
+    Self._all.withLock { all in
       let id = all.nextID
       all.nextID += 1
       all.instances[id] = self
@@ -123,7 +122,7 @@ extension Configuration {
   ///     `_addToAll()`. If `nil`, this function has no effect.
   private func _removeFromAll(identifiedBy id: UInt64?) {
     if let id {
-      Self.$_all.withLock { all in
+      Self._all.withLock { all in
         _ = all.instances.removeValue(forKey: id)
       }
     }

--- a/Sources/Testing/Support/Environment.swift
+++ b/Sources/Testing/Support/Environment.swift
@@ -21,8 +21,7 @@ enum Environment {
   ///
   /// The mechanism by which this dictionary is initially populated depends on
   /// platform-specific implementation details.
-  @Locked
-  private static var _environment = [String: String]()
+  private static let _environment = Locked<[String: String]>()
 #endif
 
   /// Get the environment variable with the specified name.
@@ -34,7 +33,7 @@ enum Environment {
   ///   is not set for the current process.
   static func variable(named name: String) -> String? {
 #if SWT_NO_ENVIRONMENT_VARIABLES
-    _environment[name]
+    _environment.rawValue[name]
 #elseif SWT_TARGET_OS_APPLE || os(Linux)
     getenv(name).flatMap { String(validatingUTF8: $0) }
 #elseif os(Windows)

--- a/Sources/Testing/Support/Locked.swift
+++ b/Sources/Testing/Support/Locked.swift
@@ -10,11 +10,11 @@
 
 private import TestingInternals
 
-/// A property wrapper that wraps a value requiring access from a synchronous
-/// caller during concurrent execution.
+/// A type that wraps a value requiring access from a synchronous caller during
+/// concurrent execution.
 ///
-/// Instances of this type use a lock to synchronize access to their wrapped
-/// values. The lock is not recursive.
+/// Instances of this type use a lock to synchronize access to their raw values.
+/// The lock is not recursive.
 ///
 /// Instances of this type can be used to synchronize access to shared data from
 /// a synchronous caller. Wherever possible, use actor isolation or other Swift
@@ -25,7 +25,6 @@ private import TestingInternals
 /// - Bug: The state protected by this type should instead be protected using
 ///     actor isolation, but actor-isolated functions cannot be called from
 ///     synchronous functions. ([83888717](rdar://83888717))
-@propertyWrapper
 struct Locked<T>: @unchecked Sendable where T: Sendable {
   /// The platform-specific type to use for locking.
   ///
@@ -64,8 +63,8 @@ struct Locked<T>: @unchecked Sendable where T: Sendable {
   /// Storage for the underlying lock and wrapped value.
   private var _storage: ManagedBuffer<T, _Lock>
 
-  init(wrappedValue: T) {
-    _storage = _Storage.create(minimumCapacity: 1, makingHeaderWith: { _ in wrappedValue })
+  init(rawValue: T) {
+    _storage = _Storage.create(minimumCapacity: 1, makingHeaderWith: { _ in rawValue })
     _storage.withUnsafeMutablePointerToElements { lock in
 #if SWT_TARGET_OS_APPLE || os(Linux)
       _ = pthread_mutex_init(lock, nil)
@@ -77,12 +76,8 @@ struct Locked<T>: @unchecked Sendable where T: Sendable {
     }
   }
 
-  var wrappedValue: T {
+  var rawValue: T {
     withLock { $0 }
-  }
-
-  var projectedValue: Locked {
-    self
   }
 
   /// Acquire the lock and invoke a function while it is held.
@@ -98,7 +93,7 @@ struct Locked<T>: @unchecked Sendable where T: Sendable {
   /// synchronous caller. Wherever possible, use actor isolation or other Swift
   /// concurrency tools.
   nonmutating func withLock<R>(_ body: (inout T) throws -> R) rethrows -> R {
-    try _storage.withUnsafeMutablePointers { wrappedValue, lock in
+    try _storage.withUnsafeMutablePointers { rawValue, lock in
 #if SWT_TARGET_OS_APPLE || os(Linux)
       _ = pthread_mutex_lock(lock)
       defer {
@@ -113,7 +108,7 @@ struct Locked<T>: @unchecked Sendable where T: Sendable {
 #warning("Platform-specific implementation missing: locking unavailable")
 #endif
 
-      return try body(&wrappedValue.pointee)
+      return try body(&rawValue.pointee)
     }
   }
 }
@@ -124,11 +119,11 @@ extension Locked where T: AdditiveArithmetic {
   /// - Parameters:
   ///   - addend: The value to add.
   ///
-  /// - Returns: The sum of ``wrappedValue`` and `addend`.
+  /// - Returns: The sum of ``rawValue`` and `addend`.
   @discardableResult func add(_ addend: T) -> T {
-    withLock { wrappedValue in
-      let result = wrappedValue + addend
-      wrappedValue = result
+    withLock { rawValue in
+      let result = rawValue + addend
+      rawValue = result
       return result
     }
   }
@@ -137,10 +132,27 @@ extension Locked where T: AdditiveArithmetic {
 extension Locked where T: Numeric {
   /// Increment the current wrapped value of this instance.
   ///
-  /// - Returns: The sum of ``wrappedValue`` and `1`.
+  /// - Returns: The sum of ``rawValue`` and `1`.
   ///
   /// This function is exactly equivalent to `add(1)`.
   @discardableResult func increment() -> T {
     add(1)
+  }
+}
+
+extension Locked {
+  /// Initialize an instance of this type with a raw value of `0`.
+  init() where T: AdditiveArithmetic {
+    self.init(rawValue: .zero)
+  }
+
+  /// Initialize an instance of this type with a raw value of `nil`.
+  init<V>() where T == V? {
+    self.init(rawValue: nil)
+  }
+
+  /// Initialize an instance of this type with a raw value of `[:]`.
+  init<K, V>() where T == Dictionary<K, V> {
+    self.init(rawValue: [:])
   }
 }

--- a/Sources/Testing/Support/Locked.swift
+++ b/Sources/Testing/Support/Locked.swift
@@ -25,7 +25,7 @@ private import TestingInternals
 /// - Bug: The state protected by this type should instead be protected using
 ///     actor isolation, but actor-isolated functions cannot be called from
 ///     synchronous functions. ([83888717](rdar://83888717))
-struct Locked<T>: @unchecked Sendable where T: Sendable {
+struct Locked<T>: RawRepresentable, @unchecked Sendable where T: Sendable {
   /// The platform-specific type to use for locking.
   ///
   /// It would be preferable to implement this lock in Swift, however there is

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -23,7 +23,7 @@ import FoundationXML
 #endif
 struct EventRecorderTests {
   final class Stream: TextOutputStream, Sendable {
-    let buffer = Locked<String>(wrappedValue: "")
+    let buffer = Locked<String>(rawValue: "")
 
     @Sendable func write(_ string: String) {
       buffer.withLock {
@@ -63,7 +63,7 @@ struct EventRecorderTests {
 
     await runTest(for: WrittenTests.self, configuration: configuration)
 
-    let buffer = stream.buffer.wrappedValue
+    let buffer = stream.buffer.rawValue
     #expect(buffer.contains("failWhale"))
     #expect(buffer.contains("Whales fail."))
 #if !SWT_NO_UNSTRUCTURED_TASKS
@@ -110,7 +110,7 @@ struct EventRecorderTests {
 
     await runTest(for: PredictablyFailingTests.self, configuration: configuration)
 
-    let buffer = stream.buffer.wrappedValue
+    let buffer = stream.buffer.rawValue
     if testsWithSignificantIOAreEnabled {
       print(buffer, terminator: "")
     }
@@ -154,7 +154,7 @@ struct EventRecorderTests {
     await Test(name: "Innocuous Test Name") {
     }.run(configuration: configuration)
 
-    let buffer = stream.buffer.wrappedValue
+    let buffer = stream.buffer.rawValue
     if testsWithSignificantIOAreEnabled {
       print(buffer, terminator: "")
     }
@@ -176,7 +176,7 @@ struct EventRecorderTests {
 
     await runTest(for: PredictablyFailingTests.self, configuration: configuration)
 
-    let buffer = stream.buffer.wrappedValue
+    let buffer = stream.buffer.rawValue
     if testsWithSignificantIOAreEnabled {
       print(buffer, terminator: "")
     }
@@ -227,7 +227,7 @@ struct EventRecorderTests {
     // There is no formal schema for us to test against, so we're just testing
     // that the XML can be parsed by Foundation.
 
-    let xmlString = stream.buffer.wrappedValue
+    let xmlString = stream.buffer.rawValue
     #expect(xmlString.hasPrefix("<?xml"))
     let xmlData = try #require(xmlString.data(using: .utf8))
     #expect(xmlData.count > 1024)

--- a/Tests/TestingTests/Support/LockTests.swift
+++ b/Tests/TestingTests/Support/LockTests.swift
@@ -10,17 +10,16 @@
 
 @testable import Testing
 
-@Suite("@Locked Tests")
+@Suite("Locked Tests")
 struct LockTests {
   @Test("Mutating a value within withLock(_:)")
   func locking() {
-    @Locked
-    var value = 0
+    let value = Locked(rawValue: 0)
 
-    #expect(value == 0)
-    $value.withLock { value in
+    #expect(value.rawValue == 0)
+    value.withLock { value in
       value = 1
     }
-    #expect(value == 1)
+    #expect(value.rawValue == 1)
   }
 }


### PR DESCRIPTION
Property wrappers, when used as static properties, are inherently concurrency-unsafe (because they must be `var`, not `let`.) Discussed with the core Swift folks; this PR removes property wrapper "conformance" from `Locked`, adds `RawRepresentable` to replace it, and modifies call sites as appropriate.

Resolves rdar://121054518.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
