### PR TITLE
Change `var` to `let` to suppress a warning.

### DIFF
--- a/Sources/Testing/SourceAttribution/Expression.swift
+++ b/Sources/Testing/SourceAttribution/Expression.swift
@@ -210,7 +210,7 @@ public struct Expression: Sendable {
   func expandedDescription(depth: Int = 0, includingTypeNames: Bool = false, includingParenthesesIfNeeded: Bool = true) -> String {
     var result = ""
     switch kind {
-    case var .generic(sourceCode), var .stringLiteral(sourceCode, _):
+    case let .generic(sourceCode), let .stringLiteral(sourceCode, _):
       result = if includingTypeNames, let fullyQualifiedTypeNameOfRuntimeValue {
         "\(sourceCode): \(fullyQualifiedTypeNameOfRuntimeValue)"
       } else {


### PR DESCRIPTION
This line needs a tweak:

```swift
case var .generic(sourceCode), var .stringLiteral(sourceCode, _):
```

We are no longer mutating `sourceCode` in this case statement, so the variables can be constant (`let`.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
