### PR TITLE
Fix miscompile when using `is` and `as?` with `any P` in an expectation.

### DIFF
--- a/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
+++ b/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
@@ -172,7 +172,7 @@ private func _parseCondition(from expr: IsExprSyntax, for macro: some Freestandi
     "__checkCast",
     arguments: [
       Argument(expression: expression),
-      Argument(label: .identifier("is"), expression: "\(type.trimmed).self")
+      Argument(label: .identifier("is"), expression: "(\(type.trimmed)).self")
     ],
     expression: createExpressionExprForBinaryOperation(expression, expr.isKeyword, type)
   )
@@ -196,7 +196,7 @@ private func _parseCondition(from expr: AsExprSyntax, for macro: some Freestandi
       "__checkCast",
       arguments: [
         Argument(expression: expression),
-        Argument(label: .identifier("as"), expression: "\(type.trimmed).self")
+        Argument(label: .identifier("as"), expression: "(\(type.trimmed)).self")
       ],
       expression: createExpressionExprForBinaryOperation(expression, TokenSyntax.unknown("as?"), type)
     )

--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -43,7 +43,7 @@ struct ConditionMacroTests {
       ##"#expect(try x())"##:
         ##"Testing.__checkValue(try x(), expression: .__fromSyntaxNode("try x()"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(1 is Int)"##:
-        ##"Testing.__checkCast(1, is: Int.self, expression: .__fromBinaryOperation(.__fromSyntaxNode("1"), "is", .__fromSyntaxNode("Int")), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkCast(1, is: (Int).self, expression: .__fromBinaryOperation(.__fromSyntaxNode("1"), "is", .__fromSyntaxNode("Int")), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect("123") { 1 == 2 } then: { foo() }"##:
         ##"Testing.__checkClosureCall(performing: { 1 == 2 }, then: { foo() }, expression: .__fromBinaryOperation(.__fromSyntaxNode("1"), "==", .__fromSyntaxNode("2")), comments: ["123"], isRequired: false, sourceLocation:Testing.SourceLocation()).__expected()"##,
       ##"#expect("123") { let x = 0 }"##:
@@ -119,7 +119,7 @@ struct ConditionMacroTests {
       ##"#require(try x())"##:
         ##"Testing.__checkValue(try x(), expression: .__fromSyntaxNode("try x()"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(1 is Int)"##:
-        ##"Testing.__checkCast(1, is: Int.self, expression: .__fromBinaryOperation(.__fromSyntaxNode("1"), "is", .__fromSyntaxNode("Int")), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkCast(1, is: (Int).self, expression: .__fromBinaryOperation(.__fromSyntaxNode("1"), "is", .__fromSyntaxNode("Int")), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require("123") { 1 == 2 } then: { foo() }"##:
         ##"Testing.__checkClosureCall(performing: { 1 == 2 }, then: { foo() }, expression: .__fromBinaryOperation(.__fromSyntaxNode("1"), "==", .__fromSyntaxNode("2")), comments: ["123"], isRequired: true, sourceLocation:Testing.SourceLocation()).__required()"##,
       ##"#require("123") { let x = 0 }"##:
@@ -181,7 +181,7 @@ struct ConditionMacroTests {
       ##"#require(123 ?? nil)"##:
         ##"Testing.__checkBinaryOperation(123, { $0 ?? $1() }, nil, expression: .__fromBinaryOperation(.__fromSyntaxNode("123"), "??", .__fromSyntaxNode("nil")), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(123 as? Double)"##:
-        ##"Testing.__checkCast(123,as: Double.self, expression: .__fromBinaryOperation(.__fromSyntaxNode("123"), "as?", .__fromSyntaxNode("Double")), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkCast(123,as: (Double).self, expression: .__fromBinaryOperation(.__fromSyntaxNode("123"), "as?", .__fromSyntaxNode("Double")), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(123 as Double)"##:
         ##"Testing.__checkValue(123 as Double, expression: .__fromSyntaxNode("123 as Double"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(123 as! Double)"##:

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -416,6 +416,14 @@ final class IssueTests: XCTestCase {
     await fulfillment(of: [expectRecorded, requireRecorded], timeout: 0.0)
   }
 
+  func testCastAsAnyProtocol() async {
+    // Sanity check that we parse types cleanly.
+    await Test {
+      #expect((1 as Any) is any Numeric)
+      _ = try #require((1 as Any) as? any Numeric)
+    }.run(configuration: .init())
+  }
+
   func testErrorCheckingWithExpect() async throws {
     let expectationFailed = expectation(description: "Expectation failed")
     expectationFailed.isInverted = true


### PR DESCRIPTION
This PR fixes a miscompile with expectations of the forms:

```swift
#expect(x is any P)
_ = try #require(x as? any P)
```

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
