### PR TITLE
Add more checks for `SWT_NO_FILE_IO`.

### DIFF
--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -248,7 +248,15 @@ public enum XCTestScaffold: Sendable {
 #endif
     }
 
-    await runTests(options: .for(.stderr), configuration: configuration)
+    var options = [Event.ConsoleOutputRecorder.Option]()
+#if !SWT_NO_FILE_IO
+    options += .for(.stderr)
+#endif
+    if Environment.flag(named: "SWT_VERBOSE_OUTPUT") == true {
+      options.append(.useVerboseOutput)
+    }
+    
+    await runTests(options: options, configuration: configuration)
 #endif
   }
 }


### PR DESCRIPTION
My recent change to add `FileHandle` didn't correctly handle the no-file-I/O case that we'd like to support. (My bad!) This PR corrects that, and I tested it this time I promise.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
