### PR TITLE
Implement a test iteration feature.

### DIFF
--- a/Sources/Testing/Events/Event.swift
+++ b/Sources/Testing/Events/Event.swift
@@ -28,10 +28,10 @@ public struct Event: Sendable {
     /// This event is posted at the start of each test plan iteration.
     ///
     /// By default, a test plan runs for one iteration, but the
-    /// ``Configuration/iterationPolicy-swift.property`` property can be set to
+    /// ``Configuration/repetitionPolicy-swift.property`` property can be set to
     /// allow for more iterations.
     @_spi(ExperimentalTestRunning)
-    case iterationStarted(_ index: Int)
+    indirect case iterationStarted(_ index: Int)
 
     /// A step in the runner plan started.
     ///
@@ -124,7 +124,7 @@ public struct Event: Sendable {
     /// This event is posted at the end of each test plan iteration.
     ///
     /// By default, a test plan runs for one iteration, but the
-    /// ``Configuration/iterationPolicy-swift.property`` property can be set to
+    /// ``Configuration/repetitionPolicy-swift.property`` property can be set to
     /// allow for more iterations.
     @_spi(ExperimentalTestRunning)
     case iterationEnded(_ index: Int)
@@ -329,7 +329,7 @@ extension Event.Kind {
     /// This event is posted at the start of each test plan iteration.
     ///
     /// By default, a test plan runs for one iteration, but the
-    /// ``Configuration/iterationPolicy-swift.property`` property can be set to
+    /// ``Configuration/repetitionPolicy-swift.property`` property can be set to
     /// allow for more iterations.
     @_spi(ExperimentalTestRunning)
     case iterationStarted(_ index: Int)
@@ -407,10 +407,10 @@ extension Event.Kind {
     /// This event is posted at the end of each test plan iteration.
     ///
     /// By default, a test plan runs for one iteration, but the
-    /// ``Configuration/iterationPolicy-swift.property`` property can be set to
+    /// ``Configuration/repetitionPolicy-swift.property`` property can be set to
     /// allow for more iterations.
     @_spi(ExperimentalTestRunning)
-    case iterationEnded(_ index: Int)
+    indirect case iterationEnded(_ index: Int)
 
     /// A test run ended.
     ///

--- a/Sources/Testing/Events/Event.swift
+++ b/Sources/Testing/Events/Event.swift
@@ -15,16 +15,30 @@ public struct Event: Sendable {
   public enum Kind: Sendable {
     /// A test run started.
     ///
-    /// This is the first event posted after ``Runner/run()`` is called.
+    /// This event is the first event posted after ``Runner/run()`` is called.
     @_spi(ExperimentalTestRunning)
     case runStarted
+
+    /// An iteration of the test run started.
+    ///
+    /// - Parameters:
+    ///   - index: The index of the iteration. The first iteration has an index
+    ///     of `0`.
+    ///
+    /// This event is posted at the start of each test plan iteration.
+    ///
+    /// By default, a test plan runs for one iteration, but the
+    /// ``Configuration/iterationPolicy-swift.property`` property can be set to
+    /// allow for more iterations.
+    @_spi(ExperimentalTestRunning)
+    case iterationStarted(_ index: Int)
 
     /// A step in the runner plan started.
     ///
     /// - Parameters:
     ///   - step: The step in the runner plan which started.
     ///
-    /// This is posted when a ``Runner`` begins processing a
+    /// This event is posted when a ``Runner`` begins processing a
     /// ``Runner/Plan/Step``. Processing this step may result in its associated
     /// ``Test`` being run, skipped, or another action, so this event will only
     /// be followed by a ``testStarted`` event if the step's test is run.
@@ -96,14 +110,28 @@ public struct Event: Sendable {
     /// - Parameters:
     ///   - step: The step in the runner plan which ended.
     ///
-    /// This is posted when a ``Runner`` finishes processing a
+    /// This event is posted when a ``Runner`` finishes processing a
     /// ``Runner/Plan/Step``.
     @_spi(ExperimentalTestRunning)
     indirect case planStepEnded(Runner.Plan.Step)
 
+    /// An iteration of the test run ended.
+    ///
+    /// - Parameters:
+    ///   - index: The index of the iteration. The first iteration has an index
+    ///     of `0`.
+    ///
+    /// This event is posted at the end of each test plan iteration.
+    ///
+    /// By default, a test plan runs for one iteration, but the
+    /// ``Configuration/iterationPolicy-swift.property`` property can be set to
+    /// allow for more iterations.
+    @_spi(ExperimentalTestRunning)
+    case iterationEnded(_ index: Int)
+
     /// A test run ended.
     ///
-    /// This is the last event posted before ``Runner/run()`` returns.
+    /// This event is the last event posted before ``Runner/run()`` returns.
     @_spi(ExperimentalTestRunning)
     case runEnded
   }
@@ -292,6 +320,20 @@ extension Event.Kind {
     @_spi(ExperimentalTestRunning)
     case runStarted
 
+    /// An iteration of the test run started.
+    ///
+    /// - Parameters:
+    ///   - index: The index of the iteration. The first iteration has an index
+    ///     of `0`.
+    ///
+    /// This event is posted at the start of each test plan iteration.
+    ///
+    /// By default, a test plan runs for one iteration, but the
+    /// ``Configuration/iterationPolicy-swift.property`` property can be set to
+    /// allow for more iterations.
+    @_spi(ExperimentalTestRunning)
+    case iterationStarted(_ index: Int)
+
     /// A step in the runner plan started.
     ///
     /// - Parameters:
@@ -356,6 +398,20 @@ extension Event.Kind {
     @_spi(ExperimentalTestRunning)
     case planStepEnded
 
+    /// An iteration of the test run ended.
+    ///
+    /// - Parameters:
+    ///   - index: The index of the iteration. The first iteration has an index
+    ///     of `0`.
+    ///
+    /// This event is posted at the end of each test plan iteration.
+    ///
+    /// By default, a test plan runs for one iteration, but the
+    /// ``Configuration/iterationPolicy-swift.property`` property can be set to
+    /// allow for more iterations.
+    @_spi(ExperimentalTestRunning)
+    case iterationEnded(_ index: Int)
+
     /// A test run ended.
     ///
     /// This is the last event posted before ``Runner/run()`` returns.
@@ -368,6 +424,8 @@ extension Event.Kind {
       switch kind {
       case .runStarted:
         self = .runStarted
+      case let .iterationStarted(index):
+        self = .iterationStarted(index)
       case .planStepStarted:
         self = .planStepStarted
       case .testStarted:
@@ -387,6 +445,8 @@ extension Event.Kind {
         self = .testSkipped(skipInfo)
       case .planStepEnded:
         self = .planStepEnded
+      case let .iterationEnded(index):
+        self = .iterationEnded(index)
       case .runEnded:
         self = .runEnded
       }

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -231,7 +231,7 @@ extension Event.HumanReadableOutputRecorder {
       ) + _formattedComments(comments)
 
     case let .iterationStarted(index):
-      if let iterationCount = Configuration.current?.iterationPolicy.count, iterationCount > 1 {
+      if let iterationCount = Configuration.current?.repetitionPolicy.maximumIterationCount, iterationCount > 1 {
         _context.withLock { context in
           context.iterationStartInstant = instant
         }

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -35,6 +35,9 @@ extension Event {
       /// The instant at which the run started.
       var runStartInstant: Test.Clock.Instant?
 
+      /// The instant at which the current iteration started.
+      var iterationStartInstant: Test.Clock.Instant?
+
       /// The number of tests started or skipped during the run.
       ///
       /// This value does not include test suites.
@@ -227,6 +230,19 @@ extension Event.HumanReadableOutputRecorder {
         )
       ) + _formattedComments(comments)
 
+    case let .iterationStarted(index):
+      if let iterationCount = Configuration.current?.iterationPolicy.count, iterationCount > 1 {
+        _context.withLock { context in
+          context.iterationStartInstant = instant
+        }
+        return [
+          Message(
+            symbol: .default,
+            stringValue: "Iteration \(index + 1) started."
+          )
+        ]
+      }
+
     case .planStepStarted, .planStepEnded:
       // Suppress events of these kinds from output as they are not generally
       // interesting in human-readable output.
@@ -379,6 +395,19 @@ extension Event.HumanReadableOutputRecorder {
 
     case .testCaseEnded:
       break
+
+    case let .iterationEnded(index):
+      guard let iterationStartInstant = _context.rawValue.iterationStartInstant else {
+        break
+      }
+      let duration = iterationStartInstant.descriptionOfDuration(to: instant)
+
+      return [
+        Message(
+          symbol: .default,
+          stringValue: "Iteration \(index + 1) ended after \(duration)."
+        )
+      ]
 
     case .runEnded:
       let context = _context.rawValue

--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -25,7 +25,7 @@ public struct Configuration: Sendable {
   ///
   /// When a ``Runner`` is run, it will run all tests in its corresponding
   /// ``Runner/Plan`` according to the policy described by its
-  /// ``Configuration/iterationPolicy-swift.property`` property. For instance,
+  /// ``Configuration/repetitionPolicy-swift.property`` property. For instance,
   /// if that property is set to:
   ///
   /// ```swift
@@ -36,9 +36,10 @@ public struct Configuration: Sendable {
   /// is recorded, the current iteration will complete, but no further
   /// iterations will be attempted.
   ///
-  /// If the value of an instance's ``count`` property is `1`, the value of its
-  /// ``continuationCondition-swift.property`` property has no effect.
-  public struct IterationPolicy: Sendable {
+  /// If the value of an instance's ``maximumIterationCount`` property is `1`,
+  /// the value of its ``continuationCondition-swift.property`` property has no
+  /// effect.
+  public struct RepetitionPolicy: Sendable {
     /// An enumeration describing the conditions under which test iterations
     /// should continue.
     public enum ContinuationCondition: Sendable {
@@ -66,7 +67,7 @@ public struct Configuration: Sendable {
     ///
     /// - Precondition: The value of this property must be greater than or equal
     ///   to `1`.
-    public var count: Int {
+    public var maximumIterationCount: Int {
       willSet {
         precondition(newValue >= 1, "Test runs must iterate at least once.")
       }
@@ -79,20 +80,20 @@ public struct Configuration: Sendable {
     ///     should continue. If `nil`, the iterations should continue
     ///     unconditionally `count` times.
     ///   - count: The maximum number of times the test run should iterate.
-    public static func repeating(_ continuationCondition: ContinuationCondition? = nil, count: Int) -> Self {
-      Self(continuationCondition: continuationCondition, count: count)
+    public static func repeating(_ continuationCondition: ContinuationCondition? = nil, maximumIterationCount: Int) -> Self {
+      Self(continuationCondition: continuationCondition, maximumIterationCount: maximumIterationCount)
     }
 
     /// An instance of this type representing a single iteration.
     public static var once: Self {
-      repeating(count: 1)
+      repeating(maximumIterationCount: 1)
     }
   }
 
   /// Whether or not, and how, to iterate the test plan repeatedly.
   ///
   /// By default, the value of this property allows for a single iteration.
-  public var iterationPolicy: IterationPolicy = .once
+  public var repetitionPolicy: RepetitionPolicy = .once
 
   // MARK: - Main actor isolation
 

--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -206,6 +206,32 @@ func configurationForSwiftPMEntryPoint(withArguments args: [String]) throws -> C
     }
   }
 
+  // Set up the iteration policy for the test run.
+  var iterationPolicy: Configuration.IterationPolicy = .once
+  var hadExplicitRepetitionCount = false
+  if let repetitionsIndex = args.firstIndex(of: "--repetitions"), repetitionsIndex < args.endIndex,
+     let repetitionCount = Int(args[args.index(after: repetitionsIndex)]), repetitionCount > 0 {
+    iterationPolicy.count = repetitionCount
+    hadExplicitRepetitionCount = true
+  }
+  if let repeatUntilIndex = args.firstIndex(of: "--repeat-until"), repeatUntilIndex < args.endIndex {
+    let repeatUntil = args[args.index(after: repeatUntilIndex)].lowercased()
+    switch repeatUntil {
+    case "pass":
+      iterationPolicy.continuationCondition = .whileIssueRecorded
+    case "fail":
+      iterationPolicy.continuationCondition = .untilIssueRecorded
+    default:
+      throw _EntryPointError.invalidArgument("--repeat-until", value: repeatUntil)
+    }
+    if !hadExplicitRepetitionCount {
+      // The caller wants to repeat until a condition is met, but didn't say how
+      // many times to repeat, so assume they meant "forever".
+      iterationPolicy.count = .max
+    }
+  }
+  configuration.iterationPolicy = iterationPolicy
+
   return configuration
 }
 
@@ -329,6 +355,13 @@ private enum _EntryPointError: Error {
   /// - Parameters:
   ///   - explanation: An explanation of the problem.
   case featureUnavailable(_ explanation: String)
+
+  /// An argument was invalid.
+  ///
+  /// - Parameters:
+  ///   - name: The name of the argument.
+  ///   - value: The invalid value.
+  case invalidArgument(_ name: String, value: String)
 }
 
 extension _EntryPointError: CustomStringConvertible {
@@ -336,6 +369,8 @@ extension _EntryPointError: CustomStringConvertible {
     switch self {
     case let .featureUnavailable(explanation):
       explanation
+    case let .invalidArgument(name, value):
+      #"Invalid value "\#(value)" for argument \#(name)"#
     }
   }
 }

--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -207,30 +207,30 @@ func configurationForSwiftPMEntryPoint(withArguments args: [String]) throws -> C
   }
 
   // Set up the iteration policy for the test run.
-  var iterationPolicy: Configuration.IterationPolicy = .once
+  var repetitionPolicy: Configuration.RepetitionPolicy = .once
   var hadExplicitRepetitionCount = false
   if let repetitionsIndex = args.firstIndex(of: "--repetitions"), repetitionsIndex < args.endIndex,
      let repetitionCount = Int(args[args.index(after: repetitionsIndex)]), repetitionCount > 0 {
-    iterationPolicy.count = repetitionCount
+    repetitionPolicy.maximumIterationCount = repetitionCount
     hadExplicitRepetitionCount = true
   }
   if let repeatUntilIndex = args.firstIndex(of: "--repeat-until"), repeatUntilIndex < args.endIndex {
     let repeatUntil = args[args.index(after: repeatUntilIndex)].lowercased()
     switch repeatUntil {
     case "pass":
-      iterationPolicy.continuationCondition = .whileIssueRecorded
+      repetitionPolicy.continuationCondition = .whileIssueRecorded
     case "fail":
-      iterationPolicy.continuationCondition = .untilIssueRecorded
+      repetitionPolicy.continuationCondition = .untilIssueRecorded
     default:
       throw _EntryPointError.invalidArgument("--repeat-until", value: repeatUntil)
     }
     if !hadExplicitRepetitionCount {
       // The caller wants to repeat until a condition is met, but didn't say how
       // many times to repeat, so assume they meant "forever".
-      iterationPolicy.count = .max
+      repetitionPolicy.maximumIterationCount = .max
     }
   }
-  configuration.iterationPolicy = iterationPolicy
+  configuration.repetitionPolicy = repetitionPolicy
 
   return configuration
 }

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -367,17 +367,55 @@ extension Runner {
     var runner = runner
     runner.configureEventHandlerRuntimeState()
 
+    // Track whether or not any issues were recorded across the entire run.
+    let issueRecorded = Locked(rawValue: false)
+    runner.configuration.eventHandler = { [eventHandler = runner.configuration.eventHandler] event, context in
+      if case let .issueRecorded(issue) = event.kind, !issue.isKnown {
+        issueRecorded.withLock { issueRecorded in
+          issueRecorded = true
+        }
+      }
+      eventHandler(event, context)
+    }
+
     await Configuration.withCurrent(runner.configuration) {
       Event.post(.runStarted, for: nil, testCase: nil, configuration: runner.configuration)
       defer {
         Event.post(.runEnded, for: nil, testCase: nil, configuration: runner.configuration)
       }
 
-      await withTaskGroup(of: Void.self) { [runner] taskGroup in
-        _ = taskGroup.addTaskUnlessCancelled {
-          try? await runner._runStep(atRootOf: runner.plan.stepGraph, depth: 0, lastAncestorStep: nil)
+      let iterationPolicy = runner.configuration.iterationPolicy
+      for iterationIndex in 0 ..< iterationPolicy.count {
+        Event.post(.iterationStarted(iterationIndex), for: nil, testCase: nil, configuration: runner.configuration)
+        defer {
+          Event.post(.iterationEnded(iterationIndex), for: nil, testCase: nil, configuration: runner.configuration)
         }
-        await taskGroup.waitForAll()
+
+        await withTaskGroup(of: Void.self) { [runner] taskGroup in
+          _ = taskGroup.addTaskUnlessCancelled {
+            try? await runner._runStep(atRootOf: runner.plan.stepGraph, depth: 0, lastAncestorStep: nil)
+          }
+          await taskGroup.waitForAll()
+        }
+
+        // Determine if the test plan should iterate again. (The iteration count
+        // is handled by the outer for-loop.)
+        let shouldContinue = switch iterationPolicy.continuationCondition {
+        case nil:
+          true
+        case .untilIssueRecorded:
+          !issueRecorded.rawValue
+        case .whileIssueRecorded:
+          issueRecorded.rawValue
+        }
+        guard shouldContinue else {
+          break
+        }
+
+        // Reset the run-wide "issue was recorded" flag for this iteration.
+        issueRecorded.withLock { issueRecorded in
+          issueRecorded = false
+        }
       }
     }
   }

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -384,8 +384,8 @@ extension Runner {
         Event.post(.runEnded, for: nil, testCase: nil, configuration: runner.configuration)
       }
 
-      let iterationPolicy = runner.configuration.iterationPolicy
-      for iterationIndex in 0 ..< iterationPolicy.count {
+      let repetitionPolicy = runner.configuration.repetitionPolicy
+      for iterationIndex in 0 ..< repetitionPolicy.maximumIterationCount {
         Event.post(.iterationStarted(iterationIndex), for: nil, testCase: nil, configuration: runner.configuration)
         defer {
           Event.post(.iterationEnded(iterationIndex), for: nil, testCase: nil, configuration: runner.configuration)
@@ -400,7 +400,7 @@ extension Runner {
 
         // Determine if the test plan should iterate again. (The iteration count
         // is handled by the outer for-loop.)
-        let shouldContinue = switch iterationPolicy.continuationCondition {
+        let shouldContinue = switch repetitionPolicy.continuationCondition {
         case nil:
           true
         case .untilIssueRecorded:

--- a/Tests/TestingTests/PlanIterationTests.swift
+++ b/Tests/TestingTests/PlanIterationTests.swift
@@ -10,7 +10,7 @@
 
 @testable @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) import Testing
 
-@Suite("Configuration.IterationPolicy Tests")
+@Suite("Configuration.RepetitionPolicy Tests")
 struct PlanIterationTests {
   @Test("One iteration (default behavior)")
   func oneIteration() async {
@@ -24,7 +24,7 @@ struct PlanIterationTests {
             ended()
           }
         }
-        configuration.iterationPolicy = .once
+        configuration.repetitionPolicy = .once
 
         await Test {
         }.run(configuration: configuration)
@@ -45,7 +45,7 @@ struct PlanIterationTests {
             ended()
           }
         }
-        configuration.iterationPolicy = .repeating(count: iterationCount)
+        configuration.repetitionPolicy = .repeating(maximumIterationCount: iterationCount)
 
         await Test {
           if Bool.random() {
@@ -74,7 +74,7 @@ struct PlanIterationTests {
             ended()
           }
         }
-        configuration.iterationPolicy = .repeating(.untilIssueRecorded, count: iterationCount)
+        configuration.repetitionPolicy = .repeating(.untilIssueRecorded, maximumIterationCount: iterationCount)
 
         await Test {
           if iterationIndex.rawValue == iterationWithIssue {
@@ -103,7 +103,7 @@ struct PlanIterationTests {
             ended()
           }
         }
-        configuration.iterationPolicy = .repeating(.whileIssueRecorded, count: iterationCount)
+        configuration.repetitionPolicy = .repeating(.whileIssueRecorded, maximumIterationCount: iterationCount)
 
         await Test {
           if iterationIndex.rawValue < iterationWithoutIssue {

--- a/Tests/TestingTests/PlanIterationTests.swift
+++ b/Tests/TestingTests/PlanIterationTests.swift
@@ -1,0 +1,116 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) import Testing
+
+@Suite("Configuration.IterationPolicy Tests")
+struct PlanIterationTests {
+  @Test("One iteration (default behavior)")
+  func oneIteration() async {
+    await confirmation("N iterations started") { started in
+      await confirmation("N iterations ended") { ended in
+        var configuration = Configuration()
+        configuration.eventHandler = { event, _ in
+          if case .iterationStarted = event.kind {
+            started()
+          } else if case .iterationEnded = event.kind {
+            ended()
+          }
+        }
+        configuration.iterationPolicy = .once
+
+        await Test {
+        }.run(configuration: configuration)
+      }
+    }
+  }
+
+  @Test("Unconditional iteration")
+  func unconditionalIteration() async {
+    let iterationCount = 10
+    await confirmation("N iterations started", expectedCount: iterationCount) { started in
+      await confirmation("N iterations ended", expectedCount: iterationCount) { ended in
+        var configuration = Configuration()
+        configuration.eventHandler = { event, _ in
+          if case .iterationStarted = event.kind {
+            started()
+          } else if case .iterationEnded = event.kind {
+            ended()
+          }
+        }
+        configuration.iterationPolicy = .repeating(count: iterationCount)
+
+        await Test {
+          if Bool.random() {
+            #expect(Bool(false))
+          }
+        }.run(configuration: configuration)
+      }
+    }
+  }
+
+  @Test("Iteration until issue recorded")
+  func iterationUntilIssueRecorded() async {
+    let iterationIndex = Locked(rawValue: 0)
+    let iterationCount = 10
+    let iterationWithIssue = 5
+    await confirmation("N iterations started", expectedCount: iterationWithIssue + 1) { started in
+      await confirmation("N iterations ended", expectedCount: iterationWithIssue + 1) { ended in
+        var configuration = Configuration()
+        configuration.eventHandler = { event, _ in
+          if case let .iterationStarted(index) = event.kind {
+            iterationIndex.withLock { iterationIndex in
+              iterationIndex = index
+            }
+            started()
+          } else if case .iterationEnded = event.kind {
+            ended()
+          }
+        }
+        configuration.iterationPolicy = .repeating(.untilIssueRecorded, count: iterationCount)
+
+        await Test {
+          if iterationIndex.rawValue == iterationWithIssue {
+            #expect(Bool(false))
+          }
+        }.run(configuration: configuration)
+      }
+    }
+  }
+
+  @Test("Iteration while issue recorded")
+  func iterationWhileIssueRecorded() async {
+    let iterationIndex = Locked(rawValue: 0)
+    let iterationCount = 10
+    let iterationWithoutIssue = 5
+    await confirmation("N iterations started", expectedCount: iterationWithoutIssue + 1) { started in
+      await confirmation("N iterations ended", expectedCount: iterationWithoutIssue + 1) { ended in
+        var configuration = Configuration()
+        configuration.eventHandler = { event, _ in
+          if case let .iterationStarted(index) = event.kind {
+            iterationIndex.withLock { iterationIndex in
+              iterationIndex = index
+            }
+            started()
+          } else if case .iterationEnded = event.kind {
+            ended()
+          }
+        }
+        configuration.iterationPolicy = .repeating(.whileIssueRecorded, count: iterationCount)
+
+        await Test {
+          if iterationIndex.rawValue < iterationWithoutIssue {
+            #expect(Bool(false))
+          }
+        }.run(configuration: configuration)
+      }
+    }
+  }
+}

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -130,24 +130,24 @@ struct SwiftPMTests {
   @available(_regexAPI, *)
   func repetitions() throws {
     let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--repetitions", "2468"])
-    #expect(configuration.iterationPolicy.count == 2468)
-    #expect(configuration.iterationPolicy.continuationCondition == nil)
+    #expect(configuration.repetitionPolicy.maximumIterationCount == 2468)
+    #expect(configuration.repetitionPolicy.continuationCondition == nil)
   }
 
   @Test("--repeat-until pass argument (alone)")
   @available(_regexAPI, *)
   func repeatUntilPass() throws {
     let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--repeat-until", "pass"])
-    #expect(configuration.iterationPolicy.count == .max)
-    #expect(configuration.iterationPolicy.continuationCondition == .whileIssueRecorded)
+    #expect(configuration.repetitionPolicy.maximumIterationCount == .max)
+    #expect(configuration.repetitionPolicy.continuationCondition == .whileIssueRecorded)
   }
 
   @Test("--repeat-until fail argument (alone)")
   @available(_regexAPI, *)
   func repeatUntilFail() throws {
     let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--repeat-until", "fail"])
-    #expect(configuration.iterationPolicy.count == .max)
-    #expect(configuration.iterationPolicy.continuationCondition == .untilIssueRecorded)
+    #expect(configuration.repetitionPolicy.maximumIterationCount == .max)
+    #expect(configuration.repetitionPolicy.continuationCondition == .untilIssueRecorded)
   }
 
   @Test("--repeat-until argument with garbage value (alone)")
@@ -162,8 +162,8 @@ struct SwiftPMTests {
   @available(_regexAPI, *)
   func repetitionsAndRepeatUntil() throws {
     let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--repetitions", "2468", "--repeat-until", "pass"])
-    #expect(configuration.iterationPolicy.count == 2468)
-    #expect(configuration.iterationPolicy.continuationCondition == .whileIssueRecorded)
+    #expect(configuration.repetitionPolicy.maximumIterationCount == 2468)
+    #expect(configuration.repetitionPolicy.continuationCondition == .whileIssueRecorded)
   }
 
   @Test("list subcommand")

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -126,6 +126,46 @@ struct SwiftPMTests {
   }
 #endif
 
+  @Test("--repetitions argument (alone)")
+  @available(_regexAPI, *)
+  func repetitions() throws {
+    let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--repetitions", "2468"])
+    #expect(configuration.iterationPolicy.count == 2468)
+    #expect(configuration.iterationPolicy.continuationCondition == nil)
+  }
+
+  @Test("--repeat-until pass argument (alone)")
+  @available(_regexAPI, *)
+  func repeatUntilPass() throws {
+    let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--repeat-until", "pass"])
+    #expect(configuration.iterationPolicy.count == .max)
+    #expect(configuration.iterationPolicy.continuationCondition == .whileIssueRecorded)
+  }
+
+  @Test("--repeat-until fail argument (alone)")
+  @available(_regexAPI, *)
+  func repeatUntilFail() throws {
+    let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--repeat-until", "fail"])
+    #expect(configuration.iterationPolicy.count == .max)
+    #expect(configuration.iterationPolicy.continuationCondition == .untilIssueRecorded)
+  }
+
+  @Test("--repeat-until argument with garbage value (alone)")
+  @available(_regexAPI, *)
+  func repeatUntilGarbage() {
+    #expect(throws: (any Error).self) {
+      _ = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--repeat-until", "qwertyuiop"])
+    }
+  }
+
+  @Test("--repetitions and --repeat-until arguments")
+  @available(_regexAPI, *)
+  func repetitionsAndRepeatUntil() throws {
+    let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--repetitions", "2468", "--repeat-until", "pass"])
+    #expect(configuration.iterationPolicy.count == 2468)
+    #expect(configuration.iterationPolicy.continuationCondition == .whileIssueRecorded)
+  }
+
   @Test("list subcommand")
   func list() async throws {
     let testIDs = await listTestsForSwiftPM(Test.all)


### PR DESCRIPTION
This PR introduces a test iteration feature similar to the one supported by XCTest. Developers setting up an instance of `Configuration` can specify how many times to repeat a test plan during a test run as well as under what conditions iteration should continue or stop.

A new property, `iterationPolicy`, is added to `Configuration`, with two properties of its own as described above and a couple of convenience factory methods. When a `Runner` is run, its configuration's iteration policy is consulted and the entire test run is repeated as needed. New event kinds have been added for iteration start and end.

SwiftPM integration to come in a later PR in that repository.

Resolves rdar://88665403.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
