### PR TITLE
Remove `public` keyword from most swift-syntax imports in the macro target.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -131,17 +131,6 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .enableExperimentalFeature("StrictConcurrency"),
       .enableUpcomingFeature("ExistentialAny"),
 
-      // FIXME: In a certain range of Swift toolchains, this feature causes
-      // warnings to be emitted such as:
-      //
-      // ```
-      // warning: public import of 'SwiftSyntax' was not used in public declarations or inlinable code
-      // ```
-      //
-      // Once this package only builds using new-enough toolchains where that
-      // problem is resolved, we should remove the `public` access level from
-      // the `import` declarations in the `TestingMacros` target which do not
-      // require it, to resolve these warnings.
       .enableExperimentalFeature("AccessLevelOnImport"),
       .enableUpcomingFeature("InternalImportsByDefault"),
 

--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -34,7 +34,7 @@ public import SwiftSyntaxMacros
 /// The `__check()` function that implements expansions of these macros must
 /// take any developer-supplied arguments _before_ the ones inserted during
 /// macro expansion (starting with the `"sourceCode"` argument.)
-private protocol _ConditionMacro: ExpressionMacro, Sendable {
+public protocol ConditionMacro: ExpressionMacro, Sendable {
   /// Whether or not the macro's expansion may throw an error.
   static var isThrowing: Bool { get }
 }
@@ -49,7 +49,7 @@ private var _sourceLocationLabel: TokenSyntax { .identifier("sourceLocation") }
 /// with `#expect()` or `#require()`.
 private var _trailingClosureLabel: TokenSyntax { .identifier("performing") }
 
-extension _ConditionMacro {
+extension ConditionMacro {
   public static func expansion(
     of macro: some FreestandingMacroExpansionSyntax,
     in context: some MacroExpansionContext
@@ -188,8 +188,8 @@ extension _ConditionMacro {
 // MARK: -
 
 /// A type describing the expansion of the `#expect()` macro.
-public struct ExpectMacro: _ConditionMacro {
-  fileprivate static var isThrowing: Bool {
+public struct ExpectMacro: ConditionMacro {
+  public static var isThrowing: Bool {
     false
   }
 }
@@ -197,8 +197,8 @@ public struct ExpectMacro: _ConditionMacro {
 // MARK: -
 
 /// A type describing the expansion of the `#require()` macro.
-public struct RequireMacro: _ConditionMacro {
-  fileprivate static var isThrowing: Bool {
+public struct RequireMacro: ConditionMacro {
+  public static var isThrowing: Bool {
     true
   }
 }

--- a/Sources/TestingMacros/Support/Additions/DeclGroupSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/DeclGroupSyntaxAdditions.swift
@@ -8,7 +8,11 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if swift(>=5.11)
+import SwiftSyntax
+#else
 public import SwiftSyntax
+#endif
 
 extension DeclGroupSyntax {
   /// The type declared or extended by this instance.

--- a/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
@@ -8,8 +8,13 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if swift(>=5.11)
+import SwiftSyntax
+import SwiftSyntaxMacros
+#else
 public import SwiftSyntax
 public import SwiftSyntaxMacros
+#endif
 
 extension FunctionDeclSyntax {
   /// Whether or not this function a `static` or `class` function.

--- a/Sources/TestingMacros/Support/Additions/TokenSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/TokenSyntaxAdditions.swift
@@ -8,7 +8,11 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if swift(>=5.11)
+import SwiftSyntax
+#else
 public import SwiftSyntax
+#endif
 
 extension TokenSyntax {
   /// The text of this instance with all backticks removed.

--- a/Sources/TestingMacros/Support/Additions/TriviaPieceAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/TriviaPieceAdditions.swift
@@ -8,7 +8,11 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if swift(>=5.11)
+import SwiftSyntax
+#else
 public import SwiftSyntax
+#endif
 
 extension TriviaPiece {
   /// The number of newline characters represented by this trivia piece.

--- a/Sources/TestingMacros/Support/Additions/TypeSyntaxProtocolAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/TypeSyntaxProtocolAdditions.swift
@@ -8,7 +8,11 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if swift(>=5.11)
+import SwiftSyntax
+#else
 public import SwiftSyntax
+#endif
 
 extension TypeSyntaxProtocol {
   /// Whether or not this type is an optional type (`T?`, `Optional<T>`, etc.)

--- a/Sources/TestingMacros/Support/Additions/VersionTupleSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/VersionTupleSyntaxAdditions.swift
@@ -8,7 +8,11 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if swift(>=5.11)
+import SwiftSyntax
+#else
 public import SwiftSyntax
+#endif
 
 extension VersionTupleSyntax {
   /// A type describing the major, minor, and patch components of a version

--- a/Sources/TestingMacros/Support/Additions/WithAttributesSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/WithAttributesSyntaxAdditions.swift
@@ -8,8 +8,13 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if swift(>=5.11)
+import SwiftSyntax
+import SwiftSyntaxMacros
+#else
 public import SwiftSyntax
 public import SwiftSyntaxMacros
+#endif
 
 extension WithAttributesSyntax {
   /// The set of availability attributes on this instance.

--- a/Sources/TestingMacros/Support/Argument.swift
+++ b/Sources/TestingMacros/Support/Argument.swift
@@ -8,7 +8,11 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if swift(>=5.11)
+import SwiftSyntax
+#else
 public import SwiftSyntax
+#endif
 
 /// A type describing an argument to a function, closure, etc.
 ///

--- a/Sources/TestingMacros/Support/AttributeDiscovery.swift
+++ b/Sources/TestingMacros/Support/AttributeDiscovery.swift
@@ -8,8 +8,13 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if swift(>=5.11)
+import SwiftSyntax
+import SwiftSyntaxMacros
+#else
 public import SwiftSyntax
 public import SwiftSyntaxMacros
+#endif
 
 /// A syntax rewriter that removes leading `Self.` tokens from member access
 /// expressions in a syntax tree.

--- a/Sources/TestingMacros/Support/AvailabilityGuards.swift
+++ b/Sources/TestingMacros/Support/AvailabilityGuards.swift
@@ -8,8 +8,13 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if swift(>=5.11)
+import SwiftSyntax
+import SwiftSyntaxMacros
+#else
 public import SwiftSyntax
 public import SwiftSyntaxMacros
+#endif
 
 /// A structure describing a single platform/version pair from an `@available()`
 /// attribute.

--- a/Sources/TestingMacros/Support/CommentParsing.swift
+++ b/Sources/TestingMacros/Support/CommentParsing.swift
@@ -8,7 +8,11 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if swift(>=5.11)
+import SwiftSyntax
+#else
 public import SwiftSyntax
+#endif
 
 /// Find a common whitespace prefix among all lines in a string and trim it.
 ///

--- a/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
+++ b/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
@@ -8,8 +8,13 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if swift(>=5.11)
+import SwiftSyntax
+import SwiftSyntaxMacros
+#else
 public import SwiftSyntax
 public import SwiftSyntaxMacros
+#endif
 
 /// The result of parsing the condition argument passed to `#expect()` or
 /// `#require()`.

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -9,8 +9,13 @@
 //
 
 import SwiftDiagnostics
+#if swift(>=5.11)
+import SwiftSyntax
+import SwiftSyntaxMacros
+#else
 public import SwiftSyntax
 public import SwiftSyntaxMacros
+#endif
 
 /// A type describing diagnostic messages emitted by this module's macro during
 /// evaluation.

--- a/Sources/TestingMacros/Support/SourceCodeCapturing.swift
+++ b/Sources/TestingMacros/Support/SourceCodeCapturing.swift
@@ -8,7 +8,11 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if swift(>=5.11)
+import SwiftSyntax
+#else
 public import SwiftSyntax
+#endif
 
 /// Get an expression initializing an instance of ``SourceCode`` from an
 /// arbitrary syntax node.

--- a/Sources/TestingMacros/Support/SourceLocationGeneration.swift
+++ b/Sources/TestingMacros/Support/SourceLocationGeneration.swift
@@ -8,8 +8,13 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if swift(>=5.11)
+import SwiftSyntax
+import SwiftSyntaxMacros
+#else
 public import SwiftSyntax
 public import SwiftSyntaxMacros
+#endif
 
 /// Get an expression initializing an instance of ``SourceLocation`` from an
 /// arbitrary expression value.

--- a/Sources/TestingMacros/TestingMacrosMain.swift
+++ b/Sources/TestingMacros/TestingMacrosMain.swift
@@ -10,7 +10,11 @@
 
 #if canImport(SwiftCompilerPlugin)
 import SwiftCompilerPlugin
+#if swift(>=5.11)
+import SwiftSyntaxMacros
+#else
 public import SwiftSyntaxMacros
+#endif
 
 /// The main entry point for the compiler plugin executable that provides macros
 /// for the `swift-testing` package.


### PR DESCRIPTION
This PR removes the explicit `public` keyword from imports of SwiftSyntax and SwiftSyntaxMacros in all files except those that actually declare macro implementations. If compiling using Swift 5.10 or earlier, the `public` keyword is preserved because earlier compilers don't correctly handle a scenario where a module is imported publicly in one file and internally in another.

This change removes a number of warnings of the form:

```
.../swift-testing/Sources/TestingMacros/Support/AttributeDiscovery.swift:11:8: warning: public import of 'SwiftSyntax' was not used in public declarations or inlinable code
public import SwiftSyntax
~~~~~~~^
.../swift-testing/Sources/TestingMacros/Support/AttributeDiscovery.swift:12:8: warning: public import of 'SwiftSyntaxMacros' was not used in public declarations or inlinable code
public import SwiftSyntaxMacros
~~~~~~~^
```

This change also tweaks the declarations of `ExpectMacro` and `RequireMacro` as they indirectly conform to `ExpressionMacro` in a way that may confuse some versions of the Swift compiler.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
