### PR TITLE
Work around a bug with variadic generics when mixed with C strings.

### DIFF
--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -194,6 +194,116 @@ public func __checkFunctionCall<T, each U>(
   )
 }
 
+#if !SWT_FIXED_122011759
+/// Check that an expectation has passed after a condition has been evaluated
+/// and throw an error if it failed.
+///
+/// This overload works around a bug in variadic generics that may cause a
+/// miscompile when an argument to a function is a C string converted from a
+/// Swift string (e.g. the arguments to `fopen("/file/path", "wb")`.)
+///
+/// - Warning: This function is used to implement the `#expect()` and
+///   `#require()` macros. Do not call it directly.
+public func __checkFunctionCall<T, Arg0>(
+  _ lhs: T, calling functionCall: (T, Arg0) throws -> Bool, _ argument0: Arg0,
+  expression: Expression,
+  comments: @autoclosure () -> [Comment],
+  isRequired: Bool,
+  sourceLocation: SourceLocation
+) rethrows -> Result<Void, any Error> {
+  let condition = try functionCall(lhs, argument0)
+  return __checkValue(
+    condition,
+    expression: expression,
+    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(lhs, argument0),
+    comments: comments(),
+    isRequired: isRequired,
+    sourceLocation: sourceLocation
+  )
+}
+
+/// Check that an expectation has passed after a condition has been evaluated
+/// and throw an error if it failed.
+///
+/// This overload works around a bug in variadic generics that may cause a
+/// miscompile when an argument to a function is a C string converted from a
+/// Swift string (e.g. the arguments to `fopen("/file/path", "wb")`.)
+///
+/// - Warning: This function is used to implement the `#expect()` and
+///   `#require()` macros. Do not call it directly.
+public func __checkFunctionCall<T, Arg0, Arg1>(
+  _ lhs: T, calling functionCall: (T, Arg0, Arg1) throws -> Bool, _ argument0: Arg0, _ argument1: Arg1,
+  expression: Expression,
+  comments: @autoclosure () -> [Comment],
+  isRequired: Bool,
+  sourceLocation: SourceLocation
+) rethrows -> Result<Void, any Error> {
+  let condition = try functionCall(lhs, argument0, argument1)
+  return __checkValue(
+    condition,
+    expression: expression,
+    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(lhs, argument0, argument1),
+    comments: comments(),
+    isRequired: isRequired,
+    sourceLocation: sourceLocation
+  )
+}
+
+/// Check that an expectation has passed after a condition has been evaluated
+/// and throw an error if it failed.
+///
+/// This overload works around a bug in variadic generics that may cause a
+/// miscompile when an argument to a function is a C string converted from a
+/// Swift string (e.g. the arguments to `fopen("/file/path", "wb")`.)
+///
+/// - Warning: This function is used to implement the `#expect()` and
+///   `#require()` macros. Do not call it directly.
+public func __checkFunctionCall<T, Arg0, Arg1, Arg2>(
+  _ lhs: T, calling functionCall: (T, Arg0, Arg1, Arg2) throws -> Bool, _ argument0: Arg0, _ argument1: Arg1, _ argument2: Arg2,
+  expression: Expression,
+  comments: @autoclosure () -> [Comment],
+  isRequired: Bool,
+  sourceLocation: SourceLocation
+) rethrows -> Result<Void, any Error> {
+  let condition = try functionCall(lhs, argument0, argument1, argument2)
+  return __checkValue(
+    condition,
+    expression: expression,
+    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(lhs, argument0, argument1, argument2),
+    comments: comments(),
+    isRequired: isRequired,
+    sourceLocation: sourceLocation
+  )
+}
+
+/// Check that an expectation has passed after a condition has been evaluated
+/// and throw an error if it failed.
+///
+/// This overload works around a bug in variadic generics that may cause a
+/// miscompile when an argument to a function is a C string converted from a
+/// Swift string (e.g. the arguments to `fopen("/file/path", "wb")`.)
+///
+/// - Warning: This function is used to implement the `#expect()` and
+///   `#require()` macros. Do not call it directly.
+public func __checkFunctionCall<T, Arg0, Arg1, Arg2, Arg3>(
+  _ lhs: T, calling functionCall: (T, Arg0, Arg1, Arg2, Arg3) throws -> Bool, _ argument0: Arg0, _ argument1: Arg1, _ argument2: Arg2, _ argument3: Arg3,
+  expression: Expression,
+  comments: @autoclosure () -> [Comment],
+  isRequired: Bool,
+  sourceLocation: SourceLocation
+) rethrows -> Result<Void, any Error> {
+  let condition = try functionCall(lhs, argument0, argument1, argument2, argument3)
+  return __checkValue(
+    condition,
+    expression: expression,
+    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(lhs, argument0, argument1, argument2, argument3),
+    comments: comments(),
+    isRequired: isRequired,
+    sourceLocation: sourceLocation
+  )
+}
+#endif
+
 /// Check that an expectation has passed after a condition has been evaluated
 /// and throw an error if it failed.
 ///
@@ -252,6 +362,116 @@ public func __checkFunctionCall<T, each U, R>(
     sourceLocation: sourceLocation
   )
 }
+
+#if !SWT_FIXED_122011759
+/// Check that an expectation has passed after a condition has been evaluated
+/// and throw an error if it failed.
+///
+/// This overload works around a bug in variadic generics that may cause a
+/// miscompile when an argument to a function is a C string converted from a
+/// Swift string (e.g. the arguments to `fopen("/file/path", "wb")`.)
+///
+/// - Warning: This function is used to implement the `#expect()` and
+///   `#require()` macros. Do not call it directly.
+public func __checkFunctionCall<T, Arg0, R>(
+  _ lhs: T, calling functionCall: (T, Arg0) throws -> R?, _ argument0: Arg0,
+  expression: Expression,
+  comments: @autoclosure () -> [Comment],
+  isRequired: Bool,
+  sourceLocation: SourceLocation
+) rethrows -> Result<R, any Error> {
+  let optionalValue = try functionCall(lhs, argument0)
+  return __checkValue(
+    optionalValue,
+    expression: expression,
+    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(lhs, argument0),
+    comments: comments(),
+    isRequired: isRequired,
+    sourceLocation: sourceLocation
+  )
+}
+
+/// Check that an expectation has passed after a condition has been evaluated
+/// and throw an error if it failed.
+///
+/// This overload works around a bug in variadic generics that may cause a
+/// miscompile when an argument to a function is a C string converted from a
+/// Swift string (e.g. the arguments to `fopen("/file/path", "wb")`.)
+///
+/// - Warning: This function is used to implement the `#expect()` and
+///   `#require()` macros. Do not call it directly.
+public func __checkFunctionCall<T, Arg0, Arg1, R>(
+  _ lhs: T, calling functionCall: (T, Arg0, Arg1) throws -> R?, _ argument0: Arg0, _ argument1: Arg1,
+  expression: Expression,
+  comments: @autoclosure () -> [Comment],
+  isRequired: Bool,
+  sourceLocation: SourceLocation
+) rethrows -> Result<R, any Error> {
+  let optionalValue = try functionCall(lhs, argument0, argument1)
+  return __checkValue(
+    optionalValue,
+    expression: expression,
+    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(lhs, argument0, argument1),
+    comments: comments(),
+    isRequired: isRequired,
+    sourceLocation: sourceLocation
+  )
+}
+
+/// Check that an expectation has passed after a condition has been evaluated
+/// and throw an error if it failed.
+///
+/// This overload works around a bug in variadic generics that may cause a
+/// miscompile when an argument to a function is a C string converted from a
+/// Swift string (e.g. the arguments to `fopen("/file/path", "wb")`.)
+///
+/// - Warning: This function is used to implement the `#expect()` and
+///   `#require()` macros. Do not call it directly.
+public func __checkFunctionCall<T, Arg0, Arg1, Arg2, R>(
+  _ lhs: T, calling functionCall: (T, Arg0, Arg1, Arg2) throws -> R?, _ argument0: Arg0, _ argument1: Arg1, _ argument2: Arg2,
+  expression: Expression,
+  comments: @autoclosure () -> [Comment],
+  isRequired: Bool,
+  sourceLocation: SourceLocation
+) rethrows -> Result<R, any Error> {
+  let optionalValue = try functionCall(lhs, argument0, argument1, argument2)
+  return __checkValue(
+    optionalValue,
+    expression: expression,
+    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(lhs, argument0, argument1, argument2),
+    comments: comments(),
+    isRequired: isRequired,
+    sourceLocation: sourceLocation
+  )
+}
+
+/// Check that an expectation has passed after a condition has been evaluated
+/// and throw an error if it failed.
+///
+/// This overload works around a bug in variadic generics that may cause a
+/// miscompile when an argument to a function is a C string converted from a
+/// Swift string (e.g. the arguments to `fopen("/file/path", "wb")`.)
+///
+/// - Warning: This function is used to implement the `#expect()` and
+///   `#require()` macros. Do not call it directly.
+public func __checkFunctionCall<T, Arg0, Arg1, Arg2, Arg3, R>(
+  _ lhs: T, calling functionCall: (T, Arg0, Arg1, Arg2, Arg3) throws -> R?, _ argument0: Arg0, _ argument1: Arg1, _ argument2: Arg2, _ argument3: Arg3,
+  expression: Expression,
+  comments: @autoclosure () -> [Comment],
+  isRequired: Bool,
+  sourceLocation: SourceLocation
+) rethrows -> Result<R, any Error> {
+  let optionalValue = try functionCall(lhs, argument0, argument1, argument2, argument3)
+  return __checkValue(
+    optionalValue,
+    expression: expression,
+    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(lhs, argument0, argument1, argument2, argument3),
+    comments: comments(),
+    isRequired: isRequired,
+    sourceLocation: sourceLocation
+  )
+}
+#endif
 
 /// Check that an expectation has passed after a condition has been evaluated
 /// and throw an error if it failed.

--- a/Sources/TestingInternals/include/Stubs.h
+++ b/Sources/TestingInternals/include/Stubs.h
@@ -51,12 +51,6 @@ static bool swt_S_ISFIFO(mode_t mode) {
 }
 #endif
 
-/// A type used by the testing library's own tests to validate how C
-/// enumerations are presented in test output.
-enum __attribute__((enum_extensibility(open))) SWTTestEnumeration {
-  SWTTestEnumerationA, SWTTestEnumerationB
-};
-
 SWT_ASSUME_NONNULL_END
 
 #endif

--- a/Sources/TestingInternals/include/TestSupport.h
+++ b/Sources/TestingInternals/include/TestSupport.h
@@ -1,0 +1,42 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+#if !defined(SWT_TESTSUPPORT_H)
+#define SWT_TESTSUPPORT_H
+
+/// This header includes symbols that are used by the testing library's own test
+/// targets. These symbols are not used by other clients of the testing library.
+
+#include "Defines.h"
+#include "Includes.h"
+
+SWT_ASSUME_NONNULL_BEGIN
+
+/// A type used by the testing library's own tests to validate how C
+/// enumerations are presented in test output.
+enum __attribute__((enum_extensibility(open))) SWTTestEnumeration {
+  SWTTestEnumerationA, SWTTestEnumerationB
+};
+
+static inline bool swt_pointersNotEqual2(const char *a, const char *b) {
+  return a != b;
+}
+
+static inline bool swt_pointersNotEqual3(const char *a, const char *b, const char *c) {
+  return a != b && b != c;
+}
+
+static inline bool swt_pointersNotEqual4(const char *a, const char *b, const char *c, const char *d) {
+  return a != b && b != c && c != d;
+}
+
+SWT_ASSUME_NONNULL_END
+
+#endif

--- a/Tests/TestingTests/VariadicGenericTests.swift
+++ b/Tests/TestingTests/VariadicGenericTests.swift
@@ -1,0 +1,18 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+import Testing
+private import TestingInternals
+
+@Test func variadicCStringArguments() async throws {
+  #expect(swt_pointersNotEqual2("abc", "123"))
+  #expect(swt_pointersNotEqual3("abc", "123", "def"))
+  #expect(swt_pointersNotEqual4("abc", "123", "def", "456"))
+}


### PR DESCRIPTION
There's an apparent bug (rdar://122011759) when using variadic generics and passing them a string that needs to be converted to a C string. For example:

```swift
let file = try #require(fopen("/test/file", "wb"))
```

The compiler generates invalid code for this call that results in the two C string arguments to `fopen()` having the same address and containing only the trailing NUL character.

I have only reproduced the issue with functions imported from C; I cannot reproduce it at this time with functions declared in Swift.

This change works around the issue by providing explicit overloads of `__checkFunctionCall()` for functions taking 1, 2, 3, or 4 arguments. Tests calling functions that take more arguments can be refactored, e.g.:

```swift
let filePtr = f("a", "b", "c", "d", "e") // ...
let file = try #require(filePtr)
```

Resolves rdar://122014061.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
