### PR TITLE
Reduce the sizes of `Event.Kind`, `Issue.Kind`, and `Runner.Plan.Action`.

### DIFF
--- a/Sources/Testing/Events/Event.swift
+++ b/Sources/Testing/Events/Event.swift
@@ -329,13 +329,13 @@ extension Event.Kind {
     /// To enable events of this kind, set
     /// ``Configuration/deliverExpectationCheckedEvents`` to `true` before
     /// running tests.
-    case expectationChecked(_ expectation: Expectation.Snapshot)
+    indirect case expectationChecked(_ expectation: Expectation.Snapshot)
 
     /// An issue was recorded.
     ///
     /// - Parameters:
     ///   - issue: The issue which was recorded.
-    case issueRecorded(_ issue: Issue.Snapshot)
+    indirect case issueRecorded(_ issue: Issue.Snapshot)
 
     /// A test ended.
     case testEnded
@@ -344,7 +344,7 @@ extension Event.Kind {
     ///
     /// - Parameters:
     ///   - skipInfo: A ``SkipInfo`` containing details about this skipped test.
-    case testSkipped(_ skipInfo: SkipInfo)
+    indirect case testSkipped(_ skipInfo: SkipInfo)
 
     /// A step in the runner plan ended.
     ///

--- a/Sources/Testing/Events/Event.swift
+++ b/Sources/Testing/Events/Event.swift
@@ -29,7 +29,7 @@ public struct Event: Sendable {
     /// ``Test`` being run, skipped, or another action, so this event will only
     /// be followed by a ``testStarted`` event if the step's test is run.
     @_spi(ExperimentalTestRunning)
-    case planStepStarted(_ step: Runner.Plan.Step)
+    indirect case planStepStarted(_ step: Runner.Plan.Step)
 
     /// A test started.
     ///
@@ -66,13 +66,13 @@ public struct Event: Sendable {
     /// To enable events of this kind, set
     /// ``Configuration/deliverExpectationCheckedEvents`` to `true` before
     /// running tests.
-    case expectationChecked(_ expectation: Expectation)
+    indirect case expectationChecked(_ expectation: Expectation)
 
     /// An issue was recorded.
     ///
     /// - Parameters:
     ///   - issue: The issue which was recorded.
-    case issueRecorded(_ issue: Issue)
+    indirect case issueRecorded(_ issue: Issue)
 
     /// A test ended.
     ///
@@ -89,7 +89,7 @@ public struct Event: Sendable {
     /// The test that was skipped is contained in the ``Event/Context`` instance
     /// that was passed to the event handler along with this event. Its ID is
     /// available from this event's ``Event/testID`` property.
-    case testSkipped(_ skipInfo: SkipInfo)
+    indirect case testSkipped(_ skipInfo: SkipInfo)
 
     /// A step in the runner plan ended.
     ///
@@ -99,7 +99,7 @@ public struct Event: Sendable {
     /// This is posted when a ``Runner`` finishes processing a
     /// ``Runner/Plan/Step``.
     @_spi(ExperimentalTestRunning)
-    case planStepEnded(Runner.Plan.Step)
+    indirect case planStepEnded(Runner.Plan.Step)
 
     /// A test run ended.
     ///

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -21,7 +21,7 @@ public struct Issue: Sendable {
     ///
     /// - Parameters:
     ///   - expectation: The expectation that failed.
-    case expectationFailed(_ expectation: Expectation)
+    indirect case expectationFailed(_ expectation: Expectation)
 
     /// An issue due to a confirmation being confirmed the wrong number of
     /// times.
@@ -36,14 +36,14 @@ public struct Issue: Sendable {
     /// ``confirmation(_:expectedCount:fileID:filePath:line:column:_:)`` when
     /// the confirmation passed to these functions' `body` closures is confirmed
     /// too few or too many times.
-    case confirmationMiscounted(actual: Int, expected: Int)
+    indirect case confirmationMiscounted(actual: Int, expected: Int)
 
     /// An issue due to an `Error` being thrown by a test function and caught by
     /// the testing library.
     ///
     /// - Parameters:
     ///   - error: The error which was associated with this issue.
-    case errorCaught(_ error: any Error)
+    indirect case errorCaught(_ error: any Error)
 
     /// An issue due to a test reaching its time limit and timing out.
     ///
@@ -55,7 +55,7 @@ public struct Issue: Sendable {
     ///     instance of `Duration`, but the testing library's deployment target
     ///     predates the introduction of that type.
     /// }
-    case timeLimitExceeded(timeLimitComponents: (seconds: Int64, attoseconds: Int64))
+    indirect case timeLimitExceeded(timeLimitComponents: (seconds: Int64, attoseconds: Int64))
 
     /// A known issue was expected, but was not recorded.
     case knownIssueNotRecorded

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -222,7 +222,7 @@ extension Issue.Kind {
     ///
     /// - Parameters:
     ///   - expectation: The expectation that failed.
-    case expectationFailed(_ expectation: Expectation.Snapshot)
+    indirect case expectationFailed(_ expectation: Expectation.Snapshot)
 
     /// An issue due to a confirmation being confirmed the wrong number of
     /// times.
@@ -237,7 +237,7 @@ extension Issue.Kind {
     /// ``confirmation(_:expectedCount:fileID:filePath:line:column:_:)`` when
     /// the confirmation passed to these functions' `body` closures is confirmed
     /// too few or too many times.
-    case confirmationMiscounted(actual: Int, expected: Int)
+    indirect case confirmationMiscounted(actual: Int, expected: Int)
 
     /// An issue due to an `Error` being thrown by a test function and caught by
     /// the testing library.
@@ -245,7 +245,7 @@ extension Issue.Kind {
     /// - Parameters:
     ///   - errorDescription: The String representation of the error which was
     ///                       associated with this issue.
-    case errorCaught(_ errorDescription: String)
+    indirect case errorCaught(_ errorDescription: String)
 
     /// An issue due to a test reaching its time limit and timing out.
     ///
@@ -257,7 +257,7 @@ extension Issue.Kind {
     ///     instance of `Duration`, but the testing library's deployment target
     ///     predates the introduction of that type.
     /// }
-    case timeLimitExceeded(timeLimitComponents: (seconds: Int64, attoseconds: Int64))
+    indirect case timeLimitExceeded(timeLimitComponents: (seconds: Int64, attoseconds: Int64))
 
     /// A known issue was expected, but was not recorded.
     case knownIssueNotRecorded

--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -21,7 +21,7 @@ extension Runner {
       ///
       /// - Parameters:
       ///   - skipInfo: A ``SkipInfo`` representing the details of this skip.
-      case skip(_ skipInfo: SkipInfo = .init())
+      indirect case skip(_ skipInfo: SkipInfo = .init())
 
       /// The test should record an issue due to a failure during
       /// planning.
@@ -29,7 +29,7 @@ extension Runner {
       /// - Parameters:
       ///   - issue: An issue representing the failure encountered during
       ///     planning.
-      case recordIssue(_ issue: Issue)
+      indirect case recordIssue(_ issue: Issue)
 
       /// Whether this action should be applied recursively to child tests or
       /// should only be applied to the test it is already associated with.


### PR DESCRIPTION
Right now, all cases in the `Event.Kind`, `Issue.Kind`, and `Runner.Plan.Action` enums are direct, i.e. stored inline in instances of those enums. That requires that the enums be at least as large as their largest associated values, which turns out to be a fair bit:

| Type | Size (Bytes) |
|-|-|
| `Event` | 464 |
| `Event.Kind` | 345 |
| `Issue` | 225 |
| `Issue.Kind` | 160 |
| `Runner.Plan.Action` | 225 |

Nearly half a kilobyte for an event is excessive. We can reduce the space needed by storing the associated values of these enums _indirectly_ (using the `indirect` keyword.) There are cases of both enums that don't have any associated values, so let's just make _all_ associated values indirect. We end up with:

| Type | Size (Bytes) |
|-|-|
| `Event` | 120 |
| `Event.Kind` | 8 |
| `Issue` | 73 |
| `Issue.Kind` | 8 |
| `Runner.Plan.Action` | 8 |

The tradeoff is that indirect storage is basically a pointer dereference, so we lose locality—but the frequency with which events and issues are raised doesn't make the performance cost worth worrying about.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
