### PR TITLE
Add support for `swift test --verbose`.

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
@@ -81,7 +81,7 @@ extension Event {
       ///
       /// When specified, additional output is provided. The exact nature of the
       /// additional output is implementation-defined and subject to change.
-      case recordVerboseOutput
+      case useVerboseOutput
     }
 
     /// The options for this event recorder.
@@ -269,7 +269,7 @@ extension Event.ConsoleOutputRecorder {
   /// - Returns: Whether any output was produced and written to this instance's
   ///   destination.
   @discardableResult public func record(_ event: borrowing Event, in context: borrowing Event.Context) -> Bool {
-    let verbose = options.contains(.recordVerboseOutput)
+    let verbose = options.contains(.useVerboseOutput)
     let messages = _humanReadableOutputRecorder.record(event, in: context, verbosely: verbose)
     for message in messages {
       let symbol = message.symbol?.stringValue(options: options) ?? " "

--- a/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
@@ -76,6 +76,12 @@ extension Event {
       /// This option is ignored unless ``useANSIEscapeCodes`` is also
       /// specified.
       case useTagColors(_ tagColors: [Tag: Tag.Color])
+
+      /// Record verbose output.
+      ///
+      /// When specified, additional output is provided. The exact nature of the
+      /// additional output is implementation-defined and subject to change.
+      case recordVerboseOutput
     }
 
     /// The options for this event recorder.
@@ -263,7 +269,8 @@ extension Event.ConsoleOutputRecorder {
   /// - Returns: Whether any output was produced and written to this instance's
   ///   destination.
   @discardableResult public func record(_ event: borrowing Event, in context: borrowing Event.Context) -> Bool {
-    let messages = _humanReadableOutputRecorder.record(event, in: context)
+    let verbose = options.contains(.recordVerboseOutput)
+    let messages = _humanReadableOutputRecorder.record(event, in: context, verbosely: verbose)
     for message in messages {
       let symbol = message.symbol?.stringValue(options: options) ?? " "
 

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -982,6 +982,7 @@ public func __checkClosureCall<R>(
 ) -> Result<Void, any Error> {
   var errorMatches = false
   var mismatchExplanationValue: String? = nil
+  var expression = expression
   do {
     let result = try body()
 
@@ -991,6 +992,7 @@ public func __checkClosureCall<R>(
     }
     mismatchExplanationValue = explanation
   } catch {
+    expression = expression.capturingRuntimeValues(error)
     do {
       errorMatches = try errorMatcher(error)
       if !errorMatches {
@@ -1029,6 +1031,7 @@ public func __checkClosureCall<R>(
 ) async -> Result<Void, any Error> {
   var errorMatches = false
   var mismatchExplanationValue: String? = nil
+  var expression = expression
   do {
     let result = try await body()
 
@@ -1038,6 +1041,7 @@ public func __checkClosureCall<R>(
     }
     mismatchExplanationValue = explanation
   } catch {
+    expression = expression.capturingRuntimeValues(error)
     do {
       errorMatches = try await errorMatcher(error)
       if !errorMatches {

--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -41,7 +41,12 @@ private import TestingInternals
         oldEventHandler(event, context)
       }
 
-      await runTests(configuration: configuration)
+      var options: [Event.ConsoleOutputRecorder.Option] = .forStandardError
+      if args.contains("--verbose") {
+        options.append(.recordVerboseOutput)
+      }
+
+      await runTests(options: options, configuration: configuration)
     }
   } catch {
     let stderr = swt_stderr()
@@ -231,9 +236,10 @@ func configurationForSwiftPMEntryPoint(withArguments args: [String]) throws -> C
 /// ``XCTestScaffold/runAllTests(hostedBy:)``.
 ///
 /// - Parameters:
+///   - options: Options to pass when configuring the console output recorder.
 ///   - configuration: The configuration to use for running.
-func runTests(configuration: Configuration) async {
-  let eventRecorder = Event.ConsoleOutputRecorder(options: .forStandardError) { string in
+func runTests(options: [Event.ConsoleOutputRecorder.Option], configuration: Configuration) async {
+  let eventRecorder = Event.ConsoleOutputRecorder(options: options) { string in
     let stderr = swt_stderr()
     fputs(string, stderr)
     fflush(stderr)

--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -43,7 +43,7 @@ private import TestingInternals
 
       var options: [Event.ConsoleOutputRecorder.Option] = .forStandardError
       if args.contains("--verbose") {
-        options.append(.recordVerboseOutput)
+        options.append(.useVerboseOutput)
       }
 
       await runTests(options: options, configuration: configuration)

--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -247,7 +247,7 @@ public enum XCTestScaffold: Sendable {
 #endif
     }
 
-    await runTests(configuration: configuration)
+    await runTests(options: .forStandardError, configuration: configuration)
 #endif
   }
 }

--- a/Sources/Testing/SourceAttribution/Expression.swift
+++ b/Sources/Testing/SourceAttribution/Expression.swift
@@ -182,14 +182,18 @@ public struct Expression: Sendable {
   /// code and runtime value (or values) it represents.
   ///
   /// - Parameters:
+  ///   - includingTypeNames: Whether or not to include type names in output.
   ///   - includingParenthesesIfNeeded: Whether or not to enclose the
   ///     resulting string in parentheses (as needed depending on what
   ///     information this instance contains.)
   ///
   /// - Returns: A string describing this instance.
-  func expandedDescription(includingParenthesesIfNeeded: Bool = true) -> String {
+  func expandedDescription(includingTypeNames: Bool = false, includingParenthesesIfNeeded: Bool = true) -> String {
     switch kind {
-    case let .generic(sourceCode), let .stringLiteral(sourceCode, _):
+    case var .generic(sourceCode), var .stringLiteral(sourceCode, _):
+      if includingTypeNames, let fullyQualifiedTypeNameOfRuntimeValue {
+        sourceCode = "\(sourceCode): \(fullyQualifiedTypeNameOfRuntimeValue)"
+      }
       let runtimeValueDescription = runtimeValueDescription ?? "<not evaluated>"
       return if runtimeValueDescription == "(Function)" {
         // Hack: don't print string representations of function calls.

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -89,6 +89,28 @@ struct EventRecorderTests {
     }
   }
 
+  @Test("Verbose output")
+  func verboseOutput() async throws {
+    let stream = Stream()
+
+    var configuration = Configuration()
+    configuration.deliverExpectationCheckedEvents = true
+    let eventRecorder = Event.ConsoleOutputRecorder(options: [.recordVerboseOutput], writingUsing: stream.write)
+    configuration.eventHandler = { event, context in
+      eventRecorder.record(event, in: context)
+    }
+
+    await runTest(for: WrittenTests.self, configuration: configuration)
+
+    let buffer = stream.buffer.rawValue
+    #expect(buffer.contains(#"\#(Event.Symbol.details.unicodeCharacter) "abc": Swift.String"#))
+    #expect(buffer.contains(#"\#(Event.Symbol.details.unicodeCharacter) lhs: Swift.String → "987""#))
+
+    if testsWithSignificantIOAreEnabled {
+      print(buffer, terminator: "")
+    }
+  }
+
 #if !os(Windows)
   @available(_regexAPI, *)
   @Test(

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -95,7 +95,7 @@ struct EventRecorderTests {
 
     var configuration = Configuration()
     configuration.deliverExpectationCheckedEvents = true
-    let eventRecorder = Event.ConsoleOutputRecorder(options: [.recordVerboseOutput], writingUsing: stream.write)
+    let eventRecorder = Event.ConsoleOutputRecorder(options: [.useVerboseOutput], writingUsing: stream.write)
     configuration.eventHandler = { event, context in
       eventRecorder.record(event, in: context)
     }


### PR DESCRIPTION
This PR adds the ability to detect the `--verbose` flag and alter console output accordingly. When `--verbose` is specified, swift-testing will now emit more version information (when not specified, we'll only log the library version) and will emit a breakdown of subexpressions for failed expectations.

### Without `--verbose`:

<img width="1162" alt="Screenshot 2024-02-06 at 2 37 58 PM" src="https://github.com/apple/swift-testing/assets/4145863/9f2656b0-36c0-4597-9a3d-b465807b07a2">

### With `--verbose`:

<img width="1162" alt="Screenshot 2024-02-06 at 2 37 43 PM" src="https://github.com/apple/swift-testing/assets/4145863/934138fb-e183-4cda-a857-29752864acc0">

Resolves rdar://121382539.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
