### PR TITLE
Fix a use of `Locked.wrappedValue` I missed.

### DIFF
--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -147,7 +147,7 @@ struct EventRecorderTests {
 
     await runTest(for: PredictablyFailingTests.self, configuration: configuration)
 
-    let buffer = stream.buffer.wrappedValue
+    let buffer = stream.buffer.rawValue
     if testsWithSignificantIOAreEnabled {
       print(buffer, terminator: "")
     }


### PR DESCRIPTION
Follow-up to #185. I missed a use of `wrappedValue` and because our CI is broken, I didn't notice the failure.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
