### PR TITLE
Remove the 'ExperimentalParameterizedTesting' `@_spi` group from several parameterized testing-related declarations

### DIFF
--- a/Sources/Testing/Events/Event.swift
+++ b/Sources/Testing/Events/Event.swift
@@ -42,14 +42,12 @@ public struct Event: Sendable {
     ///
     /// The test case that started is contained in the ``Event/Context``
     /// instance that was passed to the event handler along with this event.
-    @_spi(ExperimentalParameterizedTesting)
     case testCaseStarted
 
     /// A test case ended.
     ///
     /// The test case that ended is contained in the ``Event/Context`` instance
     /// that was passed to the event handler along with this event.
-    @_spi(ExperimentalParameterizedTesting)
     case testCaseEnded
 
     /// An expectation was checked with `#expect()` or `#require()`.
@@ -123,7 +121,6 @@ public struct Event: Sendable {
   ///
   /// If an event occurred independently of any test case, or if the running
   /// test case cannot be determined, the value of this property is `nil`.
-  @_spi(ExperimentalParameterizedTesting)
   public var testCaseID: Test.Case.ID?
 
   /// The instant at which the event occurred.
@@ -206,7 +203,6 @@ extension Event {
     /// associated with this event. For non-parameterized tests, a single test
     /// case is synthesized. For test suite types (as opposed to test
     /// functions), the value of this property is `nil`.
-    @_spi(ExperimentalParameterizedTesting)
     public var testCase: Test.Case?
 
     /// Initialize a new instance of this type.
@@ -312,11 +308,9 @@ extension Event.Kind {
     case testStarted
 
     /// A test case started.
-    @_spi(ExperimentalParameterizedTesting)
     case testCaseStarted
 
     /// A test case ended.
-    @_spi(ExperimentalParameterizedTesting)
     case testCaseEnded
 
     /// An expectation was checked with `#expect()` or `#require()`.

--- a/Sources/Testing/Parameterization/CustomTestArgumentEncodable.swift
+++ b/Sources/Testing/Parameterization/CustomTestArgumentEncodable.swift
@@ -14,7 +14,6 @@ private import Foundation
 
 /// A protocol for customizing how arguments passed to parameterized tests are
 /// encoded, which is used to match against when running specific arguments.
-@_spi(ExperimentalParameterizedTesting)
 public protocol CustomTestArgumentEncodable: Sendable {
   /// Encode this test argument.
   ///

--- a/Sources/Testing/Parameterization/Test.Case.ID.swift
+++ b/Sources/Testing/Parameterization/Test.Case.ID.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@_spi(ExperimentalParameterizedTesting)
+@_spi(ExperimentalTestRunning)
 extension Test.Case: Identifiable {
   /// The ID of a test case.
   ///
@@ -23,7 +23,6 @@ extension Test.Case: Identifiable {
     /// case's arguments has a `nil` ID.
     public var argumentIDs: [Argument.ID]?
 
-    @_spi(ExperimentalTestRunning)
     public init(argumentIDs: [Argument.ID]?) {
       self.argumentIDs = argumentIDs
     }

--- a/Sources/Testing/Parameterization/Test.Case.swift
+++ b/Sources/Testing/Parameterization/Test.Case.swift
@@ -8,7 +8,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@_spi(ExperimentalParameterizedTesting)
 extension Test {
   /// A single test case from a parameterized ``Test``.
   ///
@@ -21,11 +20,11 @@ extension Test {
     public struct Argument: Sendable {
       /// A type representing the stable, unique identifier of a parameterized
       /// test argument.
+      @_spi(ExperimentalTestRunning)
       public struct ID: Sendable {
         /// The raw bytes of this instance's identifier.
         public var bytes: [UInt8]
 
-        @_spi(ExperimentalTestRunning)
         public init(bytes: [UInt8]) {
           self.bytes = bytes
         }
@@ -45,6 +44,7 @@ extension Test {
       /// ## See Also
       ///
       /// - ``CustomTestArgumentEncodable``
+      @_spi(ExperimentalTestRunning)
       public var id: ID? {
         // FIXME: Capture the error and propagate to the user, not as a test
         // failure but as an advisory warning. A missing argument ID will

--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -161,11 +161,9 @@ public struct Configuration: Sendable {
   ///
   /// - Returns: A Boolean value representing if the test case satisfied the
   ///   filter.
-  @_spi(ExperimentalParameterizedTesting)
   public typealias TestCaseFilter = @Sendable (_ testCase: Test.Case, _ test: Test) -> Bool
 
   /// The test case filter to which test cases should be filtered when run.
-  @_spi(ExperimentalParameterizedTesting)
   public var testCaseFilter: TestCaseFilter = { _, _ in true }
 }
 

--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -89,7 +89,6 @@ public struct Test: Sendable {
   }
 
   /// Whether or not this test is parameterized.
-  @_spi(ExperimentalParameterizedTesting)
   public var isParameterized: Bool {
     guard let parameterCount = parameters?.count else {
       return false
@@ -103,7 +102,6 @@ public struct Test: Sendable {
   /// an array of values describing its parameters, which may be empty if the
   /// test function is non-parameterized. If this instance represents a test
   /// suite, the value of this property is `nil`.
-  @_spi(ExperimentalParameterizedTesting)
   public var parameters: [Parameter]?
 
   /// Whether or not this instance is a test suite containing other tests.
@@ -203,7 +201,6 @@ extension Test {
     /// ## See Also
     ///
     /// - ``Test/parameters``
-    @_spi(ExperimentalParameterizedTesting)
     public var parameters: [Parameter]?
 
     /// Initialize an instance of this type by snapshotting the specified test.
@@ -224,7 +221,6 @@ extension Test {
     /// ## See Also
     ///
     /// - ``Test/isParameterized``
-    @_spi(ExperimentalParameterizedTesting)
     public var isParameterized: Bool {
       guard let parameterCount = parameters?.count else {
         return false

--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -90,10 +90,7 @@ public struct Test: Sendable {
 
   /// Whether or not this test is parameterized.
   public var isParameterized: Bool {
-    guard let parameterCount = parameters?.count else {
-      return false
-    }
-    return parameterCount != 0
+    parameters?.isEmpty == false
   }
 
   /// The test function parameters, if any.
@@ -222,10 +219,7 @@ extension Test {
     ///
     /// - ``Test/isParameterized``
     public var isParameterized: Bool {
-      guard let parameterCount = parameters?.count else {
-        return false
-      }
-      return parameterCount != 0
+      parameters?.isEmpty == false
     }
 
     /// Whether or not this instance is a test suite containing other tests.

--- a/Tests/TestingTests/EventTests.swift
+++ b/Tests/TestingTests/EventTests.swift
@@ -11,7 +11,7 @@
 #if canImport(Foundation)
 import Foundation
 #endif
-@testable @_spi(ExperimentalEventHandling) @_spi(ExperimentalParameterizedTesting) @_spi(ExperimentalSnapshotting) @_spi(ExperimentalTestRunning) import Testing
+@testable @_spi(ExperimentalEventHandling) @_spi(ExperimentalSnapshotting) @_spi(ExperimentalTestRunning) import Testing
 private import TestingInternals
 
 struct EventTests {

--- a/Tests/TestingTests/Test.Case.ArgumentTests.swift
+++ b/Tests/TestingTests/Test.Case.ArgumentTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalTestRunning) @_spi(ExperimentalParameterizedTesting) @_spi(ExperimentalEventHandling) import Testing
+@testable @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) import Testing
 
 @Suite("Test.Case.Argument Tests")
 struct Test_Case_ArgumentTests {

--- a/Tests/TestingTests/Test.SnapshotTests.swift
+++ b/Tests/TestingTests/Test.SnapshotTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@_spi(ExperimentalSnapshotting) @_spi(ExperimentalParameterizedTesting) import Testing
+@_spi(ExperimentalSnapshotting) import Testing
 
 #if canImport(Foundation)
 import Foundation

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalTestRunning) @_spi(ExperimentalParameterizedTesting) @_spi(ExperimentalEventHandling) import Testing
+@testable @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) import Testing
 #if canImport(XCTest)
 import XCTest
 #endif

--- a/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
+++ b/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) @_spi(ExperimentalParameterizedTesting) import Testing
+@testable @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) import Testing
 
 @Suite("TimeLimitTrait Tests", .tags("trait"))
 struct TimeLimitTraitTests {

--- a/Tests/TestingTests/ZipTests.swift
+++ b/Tests/TestingTests/ZipTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalParameterizedTesting) @_spi(ExperimentalTestRunning) import Testing
+@testable @_spi(ExperimentalTestRunning) import Testing
 
 struct ZipTests {
   @Test("Zipped collections are not combinatoric")


### PR DESCRIPTION
This removes the `@_spi(ExperimentalParameterizedTesting)` attribute from several declarations related to parameterized tests. Note that some of these still have _other_ `@_spi` attributes, which prevent them from being fully exposed.

### Motivation:

The parameterized test feature has become more mature, after a series of recent PRs which have refined its functionality and added test coverage. It now feels appropriate to lift some of the `@_spi` attributes which were artificially limiting access to certain APIs — in particular, those for inspecting the currently-executing test case (if any) and controlling how arguments are handled.

### Modifications:

This removes the `@_spi(ExperimentalParameterizedTesting)` attribute from several declarations. However, since some of those still have _other_ SPI attributes, not all of those modified are becoming fully exposed.

### Result:

The following declarations become fully exposed, without any remaining `@_spi` attributes:

- `Test.isParameterized`
- `Test.parameters`
- `Test.Case`
- `Test.Case.current`
- `Test.Case.Argument`
- `Test.Parameter`
- `CustomTestArgumentEncodable`

While auditing these, I opted to _keep_ the `@_spi(ExperimentalParameterizedTesting)` on one declaration worth calling out in particular: `Test.testCases`. This accessor allows accessing all of the individual cases of a parameterized test, and in general it's not something test authors should need to access because the testing library manages running these.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Resolves rdar://118575309
