### PR TITLE
Rename `Test.ParameterInfo` to `Test.Parameter`

### DIFF
--- a/Sources/Testing/Parameterization/CustomTestArgumentEncodable.swift
+++ b/Sources/Testing/Parameterization/CustomTestArgumentEncodable.swift
@@ -64,7 +64,7 @@ extension Test.Case.Argument.ID {
   /// ## See Also
   ///
   /// - ``CustomTestArgumentEncodable``
-  init?(identifying value: some Sendable, parameter: Test.ParameterInfo) throws {
+  init?(identifying value: some Sendable, parameter: Test.Parameter) throws {
 #if canImport(Foundation)
     func customArgumentWrapper(for value: some CustomTestArgumentEncodable) -> some Encodable {
       _CustomArgumentWrapper(rawValue: value)
@@ -103,7 +103,7 @@ extension Test.Case.Argument.ID {
   /// - Returns: An array of bytes containing the encoded representation.
   ///
   /// - Throws: Any error encountered during encoding.
-  private static func _encode(_ value: some Encodable, parameter: Test.ParameterInfo) throws -> [UInt8] {
+  private static func _encode(_ value: some Encodable, parameter: Test.Parameter) throws -> [UInt8] {
     let encoder = JSONEncoder()
 
     // Keys must be sorted to ensure deterministic matching of encoded data.
@@ -135,7 +135,7 @@ private struct _CustomArgumentWrapper<T>: RawRepresentable, Encodable where T: C
 // MARK: - Additional coding user info
 
 extension CodingUserInfoKey {
-  /// A coding user info key whose value is a ``Test/ParameterInfo``.
+  /// A coding user info key whose value is a ``Test/Parameter``.
   fileprivate static var _testParameterUserInfoKey: Self {
     Self(rawValue: "org.swift.testing.coding-user-info-key.parameter")!
   }
@@ -148,7 +148,7 @@ extension Encoder {
   /// The value of this property is non-`nil` when this encoder is being used to
   /// encode an argument passed to a parameterized test function.
   @_spi(ExperimentalParameterizedTesting)
-  public var testParameter: Test.ParameterInfo? {
-    userInfo[._testParameterUserInfoKey] as? Test.ParameterInfo
+  public var testParameter: Test.Parameter? {
+    userInfo[._testParameterUserInfoKey] as? Test.Parameter
   }
 }

--- a/Sources/Testing/Parameterization/Test.Case.Generator.swift
+++ b/Sources/Testing/Parameterization/Test.Case.Generator.swift
@@ -84,7 +84,7 @@ extension Test.Case {
     @_disfavoredOverload
     init(
       arguments collection: S,
-      parameters: [Test.ParameterInfo],
+      parameters: [Test.Parameter],
       testFunction: @escaping @Sendable (S.Element) async throws -> Void
     ) where S: Collection {
       if parameters.count > 1 {
@@ -123,7 +123,7 @@ extension Test.Case {
     ///     passes an argument value from `collection`.
     init<C1, C2>(
       arguments collection1: C1, _ collection2: C2,
-      parameters: [Test.ParameterInfo],
+      parameters: [Test.Parameter],
       testFunction: @escaping @Sendable (C1.Element, C2.Element) async throws -> Void
     ) where S == CartesianProduct<C1, C2> {
       self.init(sequence: cartesianProduct(collection1, collection2)) { element in
@@ -153,7 +153,7 @@ extension Test.Case {
     /// }
     private init<E1, E2>(
       sequence: S,
-      parameters: [Test.ParameterInfo],
+      parameters: [Test.Parameter],
       testFunction: @escaping @Sendable ((E1, E2)) async throws -> Void
     ) where S.Element == (E1, E2), E1: Sendable, E2: Sendable {
       if parameters.count > 1 {
@@ -191,7 +191,7 @@ extension Test.Case {
     /// }
     init<E1, E2>(
       arguments collection: S,
-      parameters: [Test.ParameterInfo],
+      parameters: [Test.Parameter],
       testFunction: @escaping @Sendable ((E1, E2)) async throws -> Void
     ) where S: Collection, S.Element == (E1, E2) {
       self.init(sequence: collection, parameters: parameters, testFunction: testFunction)
@@ -209,7 +209,7 @@ extension Test.Case {
     ///     passes an argument value from `zippedCollections`.
     init<C1, C2>(
       arguments zippedCollections: Zip2Sequence<C1, C2>,
-      parameters: [Test.ParameterInfo],
+      parameters: [Test.Parameter],
       testFunction: @escaping @Sendable ((C1.Element, C2.Element)) async throws -> Void
     ) where S == Zip2Sequence<C1, C2>, C1: Collection, C2: Collection {
       self.init(sequence: zippedCollections, parameters: parameters, testFunction: testFunction)
@@ -233,7 +233,7 @@ extension Test.Case {
     /// `Dictionary` includes labels (`(key: Key, value: Value)`).
     init<Key, Value>(
       arguments dictionary: Dictionary<Key, Value>,
-      parameters: [Test.ParameterInfo],
+      parameters: [Test.Parameter],
       testFunction: @escaping @Sendable ((Key, Value)) async throws -> Void
     ) where S == Dictionary<Key, Value> {
       if parameters.count > 1 {

--- a/Sources/Testing/Parameterization/Test.Case.swift
+++ b/Sources/Testing/Parameterization/Test.Case.swift
@@ -56,7 +56,7 @@ extension Test {
       public var value: any Sendable
 
       /// The parameter of the test function to which this argument was passed.
-      public var parameter: ParameterInfo
+      public var parameter: Parameter
     }
 
     /// The arguments passed to this test case.
@@ -64,7 +64,7 @@ extension Test {
     /// If the argument was a tuple but its elements were passed to distinct
     /// parameters of the test function, each element of the tuple will be
     /// represented as a separate ``Argument`` instance paired with the
-    /// ``Test/ParameterInfo`` to which it was passed. However, if the test
+    /// ``Test/Parameter`` to which it was passed. However, if the test
     /// function has a single tuple parameter, the tuple will be preserved and
     /// represented as one ``Argument`` instance.
     ///
@@ -90,7 +90,7 @@ extension Test {
     ///   - body: The body closure of this test case.
     init(
       values: [any Sendable],
-      parameters: [ParameterInfo],
+      parameters: [Parameter],
       body: @escaping @Sendable () async throws -> Void
     ) {
       let arguments = zip(values, parameters).map { value, parameter in
@@ -117,7 +117,7 @@ extension Test {
   /// value that might be passed via this parameter to a test function. To
   /// obtain the arguments of a particular ``Test/Case`` paired with their
   /// corresponding parameters, use ``Test/Case/arguments``.
-  public struct ParameterInfo: Sendable {
+  public struct Parameter: Sendable {
     /// The zero-based index of this parameter within its associated test's
     /// parameter list.
     public var index: Int
@@ -132,12 +132,12 @@ extension Test {
 
 // MARK: - Codable
 
-extension Test.ParameterInfo: Codable {}
+extension Test.Parameter: Codable {}
 extension Test.Case.Argument.ID: Codable {}
 
 // MARK: - Equatable, Hashable
 
-extension Test.ParameterInfo: Equatable {}
+extension Test.Parameter: Equatable {}
 extension Test.Case.Argument.ID: Hashable {}
 
 // MARK: - Snapshotting
@@ -182,7 +182,7 @@ extension Test.Case.Argument {
     public var valueDebugDescription: String?
 
     /// The parameter of the test function to which this argument was passed.
-    public var parameter: Test.ParameterInfo
+    public var parameter: Test.Parameter
 
     /// Initialize an instance of this type by snapshotting the specified test
     /// case argument.

--- a/Sources/Testing/Test+Macro.swift
+++ b/Sources/Testing/Test+Macro.swift
@@ -149,7 +149,7 @@ extension Test {
   ///
   /// - Warning: This type alias is used to implement the `@Test` macro. Do not
   ///   use it directly.
-  public typealias __ParameterInfo = (firstName: String, secondName: String?)
+  public typealias __Parameter = (firstName: String, secondName: String?)
 
   /// Create an instance of ``Test`` for a function.
   ///
@@ -162,7 +162,7 @@ extension Test {
     displayName: String? = nil,
     traits: [any TestTrait],
     sourceLocation: SourceLocation,
-    parameters: [__ParameterInfo] = [],
+    parameters: [__Parameter] = [],
     testFunction: @escaping @Sendable () async throws -> Void
   ) -> Self {
     let caseGenerator = Case.Generator(testFunction: testFunction)
@@ -170,15 +170,15 @@ extension Test {
   }
 }
 
-extension [Test.__ParameterInfo] {
-  /// An array of ``Test/ParameterInfo`` values based on this array of parameter
+extension [Test.__Parameter] {
+  /// An array of ``Test/Parameter`` values based on this array of parameter
   /// tuples.
   ///
   /// This conversion derives the value of the `index` property of the resulting
   /// parameter instances from the position of the tuple in the original array.
-  fileprivate var parameters: [Test.ParameterInfo] {
+  fileprivate var parameters: [Test.Parameter] {
     enumerated().map { index, parameter in
-      Test.ParameterInfo(index: index, firstName: parameter.firstName, secondName: parameter.secondName)
+      Test.Parameter(index: index, firstName: parameter.firstName, secondName: parameter.secondName)
     }
   }
 }
@@ -237,7 +237,7 @@ extension Test {
     traits: [any TestTrait],
     arguments collection: C,
     sourceLocation: SourceLocation,
-    parameters paramTuples: [__ParameterInfo],
+    parameters paramTuples: [__Parameter],
     testFunction: @escaping @Sendable (C.Element) async throws -> Void
   ) -> Self where C: Collection & Sendable, C.Element: Sendable {
     let parameters = paramTuples.parameters
@@ -365,7 +365,7 @@ extension Test {
     traits: [any TestTrait],
     arguments collection1: C1, _ collection2: C2,
     sourceLocation: SourceLocation,
-    parameters paramTuples: [__ParameterInfo],
+    parameters paramTuples: [__Parameter],
     testFunction: @escaping @Sendable (C1.Element, C2.Element) async throws -> Void
   ) -> Self where C1: Collection & Sendable, C1.Element: Sendable, C2: Collection & Sendable, C2.Element: Sendable {
     let parameters = paramTuples.parameters
@@ -388,7 +388,7 @@ extension Test {
     traits: [any TestTrait],
     arguments collection: C,
     sourceLocation: SourceLocation,
-    parameters paramTuples: [__ParameterInfo],
+    parameters paramTuples: [__Parameter],
     testFunction: @escaping @Sendable ((E1, E2)) async throws -> Void
   ) -> Self where C: Collection & Sendable, C.Element == (E1, E2), E1: Sendable, E2: Sendable {
     let parameters = paramTuples.parameters
@@ -414,7 +414,7 @@ extension Test {
     traits: [any TestTrait],
     arguments dictionary: Dictionary<Key, Value>,
     sourceLocation: SourceLocation,
-    parameters paramTuples: [__ParameterInfo],
+    parameters paramTuples: [__Parameter],
     testFunction: @escaping @Sendable ((Key, Value)) async throws -> Void
   ) -> Self where Key: Sendable, Value: Sendable {
     let parameters = paramTuples.parameters
@@ -434,7 +434,7 @@ extension Test {
     traits: [any TestTrait],
     arguments zippedCollections: Zip2Sequence<C1, C2>,
     sourceLocation: SourceLocation,
-    parameters paramTuples: [__ParameterInfo],
+    parameters paramTuples: [__Parameter],
     testFunction: @escaping @Sendable (C1.Element, C2.Element) async throws -> Void
   ) -> Self where C1: Collection & Sendable, C1.Element: Sendable, C2: Collection & Sendable, C2.Element: Sendable {
     let parameters = paramTuples.parameters

--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -104,7 +104,7 @@ public struct Test: Sendable {
   /// test function is non-parameterized. If this instance represents a test
   /// suite, the value of this property is `nil`.
   @_spi(ExperimentalParameterizedTesting)
-  public var parameters: [ParameterInfo]?
+  public var parameters: [Parameter]?
 
   /// Whether or not this instance is a test suite containing other tests.
   ///
@@ -141,7 +141,7 @@ public struct Test: Sendable {
     containingType: Any.Type? = nil,
     xcTestCompatibleSelector: __XCTestCompatibleSelector? = nil,
     testCases: Test.Case.Generator<S>,
-    parameters: [ParameterInfo]
+    parameters: [Parameter]
   ) {
     self.name = name
     self.displayName = displayName
@@ -204,7 +204,7 @@ extension Test {
     ///
     /// - ``Test/parameters``
     @_spi(ExperimentalParameterizedTesting)
-    public var parameters: [ParameterInfo]?
+    public var parameters: [Parameter]?
 
     /// Initialize an instance of this type by snapshotting the specified test.
     ///

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -404,7 +404,7 @@ struct MiscellaneousTests {
     let monomorphicTestFunctionParameters = try #require(monomorphicTestFunction.parameters)
     #expect(monomorphicTestFunctionParameters.isEmpty)
 
-    let parameterizedTestFunction = Test(arguments: 0 ..< 100, parameters: [Test.ParameterInfo(index: 0, firstName: "i")]) { _ in }
+    let parameterizedTestFunction = Test(arguments: 0 ..< 100, parameters: [Test.Parameter(index: 0, firstName: "i")]) { _ in }
     #expect(parameterizedTestFunction.isParameterized)
     let parameterizedTestFunctionTestCases = try #require(parameterizedTestFunction.testCases)
     #expect(parameterizedTestFunctionTestCases.underestimatedCount == 100)
@@ -414,8 +414,8 @@ struct MiscellaneousTests {
     #expect(parameterizedTestFunctionFirstParameter.firstName == "i")
 
     let parameterizedTestFunction2 = Test(arguments: 0 ..< 100, 0 ..< 100, parameters: [
-      Test.ParameterInfo(index: 0, firstName: "i"),
-      Test.ParameterInfo(index: 1, firstName: "j", secondName: "value"),
+      Test.Parameter(index: 0, firstName: "i"),
+      Test.Parameter(index: 1, firstName: "j", secondName: "value"),
     ]) { _, _ in }
     #expect(parameterizedTestFunction2.isParameterized)
     let parameterizedTestFunction2TestCases = try #require(parameterizedTestFunction2.testCases)

--- a/Tests/TestingTests/Test.Case.Argument.IDTests.swift
+++ b/Tests/TestingTests/Test.Case.Argument.IDTests.swift
@@ -19,7 +19,7 @@ struct Test_Case_Argument_IDTests {
   func oneCodableParameter() async throws {
     let test = Test(
       arguments: [123],
-      parameters: [Test.ParameterInfo(index: 0, firstName: "value")]
+      parameters: [Test.Parameter(index: 0, firstName: "value")]
     ) { _ in }
     let testCases = try #require(test.testCases)
     let testCase = try #require(testCases.first { _ in true })
@@ -33,7 +33,7 @@ struct Test_Case_Argument_IDTests {
   func oneCustomParameter() async throws {
     let test = Test(
       arguments: [MyCustomTestArgument(x: 123, y: "abc")],
-      parameters: [Test.ParameterInfo(index: 0, firstName: "value")]
+      parameters: [Test.Parameter(index: 0, firstName: "value")]
     ) { _ in }
     let testCases = try #require(test.testCases)
     let testCase = try #require(testCases.first { _ in true })
@@ -50,7 +50,7 @@ struct Test_Case_Argument_IDTests {
   func oneIdentifiableParameter() async throws {
     let test = Test(
       arguments: [MyIdentifiableArgument(id: "abc")],
-      parameters: [Test.ParameterInfo(index: 0, firstName: "value")]
+      parameters: [Test.Parameter(index: 0, firstName: "value")]
     ) { _ in }
     let testCases = try #require(test.testCases)
     let testCase = try #require(testCases.first { _ in true })

--- a/Tests/TestingTests/TestCaseSelectionTests.swift
+++ b/Tests/TestingTests/TestCaseSelectionTests.swift
@@ -14,7 +14,7 @@
 struct TestCaseSelectionTests {
   @Test("Multiple arguments passed to one parameter, selecting one case")
   func oneParameterSelectingOneCase() async throws {
-    let fixtureTest = Test(arguments: ["a", "b"], parameters: [Test.ParameterInfo(index: 0, firstName: "value")]) { value in
+    let fixtureTest = Test(arguments: ["a", "b"], parameters: [Test.Parameter(index: 0, firstName: "value")]) { value in
       #expect(value == "a")
     }
 
@@ -41,7 +41,7 @@ struct TestCaseSelectionTests {
 
   @Test("Multiple arguments passed to one parameter, selecting a subset of cases")
   func oneParameterSelectingMultipleCases() async throws {
-    let fixtureTest = Test(arguments: ["a", "b", "c"], parameters: [Test.ParameterInfo(index: 0, firstName: "value")]) { value in
+    let fixtureTest = Test(arguments: ["a", "b", "c"], parameters: [Test.Parameter(index: 0, firstName: "value")]) { value in
       #expect(value != "b")
     }
 
@@ -77,8 +77,8 @@ struct TestCaseSelectionTests {
     let fixtureTest = Test(
       arguments: ["a", "b"], [1, 2],
       parameters: [
-        Test.ParameterInfo(index: 0, firstName: "stringValue"),
-        Test.ParameterInfo(index: 1, firstName: "intValue"),
+        Test.Parameter(index: 0, firstName: "stringValue"),
+        Test.Parameter(index: 1, firstName: "intValue"),
       ]
     ) { stringValue, intValue in
       #expect(stringValue == "b" && intValue == 2)
@@ -117,7 +117,7 @@ struct TestCaseSelectionTests {
     let fixtureTest = Test(arguments: [
       MyCustomTestArgument(x: 1, y: "a"),
       MyCustomTestArgument(x: 2, y: "b"),
-    ], parameters: [Test.ParameterInfo(index: 0, firstName: "value")]) { arg in
+    ], parameters: [Test.Parameter(index: 0, firstName: "value")]) { arg in
       #expect(arg.x == 1 && arg.y == "a")
     }
 
@@ -147,7 +147,7 @@ struct TestCaseSelectionTests {
     let fixtureTest = Test(arguments: [
       MyCustomIdentifiableArgument(id: "a"),
       MyCustomIdentifiableArgument(id: "b"),
-    ], parameters: [Test.ParameterInfo(index: 0, firstName: "value")]) { arg in
+    ], parameters: [Test.Parameter(index: 0, firstName: "value")]) { arg in
       #expect(arg.id == "a")
     }
 

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -154,7 +154,7 @@ extension Test {
   init<C>(
     _ traits: any TestTrait...,
     arguments collection: C,
-    parameters: [ParameterInfo] = [],
+    parameters: [Parameter] = [],
     fileID: String = #fileID,
     filePath: String = #filePath,
     line: Int = #line,
@@ -186,7 +186,7 @@ extension Test {
   init<C1, C2>(
     _ traits: any TestTrait...,
     arguments collection1: C1, _ collection2: C2,
-    parameters: [ParameterInfo] = [],
+    parameters: [Parameter] = [],
     fileID: String = #fileID,
     filePath: String = #filePath,
     line: Int = #line,
@@ -213,7 +213,7 @@ extension Test {
   init<C1, C2>(
     _ traits: any TestTrait...,
     arguments zippedCollections: Zip2Sequence<C1, C2>,
-    parameters: [ParameterInfo] = [],
+    parameters: [Parameter] = [],
     fileID: String = #fileID,
     filePath: String = #filePath,
     line: Int = #line,


### PR DESCRIPTION
### Motivation:

In preparation for exposing some parameterized test-related declarations as public API (#191), we'd like to simplify the name of the `Test.ParameterInfo` type to just `Test.Parameter`. This makes certain property names like `Test.parameters` more consistent with Swift API design idioms.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
