### PR TITLE
Support re-running parameterized tests with RawRepresentable arguments automatically

### DIFF
--- a/Sources/Testing/Parameterization/CustomTestArgumentEncodable.swift
+++ b/Sources/Testing/Parameterization/CustomTestArgumentEncodable.swift
@@ -15,24 +15,9 @@ private import Foundation
 /// A protocol for customizing how arguments passed to parameterized tests are
 /// encoded, which is used to match against when running specific arguments.
 ///
-/// By default, the testing library checks whether a test argument conforms to
-/// `Encodable` and encodes it using `encode(to:)` if it does. `Encodable` is
-/// sufficient for many types, but for some types the output of that function
-/// may contain large data payloads that cause poor performance, may not be
-/// stable and unique, or may otherwise be deemed unsuitable for testing.
+/// ## See Also
 ///
-/// If the type of the argument does not conform to `Encodable` but it does
-/// conform to `Identifiable` and its associated `ID` type conforms to
-/// `Encodable`, the value of its `id` property is encoded with `encode(to:)`
-/// and is used as the encoded representation.
-///
-/// If neither of the approaches for encoded representation described above is
-/// sufficient, a type can be made to conform to
-/// ``CustomTestArgumentEncodable``. The testing library will then call
-/// ``encodeTestArgument(to:)`` on values of that type instead of `encode(to:)`.
-///
-/// A type that conforms to this protocol is not required to conform to either
-/// `Encodable` or `Decodable`.
+/// - <doc:ParameterizedTesting>
 public protocol CustomTestArgumentEncodable: Sendable {
   /// Encode this test argument.
   ///
@@ -78,6 +63,8 @@ extension Test.Case.Argument.ID {
 
     let encodableValue: (any Encodable)? = if let customEncodable = value as? any CustomTestArgumentEncodable {
       customArgumentWrapper(for: customEncodable)
+    } else if let rawRepresentable = value as? any RawRepresentable, let encodableRawValue = rawRepresentable.rawValue as? any Encodable {
+      encodableRawValue
     } else if let encodable = value as? any Encodable {
       encodable
     } else if let identifiable = value as? any Identifiable, let encodableID = identifiable.id as? any Encodable {

--- a/Sources/Testing/Parameterization/CustomTestArgumentEncodable.swift
+++ b/Sources/Testing/Parameterization/CustomTestArgumentEncodable.swift
@@ -15,6 +15,16 @@ private import Foundation
 /// A protocol for customizing how arguments passed to parameterized tests are
 /// encoded, which is used to match against when running specific arguments.
 ///
+/// The testing library checks whether a test argument conforms to this
+/// protocol, or any of several other known protocols, when running selected
+/// test cases. When a test argument conforms to this protocol, that conformance
+/// takes highest priority, and the testing library will then call
+/// ``encodeTestArgument(to:)`` on the argument. A type that conforms to this
+/// protocol is not required to conform to either `Encodable` or `Decodable`.
+///
+/// See <doc:ParameterizedTesting> for a list of the other supported ways to
+/// allow running selected test cases.
+///
 /// ## See Also
 ///
 /// - <doc:ParameterizedTesting>

--- a/Sources/Testing/Testing.docc/ParameterizedTesting.md
+++ b/Sources/Testing/Testing.docc/ParameterizedTesting.md
@@ -137,6 +137,29 @@ words, this test function will be passed the inputs `(.burger, 1)`,
 `(.iceCream, 2)`, ..., `(.kebab, 5)` instead of `(.burger, 1)`, `(.burger, 2)`,
 `(.burger, 3)`, ... `(.kebab, 99)`, `(.kebab, 100)`.
 
+## Running selected test cases
+
+If a parameterized test meets certain requirements, the testing library allows
+users to run specific test cases it contains. This can be useful when a test
+has many cases but only some are failing since it enables re-running and
+debugging the failing cases in isolation.
+
+To support running selected test cases, it must be possible to deterministically
+match the test case's arguments. When a user attempts to run selected test cases
+of a parameterized test function, the testing library evaluates each argument of
+the tests' cases for conformance to one of several known protocols, and if all
+arguments of a test case conform to one of those protocols, that test case can
+be run selectively. The following lists the known protocols, in precedence order
+(highest to lowest):
+
+1. ``CustomTestArgumentEncodable``.
+1. `RawRepresentable`, where `RawValue` conforms to `Encodable`.
+1. `Encodable`.
+1. `Identifiable`, where `ID` conforms to `Encodable`.
+
+If any argument of a test case does not meet one of the above requirements, then
+the overall test case cannot be run selectively.
+
 ## Topics
 
 - ``Test(_:_:arguments:)-8kn7a``

--- a/Tests/TestingTests/Test.Case.Argument.IDTests.swift
+++ b/Tests/TestingTests/Test.Case.Argument.IDTests.swift
@@ -59,6 +59,20 @@ struct Test_Case_Argument_IDTests {
     let argumentID = try #require(argument.id)
     #expect(String(bytes: argumentID.bytes, encoding: .utf8) == #""abc""#)
   }
+
+  @Test("One RawRepresentable parameter")
+  func oneRawRepresentableParameter() async throws {
+    let test = Test(
+      arguments: [MyRawRepresentableArgument(rawValue: "abc")],
+      parameters: [Test.Parameter(index: 0, firstName: "value")]
+    ) { _ in }
+    let testCases = try #require(test.testCases)
+    let testCase = try #require(testCases.first { _ in true })
+    #expect(testCase.arguments.count == 1)
+    let argument = try #require(testCase.arguments.first)
+    let argumentID = try #require(argument.id)
+    #expect(String(bytes: argumentID.bytes, encoding: .utf8) == #""abc""#)
+  }
 }
 
 // MARK: - Fixture parameter types
@@ -85,4 +99,8 @@ extension MyCustomTestArgument: Encodable {}
 
 private struct MyIdentifiableArgument: Identifiable {
   var id: String
+}
+
+private struct MyRawRepresentableArgument: RawRepresentable {
+  var rawValue: String
 }


### PR DESCRIPTION
This augments our heuristics for determining whether an argument to a parameterized test can be re-run, by allowing `RawRepresentable`-conforming types whose associated `RawValue` type is `Encodable`.

### Motivation:

A specific, common use case of this is to allow enum types imported from C or Objective-C to automatically be able to be re-run, which will work with these changes because such types are imported as `RawRepresentable`-conforming types with a numeric `RawValue` type.

### Modifications:

- Look for `RawRepresentable` types w/encodable `RawValue` in `Test.Case.Argument.ID.init(identifying:parameter:)`.
- Add a new section to the Parameterized Testing article detailing the known protocols and their precedence.
- Add some unit tests.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Resolves rdar://122321338
