### PR TITLE
Adjust uses of `fopen()` and `strerror()` on Windows.

### DIFF
--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -142,13 +142,14 @@ func configurationForSwiftPMEntryPoint(withArguments args: [String]) throws -> C
 
 #if os(Windows)
     // Windows deprecates fopen() as insecure, so create a wrapper function
-    // that calls fopen_s() instead. If we end up using fopen() in other
-    // places, be sure to hoist this function so it can be reused.
+    // that calls _wfopen_s() instead. If we end up using fopen() in other
+    // places, be sure to hoist this function so it can be reused (and consider
+    // combining it with FileCloser into a single "file" interface.)
     func fopen(_ path: String, _ mode: String) -> SWT_FILEHandle? {
-      path.withCString { path in
-        mode.withCString { mode in
+      path.withCString(encodedAs: UTF16.self) { path in
+        mode.withCString(encodedAs: UTF16.self) { mode in
           var file: SWT_FILEHandle?
-          let result = fopen_s(&file, path, mode)
+          let result = _wfopen_s(&file, path, mode)
           if result != 0 {
             _set_errno(result)
             return nil

--- a/Sources/Testing/Support/CError.swift
+++ b/Sources/Testing/Support/CError.swift
@@ -27,7 +27,8 @@ struct CError: Error, RawRepresentable {
 /// - Parameters:
 ///   - errorCode: The error code to describe.
 ///
-/// - Returns: A Swift string equal to the result of `strerror()`.
+/// - Returns: A Swift string equal to the result of `strerror()` from the C
+///   standard library.
 func strerror(_ errorCode: CInt) -> String {
   String(unsafeUninitializedCapacity: 1024) { buffer in
 #if SWT_TARGET_OS_APPLE || os(Linux)

--- a/Sources/Testing/Support/CError.swift
+++ b/Sources/Testing/Support/CError.swift
@@ -30,19 +30,14 @@ struct CError: Error, RawRepresentable {
 /// - Returns: A Swift string equal to the result of `strerror()` from the C
 ///   standard library.
 func strerror(_ errorCode: CInt) -> String {
+#if os(Windows)
   String(unsafeUninitializedCapacity: 1024) { buffer in
-#if SWT_TARGET_OS_APPLE || os(Linux)
-    _ = strerror_r(errorCode, buffer.baseAddress!, buffer.count)
-#elseif os(Windows)
     _ = strerror_s(buffer.baseAddress!, buffer.count, errorCode)
-#else
-    guard let stringValue = strerror(errorCode) else {
-      return 0
-    }
-    strncpy(buffer.baseAddress!, stringValue, buffer.count)
-#endif
     return strnlen(buffer.baseAddress!, buffer.count)
   }
+#else
+  String(cString: TestingInternals.strerror(errorCode))
+#endif
 }
 
 extension CError: CustomStringConvertible {

--- a/Sources/Testing/Support/CError.swift
+++ b/Sources/Testing/Support/CError.swift
@@ -22,8 +22,30 @@ struct CError: Error, RawRepresentable {
 
 // MARK: - CustomStringConvertible
 
+/// Get a string describing a C error code.
+///
+/// - Parameters:
+///   - errorCode: The error code to describe.
+///
+/// - Returns: A Swift string equal to the result of `strerror()`.
+func strerror(_ errorCode: CInt) -> String {
+  String(unsafeUninitializedCapacity: 1024) { buffer in
+#if SWT_TARGET_OS_APPLE || os(Linux)
+    _ = strerror_r(errorCode, buffer.baseAddress!, buffer.count)
+#elseif os(Windows)
+    _ = strerror_s(buffer.baseAddress!, buffer.count, errorCode)
+#else
+    guard let stringValue = strerror(errorCode) else {
+      return 0
+    }
+    strncpy(buffer.baseAddress!, stringValue, buffer.count)
+#endif
+    return strnlen(buffer.baseAddress!, buffer.count)
+  }
+}
+
 extension CError: CustomStringConvertible {
   var description: String {
-    String(cString: strerror(rawValue))
+    strerror(rawValue)
   }
 }

--- a/Tests/TestingTests/Support/CErrorTests.swift
+++ b/Tests/TestingTests/Support/CErrorTests.swift
@@ -17,8 +17,6 @@ struct CErrorTests {
   func errorDescription(errorCode: CInt) {
     let description = String(describing: CError(rawValue: errorCode))
     #expect(!description.isEmpty)
-    description.withCString { description in
-      #expect(0 == strcmp(strerror(errorCode), description))
-    }
+    #expect(strerror(errorCode) == description)
   }
 }


### PR DESCRIPTION
The Windows SDK deprecates the C standard functions `fopen()` and `strerror()`. This PR modifies our uses of these functions to make Windows happy.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
