### PR TITLE
Work around an issue in the toolchain calling `Result.get()`.

### DIFF
--- a/Sources/Testing/Support/Additions/ResultAdditions.swift
+++ b/Sources/Testing/Support/Additions/ResultAdditions.swift
@@ -20,6 +20,13 @@ extension Result {
   /// - Warning: This function is used to implement the `#expect()` and
   ///   `#require()` macros. Do not call it directly.
   public func __required() throws -> Success {
-    try get()
+    /// `get()` is current broken in the Swift standard library, so switch
+    /// manually to work around the problem. ([122797397](rdar://122797397))
+    switch self {
+    case let .success(result):
+      return result
+    case let .failure(error):
+      throw error
+    }
   }
 }

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -1153,7 +1153,6 @@ final class IssueTests: XCTestCase {
       if case let .expectationFailed(expectation) = issue.kind {
         expectationFailed.fulfill()
         let desc = expectation.evaluatedExpression.expandedDescription()
-        print(desc)
         XCTAssertTrue(desc.contains("nil"))
       }
     }


### PR DESCRIPTION
There's currently a miscompile of some sort calling `Result.get()` using a main-branch toolchain. (I'm guessing it's related to SE-0413 adoption, but that's speculation only.) ([122797397](rdar://122797397))

This change works around the issue by switching over `Result` instead of calling `get()` in the one spot where we do so.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
