### PR TITLE
Reduce the package manifest's tools version requirement to 5.9.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 5.9
 
 //
 // This source file is part of the Swift.org open source project


### PR DESCRIPTION
This PR changes Package.swift such that it requires the Swift 5.9 version of Swift Package Manager (_et al._) As of right now, Swift Package Index does not support Swift 5.10 or newer, so we need to wait until they do before we can bump the requirement to 5.10 (otherwise SPI won't be able to index swift-testing.)

Resolves #212.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
