### PR TITLE
Make Expression.expandedDescription(depth:includingTypeNames:includingParenthesesIfNeeded:) -> String SPI

### DIFF
--- a/Sources/Testing/SourceAttribution/Expression.swift
+++ b/Sources/Testing/SourceAttribution/Expression.swift
@@ -207,7 +207,8 @@ public struct Expression: Sendable {
   ///     information this instance contains.)
   ///
   /// - Returns: A string describing this instance.
-  func expandedDescription(depth: Int = 0, includingTypeNames: Bool = false, includingParenthesesIfNeeded: Bool = true) -> String {
+  @_spi(ExperimentalSourceCodeCapturing)
+  public func expandedDescription(depth: Int = 0, includingTypeNames: Bool = false, includingParenthesesIfNeeded: Bool = true) -> String {
     var result = ""
     switch kind {
     case let .generic(sourceCode), let .stringLiteral(sourceCode, _):


### PR DESCRIPTION
Expose `Expression.expandedDescription(depth:includingTypeNames:includingParenthesesIfNeeded:) -> String SPI` which is currently IPI as SPI so that it can be used from outside the Testing module.

### Motivation:
If you want to inspect issues from outside the Testing library, it would be useful to have that method available since it provides a nice summary of the expression that failed a test.

### Modifications:

Added `@_spi(ExperimentalSourceCodeCapturing) public` to `Expression.expandedDescription(depth:includingTypeNames:includingParenthesesIfNeeded:) -> String SPI`.

### Result:

`Expression.expandedDescription(depth:includingTypeNames:includingParenthesesIfNeeded:) -> String SPI` is now accessible from outside the Testing module.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
