### PR TITLE
Migrate file I/O code to a dedicated `FileHandle` type.

### DIFF
--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -172,12 +172,13 @@ public enum XCTestScaffold: Sendable {
 #if SWIFT_PM_SUPPORTS_SWIFT_TESTING
     let message = Event.ConsoleOutputRecorder.warning(
       "This version of Swift Package Manager supports running swift-testing tests directly. Ignoring call to \(#function).",
-      options: .forStandardError
+      options: .for(.stderr)
     )
 #if SWT_TARGET_OS_APPLE
-    let stderr = swt_stderr()
-    fputs(message, stderr)
-    fflush(stderr)
+    FileHandle.stderr.withUnsafeCFILEHandle { stderr in
+      fputs(message, stderr)
+      fflush(stderr)
+    }
 #else
     print(message)
 #endif
@@ -247,7 +248,7 @@ public enum XCTestScaffold: Sendable {
 #endif
     }
 
-    await runTests(options: .forStandardError, configuration: configuration)
+    await runTests(options: .for(.stderr), configuration: configuration)
 #endif
   }
 }

--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -1,0 +1,224 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+internal import TestingInternals
+
+#if !SWT_NO_FILE_IO
+/// A type representing a file handle.
+///
+/// Instances of this type abstract away the C `FILE *` type for Swift.
+///
+/// Whether or not a particular C file handle is safe to use concurrently is
+/// platform- and file-specific. The testing library assumes that the standard
+/// I/O file handles are generally concurrency-safe as implemented on supported
+/// platforms.
+///
+/// This type is not part of the public interface of the testing library.
+struct FileHandle: ~Copyable, @unchecked Sendable {
+  /// The underlying C file handle.
+  private var _fileHandle: SWT_FILEHandle
+
+  /// Whether or not to close `_fileHandle` when this instance is deinitialized.
+  private var _closeWhenDone: Bool
+
+  /// The C standard error stream.
+  static var stderr: Self {
+    // The value of stderr might change over time on some platforms, so this
+    // property needs to be computed each time. Fortunately, creating a new
+    // instance of this type from an existing C file handle is cheap.
+    Self(unsafeCFILEHandle: swt_stderr(), closeWhenDone: false)
+  }
+
+  /// Initialize an instance of this type by opening a file at the given path
+  /// with the given mode.
+  ///
+  /// - Parameters:
+  ///   - path: The path to open.
+  ///   - mode: The mode to open `path` with, such as `"wb"`.
+  ///
+  /// - Throws: Any error preventing the stream from being opened.
+  init(atPath path: String, mode: String) throws {
+#if os(Windows)
+    // Windows deprecates fopen() as insecure, so call _wfopen_s() instead.
+    _fileHandle = try path.withCString(encodedAs: UTF16.self) { path in
+      try mode.withCString(encodedAs: UTF16.self) { mode in
+        var file: SWT_FILEHandle?
+        let result = _wfopen_s(&file, path, mode)
+        guard let file, result == 0 else {
+          throw CError(rawValue: result)
+        }
+        return file
+      }
+    }
+#else
+    guard let fileHandle = fopen(path, mode) else {
+      throw CError(rawValue: swt_errno())
+    }
+    _fileHandle = fileHandle
+#endif
+    _closeWhenDone = true
+  }
+
+  /// Initialize an instance of this type to write to the given path.
+  ///
+  /// - Parameters:
+  ///   - path: The path to write to.
+  ///
+  /// - Throws: Any error preventing the stream from being opened.
+  init(forWritingAtPath path: String) throws {
+    try self.init(atPath: path, mode: "wb")
+  }
+
+  /// Initialize an instance of this type with an existing C file handle.
+  ///
+  /// - Parameters:
+  ///   - fileHandle: The C file handle to wrap. The caller is responsible for
+  ///     ensuring that this file handle is open in the expected mode and that
+  ///     another part of the system won't close it.
+  ///   - closeWhenDone: Whether or not to close `fileHandle` when the resulting
+  ///     instance is deinitialized. The caller is responsible for ensuring that
+  ///     there are no other references to `fileHandle` when passing `true`.
+  init(unsafeCFILEHandle fileHandle: SWT_FILEHandle, closeWhenDone: Bool) {
+    _fileHandle = fileHandle
+    _closeWhenDone = closeWhenDone
+  }
+
+  deinit {
+    if _closeWhenDone {
+      fclose(_fileHandle)
+    }
+  }
+
+  /// Call a function and pass the underlying C file handle to it.
+  ///
+  /// - Parameters:
+  ///   - body: A function to call.
+  ///
+  /// - Returns: Whatever is returned by `body`.
+  ///
+  /// - Throws: Whatever is thrown by `body`.
+  ///
+  /// Use this function when calling C I/O interfaces such as `fputs()` on the
+  /// underlying C file handle.
+  borrowing func withUnsafeCFILEHandle<R>(_ body: (SWT_FILEHandle) throws -> R) rethrows -> R {
+    try body(_fileHandle)
+  }
+
+  /// Call a function and pass the underlying POSIX file descriptor to it.
+  ///
+  /// - Parameters:
+  ///   - body: A function to call.
+  ///
+  /// - Returns: Whatever is returned by `body`.
+  ///
+  /// - Throws: Whatever is thrown by `body`.
+  ///
+  /// Use this function when calling interfaces on the underlying C file handle
+  /// that require a file descriptor instead of the standard `FILE *`
+  /// representation. If the file handle cannot be converted to a file
+  /// descriptor, `nil` is passed to `body`.
+  borrowing func withUnsafePOSIXFileDescriptor<R>(_ body: (CInt?) throws -> R) rethrows -> R {
+    try withUnsafeCFILEHandle { handle in
+#if SWT_TARGET_OS_APPLE || os(Linux)
+      let fd = fileno(handle)
+#elseif os(Windows)
+      let fd = _fileno(handle)
+#else
+#warning("Platform-specific implementation missing: cannot get file descriptor from a file handle")
+      let fd: CInt = -1
+#endif
+
+      if fd >= 0 {
+        return try body(fd)
+      }
+      return try body(nil)
+    }
+  }
+
+#if os(Windows)
+  /// Call a function and pass the underlying Windows file handle to it.
+  ///
+  /// - Parameters:
+  ///   - body: A function to call.
+  ///
+  /// - Returns: Whatever is returned by `body`.
+  ///
+  /// - Throws: Whatever is thrown by `body`.
+  ///
+  /// Use this function when calling interfaces on the underlying C file handle
+  /// that require the file's `HANDLE` representation instead of the standard
+  /// `FILE *` representation. If the file handle cannot be converted to a
+  /// Windows handle, `nil` is passed to `body`.
+  borrowing func withUnsafeWindowsHANDLE<R>(_ body: (HANDLE?) throws -> R) rethrows -> R {
+    try withUnsafePOSIXFileDescriptor { fd in
+      guard let fd else {
+        return try body(nil)
+      }
+      var handle = HANDLE(bitPattern: _get_osfhandle(fd))
+      if handle == INVALID_HANDLE_VALUE || handle == .init(bitPattern: -2) {
+        handle = nil
+      }
+      return try body(handle)
+    }
+  }
+#endif
+}
+
+// MARK: - Attributes
+
+extension FileHandle {
+  /// Is this file handle a TTY or PTY?
+  var isTTY: Bool {
+#if SWT_TARGET_OS_APPLE || os(Linux)
+    // If stderr is a TTY and TERM is set, that's good enough for us.
+    withUnsafePOSIXFileDescriptor { fd in
+      if let fd, 0 != isatty(fd), let term = Environment.variable(named: "TERM"), !term.isEmpty && term != "dumb" {
+        return true
+      }
+      return false
+    }
+#elseif os(Windows)
+    // If there is a console buffer associated with the file handle, then it's a
+    // console.
+    return withUnsafeWindowsHANDLE { handle in
+      guard let handle else {
+        return false
+      }
+      var screenBufferInfo = CONSOLE_SCREEN_BUFFER_INFO()
+      return GetConsoleScreenBufferInfo(handle, &screenBufferInfo)
+    }
+#else
+#warning("Platform-specific implementation missing: cannot tell if a file is a TTY")
+    return false
+#endif
+  }
+
+  /// Is this file handle a pipe or FIFO?
+  var isPipe: Bool {
+#if SWT_TARGET_OS_APPLE || os(Linux)
+    withUnsafePOSIXFileDescriptor { fd in
+      guard let fd else {
+        return false
+      }
+      var statStruct = stat()
+      return (0 == fstat(fd, &statStruct) && swt_S_ISFIFO(statStruct.st_mode))
+    }
+#elseif os(Windows)
+    return withUnsafeWindowsHANDLE { handle in
+      guard let handle else {
+        return false
+      }
+      return FILE_TYPE_PIPE == GetFileType(handle)
+    }
+#endif
+  }
+}
+
+#endif

--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -220,5 +220,4 @@ extension FileHandle {
 #endif
   }
 }
-
 #endif

--- a/Sources/TestingInternals/include/Includes.h
+++ b/Sources/TestingInternals/include/Includes.h
@@ -56,6 +56,10 @@
 #include <pthread.h>
 #endif
 
+#if __has_include(<pty.h>)
+#include <pty.h>
+#endif
+
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -77,11 +77,7 @@ struct FileHandleTests {
   @Test("Can recognize opened TTY")
   func isTTY() throws {
 #if os(Windows)
-    let file: SWT_FILEHandle = try {
-      var file: SWT_FILEHandle?
-      try #require(0 == fopen_s(&file, "CON", "wb"))
-      return file!
-    }()
+    let fileHandle = try FileHandle(forWritingAtPath: "CON")
 #else
     let oldTERM = Environment.variable(named: "TERM")
     Environment.setVariable("xterm", named: "TERM")
@@ -125,15 +121,10 @@ struct FileHandleTests {
   @Test("/dev/null is not a TTY or pipe")
   func devNull() throws {
 #if os(Windows)
-    let file: SWT_FILEHandle = try {
-      var file: SWT_FILEHandle?
-      try #require(0 == fopen_s(&file, "NUL", "wb"))
-      return file!
-    }()
+    let fileHandle = try FileHandle(forWritingAtPath: "NUL")
 #else
-    let file = try #require(fopen("/dev/null", "wb"))
+    let fileHandle = try FileHandle(forWritingAtPath: "/dev/null")
 #endif
-    let fileHandle = FileHandle(unsafeCFILEHandle: file, closeWhenDone: true)
     #expect(!Bool(fileHandle.isTTY))
     #expect(!Bool(fileHandle.isPipe))
   }

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -57,6 +57,7 @@ struct FileHandleTests {
 #if os(Windows)
     let path = try String(unsafeUninitializedCapacity: 1024) { buffer in
       try #require(0 == tmpnam_s(buffer.baseAddress!, buffer.count))
+      return strnlen(buffer.baseAddress!, buffer.count)
     }
 #else
     let path = "/tmp/can_write_to_file_\(UInt64.random(in: 0 ..< .max))"

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -1,0 +1,146 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable import Testing
+private import TestingInternals
+
+#if !SWT_NO_FILE_IO
+// NOTE: we don't run these tests on iOS (etc.) because processes on those
+// platforms are sandboxed and do not have arbitrary filesystem access.
+#if os(macOS) || os(Linux) || os(Windows)
+@Suite("FileHandle Tests")
+struct FileHandleTests {
+  @Test("Can get file descriptor")
+  func fileDescriptor() throws {
+    #if os(Windows)
+    let tmpFile: SWT_FILEHandle = try {
+      var file: SWT_FILEHandle?
+      try #require(0 == tmpfile_s(&file))
+      return file!
+    }()
+    #else
+    let tmpFile = try #require(tmpfile())
+    #endif
+    let fileHandle = FileHandle(unsafeCFILEHandle: tmpFile, closeWhenDone: true)
+    try fileHandle.withUnsafePOSIXFileDescriptor { fd in
+      try #require(fd != nil)
+    }
+  }
+
+#if os(Windows)
+  @Test("Can get Windows file HANDLE")
+  func fileHANDLE() throws {
+    let tmpFile: SWT_FILEHandle = try {
+      var file: SWT_FILEHandle?
+      try #require(0 == tmpfile_s(&file))
+      return file!
+    }()
+    let fileHandle = FileHandle(unsafeCFILEHandle: tmpFile, closeWhenDone: true)
+    try fileHandle.withUnsafeWindowsHANDLE { handle in
+      try #require(handle != nil)
+    }
+  }
+#endif
+
+  @Test("Can write to a file")
+  func canWrite() throws {
+    // NOTE: we are not trying to test mkstemp() here. We are trying to test the
+    // capacity of FileHandle to open a file for writing, and need a temporary
+    // file to write to.
+    let fileName = "can_write_to_file_\(UInt64.random(in: 0 ..< .max))"
+#if os(Windows)
+    let cPath = try #require(_tempnam("c:\\tmp", fileName))
+    defer {
+      free(cPath)
+    }
+    let path = String(cString: cPath)
+#else
+    let path = "/tmp/\(fileName)"
+#endif
+    defer {
+      remove(path)
+    }
+    let fileHandle = try FileHandle(forWritingAtPath: path)
+    fileHandle.withUnsafeCFILEHandle { file in
+      #expect(EOF != fputs("Hello world!", file))
+    }
+  }
+
+#if !os(Windows)
+  // Disabled on Windows because the equivalent of /dev/null, CON, redirects
+  // to stdout, but stdout may be any type of file, not just a TTY.
+  @Test("Can recognize opened TTY")
+  func isTTY() throws {
+#if os(Windows)
+    let file: SWT_FILEHandle = try {
+      var file: SWT_FILEHandle?
+      try #require(0 == fopen_s(&file, "CON", "wb"))
+      return file!
+    }()
+#else
+    let file = try #require(fopen("/dev/tty", "wb"))
+#endif
+    let fileHandle = FileHandle(unsafeCFILEHandle: file, closeWhenDone: true)
+    #expect(Bool(fileHandle.isTTY))
+  }
+#endif
+
+  @Test("Can recognize opened pipe")
+  func isPipe() throws {
+#if os(Windows)
+    var rHandle: HANDLE?
+    var wHandle: HANDLE?
+    try #require(CreatePipe(&rHandle, &wHandle, nil, 0))
+    if let rHandle {
+      CloseHandle(rHandle)
+    }
+    let fdWrite = _open_osfhandle(intptr_t(bitPattern: wHandle), 0)
+    let file = try #require(_fdopen(fdWrite, "wb"))
+#else
+    var fds: [CInt] = [-1, -1]
+    try #require(0 == pipe(&fds))
+    try #require(fds[1] >= 0)
+    close(fds[0])
+    let file = try #require(fdopen(fds[1], "wb"))
+#endif
+    let fileHandle = FileHandle(unsafeCFILEHandle: file, closeWhenDone: true)
+    #expect(Bool(fileHandle.isPipe))
+  }
+
+  @Test("/dev/null is not a TTY or pipe")
+  func devNull() throws {
+#if os(Windows)
+    let file: SWT_FILEHandle = try {
+      var file: SWT_FILEHandle?
+      try #require(0 == fopen_s(&file, "NUL", "wb"))
+      return file!
+    }()
+#else
+    let file = try #require(fopen("/dev/null", "wb"))
+#endif
+    let fileHandle = FileHandle(unsafeCFILEHandle: file, closeWhenDone: true)
+    #expect(!Bool(fileHandle.isTTY))
+    #expect(!Bool(fileHandle.isPipe))
+  }
+
+#if !os(Windows)
+  // Disabled on Windows because it does not have the equivalent of
+  // fmemopen(), so there is no need for this test.
+  @Test("fmemopen()'ed file is not a TTY or pipe")
+  func fmemopenedFile() throws {
+    let file = try #require(fmemopen(nil, 1, "wb+"))
+    let fileHandle = FileHandle(unsafeCFILEHandle: file, closeWhenDone: true)
+    #expect(!Bool(fileHandle.isTTY))
+    #expect(!Bool(fileHandle.isPipe))
+  }
+#endif
+}
+#endif
+#endif


### PR DESCRIPTION
This PR migrates the bulk of our file I/O code into a single file/type, `FileHandle`. Previously, the code we used to touch the file system and `stderr` was spread across several Swift files. This has started to become a bit difficult to maintain, especially when you consider platform-specific differences (I'm looking at you, Windows…)

So I've moved the code into a single type that wraps a C `FILE *` handle. The type is move-only and sendable, and abstracts away most of the platform-specific code we had around files. Access to the underlying file handle is done via a scoped-access "with" function.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
