### PR TITLE
Add main-branch build icons to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ concurrency, and parameterize test functions across wide ranges of inputs.
 The table below describes the current level of support that `swift-testing` has
 for various platforms:
 
-| **Platform** | **CI Status** | **Support Status** |
-|-|:-:|-|
-| **macOS** | [![Build Status](https://ci.swift.org/buildStatus/icon?job=swift-testing-main-swift-5.10-macos)](https://ci.swift.org/job/swift-testing-main-swift-5.10-macos/) | Supported |
-| **iOS** | | Supported |
-| **watchOS** | | Supported |
-| **tvOS** | | Supported |
-| **Ubuntu 22.04** | [![Build Status](https://ci.swift.org/buildStatus/icon?job=swift-testing-main-swift-5.10-linux)](https://ci.swift.org/job/swift-testing-main-swift-5.10-linux/) | Supported |
-| **Windows** | | Pending support for macros |
+| **Platform** | **CI Status (5.10)** | **CI Status (main)** | **Support Status** |
+|-|:-:|:-:|-|
+| **macOS** | [![Build Status](https://ci.swift.org/buildStatus/icon?job=swift-testing-main-swift-5.10-macos)](https://ci.swift.org/job/swift-testing-main-swift-5.10-macos/) | [![Build Status](https://ci.swift.org/buildStatus/icon?job=swift-testing-main-swift-main-macos)](https://ci.swift.org/view/Swift%20Packages/job/swift-testing-main-swift-main-macos/) | Supported |
+| **iOS** | | | Supported |
+| **watchOS** | | | Supported |
+| **tvOS** | | | Supported |
+| **Ubuntu 22.04** | [![Build Status](https://ci.swift.org/buildStatus/icon?job=swift-testing-main-swift-5.10-linux)](https://ci.swift.org/job/swift-testing-main-swift-5.10-linux/) | [![Build Status](https://ci.swift.org/buildStatus/icon?job=swift-testing-main-swift-main-linux)](https://ci.swift.org/view/Swift%20Packages/job/swift-testing-main-swift-main-linux/) | Supported |
+| **Windows** | | | Supported |
 
 ## Documentation
 


### PR DESCRIPTION
This PR adds a column for main branch Jenkins jobs to our README. I'm keeping the 5.10 jobs here for now (until we drop remaining support, anyway.)

Here's what it looks like:

<img width="590" alt="Screenshot 2024-02-07 at 9 43 50 AM" src="https://github.com/apple/swift-testing/assets/4145863/1c6c6ab1-40b6-4673-b767-729ecc40831b">

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
