### PR TITLE
Add a `.serial` trait that forces a test to run its content serially.

### DIFF
--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -413,6 +413,9 @@ extension Runner.Plan.Action {
   @_spi(ExperimentalSnapshotting)
   public enum Snapshot: Sendable, Codable {
     /// The test should be run.
+    ///
+    /// - Parameters:
+    ///   - options: Options to apply to this action when it is run.
     case run(options: RunOptions)
 
     /// The test should be skipped.

--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -14,8 +14,29 @@ extension Runner {
   public struct Plan: Sendable {
     /// The action to perform for a test in this plan.
     public enum Action: Sendable {
+      /// A type describing options to apply to actions of case
+      /// ``Runner/Plan/Action/run(options:)`` when they are run.
+      public struct RunOptions: Sendable, Codable {
+        /// Whether or not this step should be run in parallel with other tests.
+        ///
+        /// By default, all steps in a runner plan are run in parallel if the
+        /// ``Configuration/isParallelizationEnabled`` property of the
+        /// configuration passed during initialization has a value of `true`.
+        ///
+        /// Traits such as ``Trait/serial`` applied to individual tests may
+        /// affect whether or not that test is parallelized.
+        ///
+        /// ## See Also
+        ///
+        /// - ``SerialTrait``
+        public var isParallelizationEnabled: Bool
+      }
+
       /// The test should be run.
-      case run
+      ///
+      /// - Parameters:
+      ///   - options: Options to apply to this action when it is run.
+      case run(options: RunOptions)
 
       /// The test should be skipped.
       ///
@@ -44,6 +65,19 @@ extension Runner {
           // case.
           return true
         }
+      }
+
+      /// Whether or not this action enables parallelization.
+      ///
+      /// If this action is of case ``run(options:)``, the value of this
+      /// property equals the value of its associated
+      /// ``RunOptions/isParallelizationEnabled`` property. Otherwise, the value
+      /// of this property is `nil`.
+      var isParallelizationEnabled: Bool? {
+        if case let .run(options) = self {
+          return options.isParallelizationEnabled
+        }
+        return nil
       }
     }
 
@@ -140,12 +174,13 @@ extension Runner.Plan {
     // Convert the list of test into a graph of steps. The actions for these
     // steps will all be .run() *unless* an error was thrown while examining
     // them, in which case it will be .recordIssue().
+    let runAction = Action.run(options: .init(isParallelizationEnabled: configuration.isParallelizationEnabled))
     var testGraph = Graph<String, Test?>()
-    var actionGraph = Graph<String, Action>(value: .run)
+    var actionGraph = Graph<String, Action>(value: runAction)
     for test in tests {
       let idComponents = test.id.keyPathRepresentation
       testGraph.insertValue(test, at: idComponents)
-      actionGraph.insertValue(.run, at: idComponents, intermediateValue: .run)
+      actionGraph.insertValue(runAction, at: idComponents, intermediateValue: runAction)
     }
 
     // Ensure the trait lists are complete for all nested tests. (Make sure to
@@ -171,7 +206,7 @@ extension Runner.Plan {
         return
       }
 
-      var action = Action.run
+      var action = runAction
       var firstCaughtError: (any Error)?
 
       // Walk all the traits and tell each to prepare to run the test.
@@ -181,7 +216,11 @@ extension Runner.Plan {
       // `SkipInfo`, the error should not be recorded.
       for trait in test.traits {
         do {
-          try await trait.prepare(for: test)
+          if let trait = trait as? any SPIAwareTrait {
+            try await trait.prepare(for: test, action: &action)
+          } else {
+            try await trait.prepare(for: test)
+          }
         } catch let error as SkipInfo {
           action = .skip(error)
           break
@@ -374,7 +413,7 @@ extension Runner.Plan.Action {
   @_spi(ExperimentalSnapshotting)
   public enum Snapshot: Sendable, Codable {
     /// The test should be run.
-    case run
+    case run(options: RunOptions)
 
     /// The test should be skipped.
     ///
@@ -397,8 +436,8 @@ extension Runner.Plan.Action {
     ///   - action: The original action to snapshot.
     init(snapshotting action: Runner.Plan.Action) {
       self = switch action {
-      case .run:
-        .run
+      case let .run(options):
+        .run(options: options)
       case let .skip(skipInfo):
         .skip(skipInfo)
       case let .recordIssue(issue):

--- a/Sources/Testing/Testing.docc/OrganizingTests.md
+++ b/Sources/Testing/Testing.docc/OrganizingTests.md
@@ -36,6 +36,9 @@ might contain, test suite types can also contain additional test suites nested
 within them. To add a nested test suite type, simply declare an additional type
 within the scope of the outer test suite type.
 
+By default, tests contained within a suite will run in parallel with each other.
+For more information about test parallelization, see <doc:Parallelization>.
+
 ## Customizing a suite's name
 
 To customize a test suite's name, supply a string literal as an argument to the

--- a/Sources/Testing/Testing.docc/Parallelization.md
+++ b/Sources/Testing/Testing.docc/Parallelization.md
@@ -35,6 +35,11 @@ Parallelization can be disabled on a per-function or per-suite basis using the
     // This function will be invoked serially, once per condiment, because the
     // containing suite has the .serial trait.
   }
+
+  @Test func startEngine() async throws {
+    // This function will not run while refill(condiment:) is running. One test
+    // must end before the other will start.
+  }
 }
 ```
 

--- a/Sources/Testing/Testing.docc/Parallelization.md
+++ b/Sources/Testing/Testing.docc/Parallelization.md
@@ -19,6 +19,9 @@ accomplished by the testing library using task groups, and tests generally all
 run in the same process. The number of tests that run concurrently is controlled
 by the Swift runtime.
 
+<!--
+HIDDEN: .serial is experimental SPI pending feature review.
+
 ## Disabling parallelization
 
 Parallelization can be disabled on a per-function or per-suite basis using the
@@ -61,6 +64,7 @@ disabled (by, for example, passing `--no-parallel` to the `swift test` command.)
 
 - ``Trait/serial``
 - ``SerialTrait``
+-->
 
 ## See Also
 

--- a/Sources/Testing/Testing.docc/Parallelization.md
+++ b/Sources/Testing/Testing.docc/Parallelization.md
@@ -1,0 +1,63 @@
+# Parallelizing test execution
+
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2023 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+Control whether tests run serially or in parallel.
+
+## Overview
+
+By default, tests run in parallel with respect to each other. Parallelization is
+accomplished by the testing library using task groups, and tests generally all
+run in the same process. The number of tests that run concurrently is controlled
+by the Swift runtime.
+
+## Disabling parallelization
+
+Parallelization can be disabled on a per-function or per-suite basis using the
+``Trait/serial`` trait:
+
+```swift
+@Test(.serial, arguments: Food.allCases) func prepare(food: Food) {
+  // This function will be invoked serially, once per food, because it has the
+  // .serial trait.
+}
+
+@Suite(.serial) {
+  @Test(arguments: Condiment.allCases) func refill(condiment: Condiment) {
+    // This function will be invoked serially, once per condiment, because the
+    // containing suite has the .serial trait.
+  }
+}
+```
+
+When added to a parameterized test function, this trait causes that test to run
+its cases serially instead of in parallel. When applied to a non-parameterized
+test function, this trait has no effect. When applied to a test suite, this
+trait causes that suite to run its contained test functions and sub-suites
+serially instead of in parallel.
+
+This trait is recursively applied: if it is applied to a suite, any
+parameterized tests or test suites contained in that suite are also serialized
+(as are any tests contained in those suites, and so on.)
+
+This trait does not affect the execution of a test relative to its peers or to
+unrelated tests. This trait has no effect if test parallelization is globally
+disabled (by, for example, passing `--no-parallel` to the `swift test` command.)
+
+## Topics
+
+- ``Trait/serial``
+- ``SerialTrait``
+
+## See Also
+
+- <doc:OrganizingTests>
+- <doc:ParameterizedTesting>

--- a/Sources/Testing/Testing.docc/Parallelization.md
+++ b/Sources/Testing/Testing.docc/Parallelization.md
@@ -30,7 +30,7 @@ Parallelization can be disabled on a per-function or per-suite basis using the
   // .serial trait.
 }
 
-@Suite(.serial) {
+@Suite(.serial) struct FoodTruckTests {
   @Test(arguments: Condiment.allCases) func refill(condiment: Condiment) {
     // This function will be invoked serially, once per condiment, because the
     // containing suite has the .serial trait.

--- a/Sources/Testing/Testing.docc/Parallelization.md
+++ b/Sources/Testing/Testing.docc/Parallelization.md
@@ -3,7 +3,7 @@
 <!--
 This source file is part of the Swift.org open source project
 
-Copyright (c) 2023 Apple Inc. and the Swift project authors
+Copyright (c) 2024 Apple Inc. and the Swift project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information

--- a/Sources/Testing/Testing.docc/ParameterizedTesting.md
+++ b/Sources/Testing/Testing.docc/ParameterizedTesting.md
@@ -17,7 +17,13 @@ Run the same test multiple times with different inputs.
 Some tests need to be run over many different inputs. For instance, a test might
 need to validate all cases of an enumeration. The testing library lets
 developers specify one or more collections to iterate over during testing, with
-the elements of those collections being forwarded to a test function.
+the elements of those collections being forwarded to a test function. An
+invocation of a test function with a particular set of argument values is called
+a test _case_.
+
+By default, the test cases of a test function will run in parallel with each
+other. For more information about test parallelization, see
+<doc:Parallelization>.
 
 ## Parameterizing over an array of values
 

--- a/Sources/Testing/Testing.docc/Traits.md
+++ b/Sources/Testing/Testing.docc/Traits.md
@@ -28,6 +28,7 @@ types that customize the behavior of test functions and test suites.
 - <doc:AddingComments>
 - <doc:AssociatingBugs>
 - <doc:LimitingExecutionTime>
+- <doc:Parallelization>
 
 ### Creating a custom trait
 

--- a/Sources/Testing/Traits/SPIAwareTrait.swift
+++ b/Sources/Testing/Traits/SPIAwareTrait.swift
@@ -1,0 +1,38 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+/// A protocol describing traits that can be added to a test function or to a
+/// test suite and that make use of SPI symbols in the testing library.
+///
+/// This protocol refines ``Trait`` in various ways that require the use of SPI.
+/// Ideally, such requirements will be promoted to API when their design
+/// stabilizes.
+@_spi(ExperimentalTestRunning)
+public protocol SPIAwareTrait: Trait {
+  /// Prepare to run the test to which this trait was added.
+  ///
+  /// - Parameters:
+  ///   - test: The test to which this trait was added.
+  ///   - action: The test plan action to use with `test`. The implementation
+  ///     may modify this value.
+  ///
+  /// - Throws: Any error that would prevent the test from running. If an error
+  ///   is thrown from this method, the test will be skipped and the error will
+  ///   be recorded as an ``Issue``.
+  ///
+  /// This method is called after all tests and their traits have been
+  /// discovered by the testing library, but before any test has begun running.
+  /// It may be used to prepare necessary internal state, or to influence
+  /// whether the test should run.
+  ///
+  /// For types that conform to this protocol, ``Runner/Plan`` calls this method
+  /// instead of ``Trait/prepare(for:)``.
+  func prepare(for test: Test, action: inout Runner.Plan.Action) async throws
+}

--- a/Sources/Testing/Traits/SerialTrait.swift
+++ b/Sources/Testing/Traits/SerialTrait.swift
@@ -26,6 +26,7 @@
 /// `swift test` command.)
 ///
 /// To add this trait to a test, use ``Trait/serial``.
+@_spi(Experimental)
 public struct SerialTrait: TestTrait, SuiteTrait {
   public var isRecursive: Bool {
     true
@@ -46,6 +47,7 @@ extension SerialTrait: SPIAwareTrait {
 
 // MARK: -
 
+@_spi(Experimental)
 extension Trait where Self == SerialTrait {
   /// A trait that serializes the test to which it is applied.
   ///

--- a/Sources/Testing/Traits/SerialTrait.swift
+++ b/Sources/Testing/Traits/SerialTrait.swift
@@ -1,0 +1,58 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+/// A type that affects whether or not a test or suite is parallelized.
+///
+/// When added to a parameterized test function, this trait causes that test to
+/// run its cases serially instead of in parallel. When applied to a
+/// non-parameterized test function, this trait has no effect. When applied to a
+/// test suite, this trait causes that suite to run its contained test functions
+/// and sub-suites serially instead of in parallel.
+///
+/// This trait is recursively applied: if it is applied to a suite, any
+/// parameterized tests or test suites contained in that suite are also
+/// serialized (as are any tests contained in those suites, and so on.)
+///
+/// This trait does not affect the execution of a test relative to its peers or
+/// to unrelated tests. This trait has no effect if test parallelization is
+/// globally disabled (by, for example, passing `--no-parallel` to the
+/// `swift test` command.)
+///
+/// To add this trait to a test, use ``Trait/serial``.
+public struct SerialTrait: TestTrait, SuiteTrait {
+  public var isRecursive: Bool {
+    true
+  }
+}
+
+// MARK: - SPIAwareTrait
+
+@_spi(ExperimentalTestRunning)
+extension SerialTrait: SPIAwareTrait {
+  public func prepare(for test: Test, action: inout Runner.Plan.Action) async throws {
+    if case var .run(options) = action {
+      options.isParallelizationEnabled = false
+      action = .run(options: options)
+    }
+  }
+}
+
+// MARK: -
+
+extension Trait where Self == SerialTrait {
+  /// A trait that serializes the test to which it is applied.
+  ///
+  /// ## See Also
+  ///
+  /// - ``SerialTrait``
+  public static var serial: Self {
+    Self()
+  }
+}

--- a/Tests/TestingTests/Support/EnvironmentTests.swift
+++ b/Tests/TestingTests/Support/EnvironmentTests.swift
@@ -11,9 +11,9 @@
 @testable import Testing
 private import TestingInternals
 
-@Suite("Environment Tests")
+@Suite("Environment Tests", .serial)
 struct EnvironmentTests {
-  var name = "SWT_ENVIRONMENT_VARIABLE_\(UInt64.random(in: 0 ... .max))"
+  var name = "SWT_ENVIRONMENT_VARIABLE_FOR_TESTING"
 
   @Test("Read environment variable")
   func readEnvironmentVariable() throws {

--- a/Tests/TestingTests/Support/EnvironmentTests.swift
+++ b/Tests/TestingTests/Support/EnvironmentTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable import Testing
+@testable @_spi(Experimental) import Testing
 private import TestingInternals
 
 @Suite("Environment Tests", .serial)

--- a/Tests/TestingTests/Traits/SerialTraitTests.swift
+++ b/Tests/TestingTests/Traits/SerialTraitTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) import Testing
+@testable @_spi(Experimental) @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) import Testing
 
 @Suite("Serial Trait Tests", .tags("trait"))
 struct SerialTraitTests {

--- a/Tests/TestingTests/Traits/SerialTraitTests.swift
+++ b/Tests/TestingTests/Traits/SerialTraitTests.swift
@@ -1,0 +1,71 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) import Testing
+
+@Suite("Serial Trait Tests", .tags("trait"))
+struct SerialTraitTests {
+  @Test(".serial trait is recursively applied")
+  func serialTrait() async {
+    var configuration = Configuration()
+    configuration.isParallelizationEnabled = true
+    let plan = await Runner.Plan(selecting: OuterSuite.self, configuration: configuration)
+    for step in plan.steps {
+      #expect(step.action.isParallelizationEnabled == false, "Step \(step) should have had parallelization disabled")
+    }
+  }
+
+  @Test(".serial trait serializes parameterized test")
+  func serializesParameterizedTestFunction() async {
+    var configuration = Configuration()
+    configuration.isParallelizationEnabled = true
+
+    let indicesRecorded = Locked<[Int]>(rawValue: [])
+    configuration.eventHandler = { event, _ in
+      if case let .issueRecorded(issue) = event.kind,
+         let comment = issue.comments.first,
+         comment.rawValue.hasPrefix("PARAMETERIZED") {
+        // Silly hack: only letters before the index, so just scrape off all
+        // leading letters and what's left will be the index as a string. No
+        // need for sscanf() or similar.
+        if let index = Int(String(comment.rawValue.drop(while: \.isLetter))) {
+          indicesRecorded.withLock { indicesRecorded in
+            indicesRecorded.append(index)
+          }
+        }
+      }
+    }
+
+    let plan = await Runner.Plan(selecting: OuterSuite.self, configuration: configuration)
+    let runner = Runner(plan: plan, configuration: configuration)
+    await runner.run()
+
+    let indicesRecordedValue = indicesRecorded.rawValue
+    #expect(indicesRecordedValue.count == 10_000)
+    let isSorted = indicesRecordedValue == indicesRecordedValue.sorted()
+    #expect(isSorted)
+  }
+}
+
+// MARK: - Fixtures
+
+@Suite(.hidden, .serial)
+private struct OuterSuite {
+  /* This @Suite intentionally left blank */ struct IntermediateSuite {
+    @Suite(.hidden)
+    struct InnerSuite {
+      @Test(.hidden) func example() {}
+
+      @Test(.hidden, arguments: 0 ..< 10_000) func parameterized(i: Int) async throws {
+        Issue.record("PARAMETERIZED\(i)")
+      }
+    }
+  }
+}


### PR DESCRIPTION
As of right now, when parallelization is enabled (the default for `swift test`, opt-in for `XCTestScaffold`), all tests scramble to run at the same time. This is generally overall a good thing for performance, because the total time spent running tests is measurably lower than if they ran serially.

However, some tests, such as those that touch shared global state, really need to run serially. This PR introduces a new trait, `.serial` AKA `SerialTrait`, that allows those tests to opt out of parallelization. Note that this is not a global effect: the tests may run in parallel with other unrelated tests, but their test cases will run serially relative to each other, and in the case of suites any contained tests will run serially (and the effect is recursive, so a parameterized test function contained in a suite that is contained in a serialized suite will run its cases serially.)

To avoid teaching the runner about another specialized trait, I wanted to modify the existing `Trait.prepare(for:)` function to take an `inout` `Runner.Plan.Action` value that a trait could then modify. However, `Runner.Plan.Action`'s design is not ready to become API, so instead I have introduced a new protocol `SPIAwareTrait` that refines `Trait` and adds the appropriate requirement.

This change means that `Runner.Plan.Action.run` now has an associated value, because whether or not a test runs parallelized is necessarily part of the step for that test. I've made the associated value an options-y structure so that we can extend it later.

> [!NOTE]
> It's very hard to write unit tests that validate that `.serial` does what it's designed to do; I'm open to writing additional tests if we can think up some that can be implemented in a reliable way.

Resolves rdar://95629402.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
