### PR TITLE
Rethink symbolic vs. string literal tags.

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
@@ -232,17 +232,7 @@ extension Event.ConsoleOutputRecorder {
   ///   with ANSI escape codes used to colorize them. If ANSI escape codes are
   ///   not enabled or if no tag colors are set, returns the empty string.
   fileprivate func colorDots(for tags: Set<Tag>) -> String {
-    let unsortedColors = tags.lazy
-      .compactMap { tag in
-        if let tagColor = tagColors[tag] {
-          return tagColor
-        } else if let sourceCode = tag.expression.map(String.init(describing:)) {
-          // If the color is defined under a key such as ".foo" and the tag was
-          // created from the expression `.foo`, we can find that too.
-          return tagColors[Tag(rawValue: sourceCode)]
-        }
-        return nil
-      }
+    let unsortedColors = tags.lazy.compactMap { tagColors[$0] }
 
     var result: String = Set(unsortedColors)
       .sorted(by: <).lazy

--- a/Sources/Testing/Testing.docc/DefiningTests.md
+++ b/Sources/Testing/Testing.docc/DefiningTests.md
@@ -65,7 +65,7 @@ line, supply a string literal as an argument to the `@Test` attribute:
 ```
 
 To further customize the appearance and behavior of a test function, use
- [traits](doc:Traits) such as ``Trait/tags(_:)``.
+ [traits](doc:Traits) such as ``Trait/tags(_:)-505n9``.
 
 ## Writing concurrent or throwing tests
 

--- a/Sources/Testing/Testing.docc/OrganizingTests.md
+++ b/Sources/Testing/Testing.docc/OrganizingTests.md
@@ -27,9 +27,9 @@ A test function can be added to a test suite in one of several ways:
 The `@Suite` attribute is not required for the testing library to recognize that
 a type contains test functions, but adding it allows customization of a test
 suite's appearance in the IDE and at the command line. If a trait such as
-``Trait/tags(_:)`` or ``Trait/disabled(_:fileID:filePath:line:column:)`` is
-applied to a test suite, it is automatically inherited by the tests contained in
-the suite.
+``Trait/tags(_:)-505n9`` or ``Trait/disabled(_:fileID:filePath:line:column:)``
+is applied to a test suite, it is automatically inherited by the tests contained
+in the suite.
 
 In addition to containing test functions and any other members that a Swift type
 might contain, test suite types can also contain additional test suites nested
@@ -51,7 +51,7 @@ To customize a test suite's name, supply a string literal as an argument to the
 ```
 
 To further customize the appearance and behavior of a test function, use
- [traits](doc:Traits) such as ``Trait/tags(_:)``.
+ [traits](doc:Traits) such as ``Trait/tags(_:)-505n9``.
 
 ## Test functions in test suite types
 

--- a/Sources/Testing/Traits/Tag+Macro.swift
+++ b/Sources/Testing/Traits/Tag+Macro.swift
@@ -1,0 +1,54 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+extension Tag {
+  /// Create a tag representing a static member of ``Tag`` such as ``Tag/red``.
+  ///
+  /// - Parameters:
+  ///   - type: The type in which the tag is declared. This type must either be
+  ///     ``Tag`` or a type nested within it.
+  ///   - name: The name of the declared variable, not including its parent
+  ///     type, module name, or a leading period.
+  ///
+  /// - Returns: An instance of ``Tag``.
+  ///
+  /// - Warning: This function is used to implement the `@Tag` macro. Do not
+  ///   call it directly.
+  public static func __fromStaticMember(of type: Any.Type, _ name: _const String) -> Self {
+    // Split up the supplied type name into its fully-qualified components. We
+    // will use this string array to reconstruct the fully-qualified name of the
+    // described static member.
+    var fullyQualifiedMemberNameComponents = fullyQualifiedName(of: type)
+      .split(separator: ".")
+      .map(String.init)
+
+    // Ensure that the tag is nested somewhere inside Testing.Tag, then strip
+    // off those elements of the fully-qualified type name. These preconditions
+    // are necessary because we do not currently have access, during macro
+    // expansion, to the lexical context in which a tag is declared.
+    precondition(fullyQualifiedMemberNameComponents.count >= 2, "Tags must be specified as members of the Tag type or a nested type in Tag.")
+    precondition(fullyQualifiedMemberNameComponents[0 ..< 2] == ["Testing", "Tag"], "Tags must be specified as members of the Tag type or a nested type in Tag.")
+    fullyQualifiedMemberNameComponents = Array(fullyQualifiedMemberNameComponents.dropFirst(2))
+
+    // Add the specified tag name to the fully-qualified name and reconstruct
+    // its string representation.
+    fullyQualifiedMemberNameComponents += CollectionOfOne(name)
+    let fullyQualifiedMemberName = fullyQualifiedMemberNameComponents.joined(separator: ".")
+
+    return Self(kind: .staticMember(fullyQualifiedMemberName))
+  }
+}
+
+/// Declare a tag that can be applied to a test function or test suite.
+///
+/// Use this tag with members of the ``Tag`` type declared in an extension to
+/// mark them as usable with tests. For more information on declaring tags, see
+/// <doc:AddingTags>.
+@attached(accessor) public macro Tag() = #externalMacro(module: "TestingMacros", type: "TagMacro")

--- a/Sources/Testing/Traits/Tag.Color.swift
+++ b/Sources/Testing/Traits/Tag.Color.swift
@@ -134,22 +134,22 @@ extension Tag.Color: Decodable {
 
 extension Tag {
   /// A tag representing the color red.
-  public static var red: Self { "red" }
+  @Tag public static var red: Self
 
   /// A tag representing the color orange.
-  public static var orange: Self { "orange" }
+  @Tag public static var orange: Self
 
   /// A tag representing the color yellow.
-  public static var yellow: Self { "yellow" }
+  @Tag public static var yellow: Self
 
   /// A tag representing the color green.
-  public static var green: Self { "green" }
+  @Tag public static var green: Self
 
   /// A tag representing the color blue.
-  public static var blue: Self { "blue" }
+  @Tag public static var blue: Self
 
   /// A tag representing the color purple.
-  public static var purple: Self { "purple" }
+  @Tag public static var purple: Self
 
   /// Whether or not this tag represents a color predefined by the testing
   /// library.

--- a/Sources/Testing/Traits/Tag.swift
+++ b/Sources/Testing/Traits/Tag.swift
@@ -10,56 +10,158 @@
 
 /// A type representing a tag that can be applied to a test.
 ///
-/// To apply tags to a test, use ``Trait/tags(_:)``.
-public struct Tag: RawRepresentable, Sendable {
-  public var rawValue: String
+/// To apply tags to a test, use one of the following functions:
+///
+/// - ``Trait/tags(_:)-505n9``
+/// - ``Trait/tags(_:)-yg0i``
+public struct Tag: Sendable {
+  /// An enumeration describing the various kinds of tag that can be applied to
+  /// a test.
+  @_spi(ForToolsIntegrationOnly)
+  public enum Kind: Sendable, Hashable {
+    /// The tag is a static member of ``Tag`` such as ``Tag/red``, declared
+    /// using the ``Tag()`` macro.
+    case staticMember(_ name: String)
 
-  /// The expression that produced this tag, if available at compile time.
-  var expression: Expression?
+    /// The tag is a string literal declared directly in source.
+    case stringLiteral(_ stringLiteral: String)
+  }
 
-  public init(rawValue: String) {
-    self.rawValue = rawValue
+  /// The kind of this tag.
+  @_spi(ForToolsIntegrationOnly)
+  public var kind: Kind
+
+  @_spi(ForToolsIntegrationOnly)
+  public init(kind: Kind) {
+    self.kind = kind
+  }
+
+  /// Initialize an instance of this type from a string provided by a user, for
+  /// instance at the command line using `swift test`.
+  ///
+  /// - Parameters:
+  ///   - stringValue: The user-supplied string value.
+  ///
+  /// Use this initializer when a user has provided an arbitrary string and it
+  /// is necessary to convert it into a tag. A simple heuristic is applied such
+  /// that the resulting instance may represent a (possibly non-existent) static
+  /// member of ``Tag`` or may represent a string literal.
+  @_spi(ForToolsIntegrationOnly)
+  public init(userProvidedStringValue stringValue: String) {
+    self.init(_codableStringValue: stringValue)
   }
 }
 
-// MARK: - ExpressibleByStringLiteral
+// MARK: - CustomStringConvertible
 
-extension Tag: ExpressibleByStringLiteral, CustomStringConvertible {
-  public init(stringLiteral: String) {
-    self.init(rawValue: stringLiteral)
-  }
-
+extension Tag: CustomStringConvertible {
   public var description: String {
-    rawValue
+    switch kind {
+    case let .staticMember(name):
+      ".\(name)"
+    case let .stringLiteral(stringLiteral):
+      #""\#(stringLiteral)""#
+    }
   }
 }
 
 // MARK: - Equatable, Hashable, Comparable
 
 extension Tag: Equatable, Hashable, Comparable {
-  public static func ==(lhs: Self, rhs: Self) -> Bool {
-    lhs.rawValue == rhs.rawValue
-  }
-
-  public func hash(into hasher: inout Hasher) {
-    hasher.combine(rawValue)
-  }
-
   public static func <(lhs: Tag, rhs: Tag) -> Bool {
-    lhs.rawValue < rhs.rawValue
+    switch (lhs.kind, rhs.kind) {
+    case let (.staticMember(lhs), .staticMember(rhs)):
+      lhs < rhs
+    case let (.stringLiteral(lhs), .stringLiteral(rhs)):
+      lhs < rhs
+
+    // (Arbitrarily) sort static members before string literals.
+    case (.staticMember, .stringLiteral):
+      true
+    case (.stringLiteral, .staticMember):
+      false
+    }
   }
 }
 
 // MARK: - Codable, CodingKeyRepresentable
 
-extension Tag: Codable, CodingKeyRepresentable {}
+extension Tag: Codable, CodingKeyRepresentable {
+  /// Initialize an instance of this type from a string previously encoded from
+  /// the `_codableStringValue` property.
+  ///
+  /// - Parameters:
+  ///   - stringValue: The previously-encoded string.
+  private init(_codableStringValue stringValue: String) {
+    if stringValue.first == "." {
+      self.init(kind: .staticMember(String(stringValue.dropFirst())))
+    } else if stringValue.first == #"\"# {
+      self.init(kind: .stringLiteral(String(stringValue.dropFirst())))
+    } else {
+      self.init(kind: .stringLiteral(stringValue))
+    }
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let stringValue = try String(from: decoder)
+    self.init(_codableStringValue: stringValue)
+  }
+
+  /// This instance represented as a string, suitable for encoding.
+  private var _codableStringValue: String {
+    switch kind {
+    case let .staticMember(name):
+      ".\(name)"
+    case let .stringLiteral(stringLiteral):
+      if stringLiteral.first == "." || stringLiteral.first == #"\"# {
+        #"\\#(stringLiteral)"#
+      } else {
+        stringLiteral
+      }
+    }
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    try _codableStringValue.encode(to: encoder)
+  }
+
+  /// A type describing a generic coding key.
+  ///
+  /// This type is used to implement `Codable` conformance for ``Tag`` so that
+  /// it can be used as a dictionary key.
+  private struct _CodingKey: CodingKey {
+    var stringValue: String
+    var intValue: Int?
+
+    init(stringValue: String) {
+      self.stringValue = stringValue
+    }
+
+    init?(intValue: Int) {
+      nil // Unsupported
+    }
+  }
+
+  @available(macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4, *)
+  public var codingKey: any CodingKey {
+    _CodingKey(stringValue: _codableStringValue)
+  }
+
+  @available(macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4, *)
+  public init?<T>(codingKey: T) where T : CodingKey {
+    self.init(_codableStringValue: codingKey.stringValue)
+  }
+}
 
 // MARK: -
 
 extension Test {
   /// The complete, unique set of tags associated with this test.
   ///
-  /// Tags are associated with tests using ``Trait/tags(_:)``.
+  /// Tags are associated with tests using one of the following functions:
+  ///
+  /// - ``Trait/tags(_:)-505n9``
+  /// - ``Trait/tags(_:)-yg0i``
   public var tags: Set<Tag> {
     traits.lazy
       .compactMap { $0 as? Tag.List }

--- a/Sources/Testing/Traits/Trait.swift
+++ b/Sources/Testing/Traits/Trait.swift
@@ -41,23 +41,6 @@ public protocol Trait: Sendable {
   ///
   /// By default, the value of this property is an empty array.
   var comments: [Comment] { get }
-
-  /// Make a copy of this trait that stores the expression corresponding to it.
-  ///
-  /// - Parameters:
-  ///   - expression: The expression, captured from source code, corresponding
-  ///     to this instance.
-  ///
-  /// - Returns: A copy of `self` updated to include its corresponding
-  ///   expression.
-  ///
-  /// The default implementation of this method does nothing and returns `self`
-  /// unmodified.
-  ///
-  /// - Warning: This protocol requirement is experimental. It is public due to
-  ///   technical limitations in Swift. It may be modified or removed in a
-  ///   future update to the testing library.
-  func _capturing(_ expression: @autoclosure () -> Expression) -> Self
 }
 
 /// A protocol describing traits that can be added to a test function.
@@ -86,10 +69,6 @@ extension Trait {
 
   public var comments: [Comment] {
     []
-  }
-
-  public func _capturing(_ expression: @autoclosure () -> Expression) -> Self {
-    self
   }
 }
 

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -282,10 +282,27 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
   ///
   /// - Returns: A diagnostic message.
   static func returnTypeNotSupported(_ returnType: TypeSyntax, on decl: some SyntaxProtocol, whenUsing attribute: AttributeSyntax) -> Self {
-    return Self(
+    Self(
       syntax: Syntax(returnType),
       message: "The result of this \(_kindString(for: decl)) will be discarded during testing.",
       severity: .warning
+    )
+  }
+
+  /// Create a diagnostic message stating that the expression used to declare a
+  /// tag on a test or suite is not supported.
+  ///
+  /// - Parameters:
+  ///   - returnType: The unsupported return type.
+  ///   - decl: The declaration with an unsupported return type.
+  ///   - attribute: The `@Test` or `@Suite` attribute.
+  ///
+  /// - Returns: A diagnostic message.
+  static func tagExprNotSupported(_ tagExpr: some SyntaxProtocol, in attribute: AttributeSyntax) -> Self {
+    Self(
+      syntax: Syntax(tagExpr),
+      message: "The tag \(tagExpr.trimmed) cannot be used with the @\(attribute.attributeNameText) attribute. Pass a member of Tag or a string literal instead.",
+      severity: .error
     )
   }
 

--- a/Sources/TestingMacros/Support/TagConstraints.swift
+++ b/Sources/TestingMacros/Support/TagConstraints.swift
@@ -1,0 +1,89 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+import SwiftDiagnostics
+#if swift(>=5.11)
+import SwiftSyntax
+import SwiftSyntaxMacros
+#else
+public import SwiftSyntax
+public import SwiftSyntaxMacros
+#endif
+
+/// Diagnose issues with the traits in a parsed attribute.
+///
+/// - Parameters:
+///   - traitExprs: An array of trait expressions to examine.
+///   - attribute: The `@Test` or `@Suite` attribute.
+///   - context: The macro context in which the expression is being parsed.
+func diagnoseIssuesWithTags(in traitExprs: [ExprSyntax], addedTo attribute: AttributeSyntax, in context: some MacroExpansionContext) {
+  // Find tags that are in an unsupported format (only .member and "literal"
+  // are allowed.)
+  for traitExpr in traitExprs {
+    // At this time, we are only looking for .tags() traits in this function.
+    guard let functionCallExpr = traitExpr.as(FunctionCallExprSyntax.self),
+          let calledExpr = functionCallExpr.calledExpression.as(MemberAccessExprSyntax.self) else {
+      continue
+    }
+
+    // Check for .tags() traits.
+    switch calledExpr.tokens(viewMode: .fixedUp).map(\.textWithoutBackticks).joined() {
+    case ".tags", "Tag.List.tags", "Testing.Tag.List.tags":
+      for tagExpr in functionCallExpr.arguments.lazy.map(\.expression) {
+        if tagExpr.is(StringLiteralExprSyntax.self) {
+          // String literals are supported tags.
+        } else if let tagExpr = tagExpr.as(MemberAccessExprSyntax.self) {
+          let joinedTokens = tagExpr.tokens(viewMode: .fixedUp).map(\.textWithoutBackticks).joined()
+          if joinedTokens.hasPrefix(".") || joinedTokens.hasPrefix("Tag.") || joinedTokens.hasPrefix("Testing.Tag.") {
+            // These prefixes are all allowed as they specify a member access
+            // into the Tag type.
+          } else {
+            context.diagnose(.tagExprNotSupported(tagExpr, in: attribute))
+            continue
+          }
+
+          // Walk all base expressions and make sure they are exclusively member
+          // access expressions.
+          func checkForValidDeclReferenceExpr(_ declReferenceExpr: DeclReferenceExprSyntax) {
+            // This is the name of a type or symbol. If there are argument names
+            // (unexpected in this context), it's a function reference and is
+            // unsupported.
+            if declReferenceExpr.argumentNames != nil {
+              context.diagnose(.tagExprNotSupported(tagExpr, in: attribute))
+            }
+          }
+          func checkForValidBaseExpr(_ baseExpr: ExprSyntax) {
+            if let baseExpr = baseExpr.as(MemberAccessExprSyntax.self) {
+              checkForValidDeclReferenceExpr(baseExpr.declName)
+              if let baseBaseExpr = baseExpr.base {
+                checkForValidBaseExpr(baseBaseExpr)
+              }
+            } else if let baseExpr = baseExpr.as(DeclReferenceExprSyntax.self) {
+              checkForValidDeclReferenceExpr(baseExpr)
+            } else {
+              // The base expression was some other kind of expression and is
+              // not supported.
+              context.diagnose(.tagExprNotSupported(tagExpr, in: attribute))
+            }
+          }
+          if let baseExpr = tagExpr.base {
+            checkForValidBaseExpr(baseExpr)
+          }
+        } else {
+          // This tag is not of a supported expression type.
+          context.diagnose(.tagExprNotSupported(tagExpr, in: attribute))
+        }
+      }
+    default:
+      // This is not a tag list (as far as we know.)
+      break
+    }
+  }
+}

--- a/Sources/TestingMacros/TagMacro.swift
+++ b/Sources/TestingMacros/TagMacro.swift
@@ -1,0 +1,49 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+public import SwiftSyntax
+public import SwiftSyntaxMacros
+
+/// A type describing the expansion of the `@Tag` attribute macro.
+///
+/// This type is used to implement the `@Tag` attribute macro. Do not use it
+/// directly.
+public struct TagMacro: AccessorMacro, Sendable {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingAccessorsOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [AccessorDeclSyntax] {
+    guard let variableDecl = declaration.as(VariableDeclSyntax.self) else {
+      context.diagnose(.attributeNotSupported(node, on: declaration))
+      return []
+    }
+    guard variableDecl.modifiers.map(\.name.tokenKind).contains(.keyword(.static)) else {
+      context.diagnose(.attributeNotSupported(node, on: declaration))
+      return []
+    }
+    guard variableDecl.bindings.count == 1 else {
+      context.diagnose(.attributeNotSupported(node, on: declaration))
+      return []
+    }
+    guard let variableName = variableDecl.bindings.first?.pattern.as(IdentifierPatternSyntax.self)?.identifier else {
+      context.diagnose(.attributeNotSupported(node, on: declaration))
+      return []
+    }
+
+    return [
+      #"""
+      get {
+        Testing.Tag.__fromStaticMember(of: self, \#(literal: variableName.textWithoutBackticks))
+      }
+      """#
+    ]
+  }
+}

--- a/Sources/TestingMacros/TestingMacrosMain.swift
+++ b/Sources/TestingMacros/TestingMacrosMain.swift
@@ -26,6 +26,7 @@ struct TestingMacrosMain: CompilerPlugin {
       TestDeclarationMacro.self,
       ExpectMacro.self,
       RequireMacro.self,
+      TagMacro.self,
     ]
   }
 }

--- a/Tests/TestingTests/PlanTests.swift
+++ b/Tests/TestingTests/PlanTests.swift
@@ -116,7 +116,7 @@ struct PlanTests {
     ]
 
     var configuration = Configuration()
-    var filter = Configuration.TestFilter(includingAnyOf: ["tag-1" as Tag, "tag-2" as Tag])
+    var filter = Configuration.TestFilter(includingAnyOf: [Tag("tag-1"), Tag("tag-2")])
     filter.includeHiddenTests = true
     configuration.testFilter = filter
 
@@ -146,7 +146,7 @@ struct PlanTests {
     ]
 
     var configuration = Configuration()
-    var filter = Configuration.TestFilter(includingAllOf: ["tag-1" as Tag, "tag-2" as Tag])
+    var filter = Configuration.TestFilter(includingAllOf: [Tag("tag-1"), Tag("tag-2")])
     filter.includeHiddenTests = true
     configuration.testFilter = filter
 
@@ -176,7 +176,7 @@ struct PlanTests {
     ]
 
     var configuration = Configuration()
-    var filter = Configuration.TestFilter(excludingAnyOf: ["tag-1" as Tag, "tag-2" as Tag])
+    var filter = Configuration.TestFilter(excludingAnyOf: [Tag("tag-1"), Tag("tag-2")])
     filter.includeHiddenTests = true
     configuration.testFilter = filter
 
@@ -206,7 +206,7 @@ struct PlanTests {
     ]
 
     var configuration = Configuration()
-    var filter = Configuration.TestFilter(excludingAllOf: ["tag-1" as Tag, "tag-2" as Tag])
+    var filter = Configuration.TestFilter(excludingAllOf: [Tag("tag-1"), Tag("tag-2")])
     filter.includeHiddenTests = true
     configuration.testFilter = filter
 
@@ -326,7 +326,7 @@ struct PlanTests {
     var configuration = Configuration()
     let selection = [innerTestType.id, outerTestType.id]
     var testFilter = Configuration.TestFilter(including: selection)
-    testFilter.combine(with: .init(excludingAnyOf: ["A" as Tag]))
+    testFilter.combine(with: .init(excludingAnyOf: [Tag("A")]))
     testFilter.includeHiddenTests = true
     configuration.testFilter = testFilter
 

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -13,6 +13,19 @@
 import XCTest
 #endif
 
+extension Tag {
+  /// A tag indicating that a test is related to a trait.
+  @Tag static var traitRelated: Self
+
+  /// Convenience initializer/shorthand for tags.
+  ///
+  /// This initializer is equivalent to ``Tag/init(userProvidedStringValue:)``
+  /// but is shorter to help keep tests readable.
+  init(_ stringValue: _const String) {
+    self.init(userProvidedStringValue: stringValue)
+  }
+}
+
 /// Get the ``Test`` instance representing a type, if one is found in the
 /// current process.
 ///

--- a/Tests/TestingTests/Traits/BugTests.swift
+++ b/Tests/TestingTests/Traits/BugTests.swift
@@ -10,7 +10,7 @@
 
 @testable import Testing
 
-@Suite("Bug Tests", .tags("trait"))
+@Suite("Bug Tests", .tags(.traitRelated))
 struct BugTests {
   @Test(".bug() with String")
   func bugFactoryMethodWithString() throws {

--- a/Tests/TestingTests/Traits/CommentTests.swift
+++ b/Tests/TestingTests/Traits/CommentTests.swift
@@ -10,7 +10,7 @@
 
 @testable @_spi(ExperimentalTestRunning) import Testing
 
-@Suite("Comment Tests", .tags("trait"))
+@Suite("Comment Tests", .tags(.traitRelated))
 struct CommentTests {
   @Test(".comment() factory method")
   func commentFactoryMethod() {

--- a/Tests/TestingTests/Traits/HiddenTraitTests.swift
+++ b/Tests/TestingTests/Traits/HiddenTraitTests.swift
@@ -10,7 +10,7 @@
 
 @testable import Testing
 
-@Suite("Hidden Trait Tests", .tags("trait"))
+@Suite("Hidden Trait Tests", .tags(.traitRelated))
 struct HiddenTraitTests {
   @Test(".hidden trait")
   func hiddenTrait() throws {

--- a/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
+++ b/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
@@ -10,7 +10,7 @@
 
 @testable @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) import Testing
 
-@Suite("TimeLimitTrait Tests", .tags("trait"))
+@Suite("TimeLimitTrait Tests", .tags(.traitRelated))
 struct TimeLimitTraitTests {
   @available(_clockAPI, *)
   @Test(".timeLimit() factory method")


### PR DESCRIPTION
## Introduction

Today, every tag wraps a string, which means that symbolic tags can be represented in two different ways:

```swift
extension Tag {
  static var critical: Self { "unimportant" }
}
```

The above tag can be referred to as `.critical` or as `"unimportant"` when added to a test, and the two names are equivalent.

The raw string value is necessary because tags need some sort of _identity_. If a tag were just `Tag()` with no associated metadata, then any two tags would compare equal, and there would be no way to distinguish them.

## Problem

String values are important for Swift Package Manager because when working at the command line, all you have to help you out are (about) 102 keys and the `--help` option. If tags map to and from strings, then you can write something like `swift test --filter-by-tag '.critical'` and have it "just work." But because a tag may have two distinct names, we need to make decisions like:

1. Should a test tagged `"unimportant"` be run if a developer asks to run tests with the `.critical` tag?
1. If a `.critical` tag is defined in two different contexts (say, two `fileprivate` declarations in different files), should they be treated as equivalent even if they have different raw string values?
1. Should `let critical: Tag = ...` at file scope be treated as equivalent to `.critical` (a static member of `Tag`)?
1. Are any of these possible equivalences transitive? If `.critical` and `critical` are the same, is `critical` the same as `"unimportant"`?
1. What happens if somebody declares a tag with a string value that's only known at runtime (e.g. taken from an environment variable)?
1. If a tag is declared symbolically in another module (e.g. `let experimental: Tag = "Swift Experimental Feature"`) how do we find out its string representation and consistently recognize it as equivalent if we don't have access to the source code of the other module?

We don't have good answers to these questions, and we've found that any solution we try to design ends up unsound or, at best, inexplicable to the end user.

## Solution

This PR refactors `Tag` pretty significantly. Gone is `RawRepresentable` conformance. In its place are two disjoint families of tags: tags declared as static members of `Tag`, and tags declared as compile-time constant string literals.

### Static members of Tag

Tags declared as static members use a new `@Tag` macro (name subject to change) to indicate at compile-time that they are tags that may be applied to tests:

```swift
extension Tag {
  @Tag static var critical: Tag
}

@Test(.tags(.critical)) func f() { ... }
```

> [!NOTE]
> The exact shape of this macro may change in the future, especially with recently landed changes to swift-syntax to allow gathering the lexical context of a macro. We may in the future change the above to something like:
>
> ```swift
> extension Tag {
>   static var critical = #tag
> }
>
> @Test(.tags(.critical)) func f() { ... }
> ```
>
> But that's a future direction we are unable to implement at this time, so best not to dwell on it.

Note that tags declared this way _do not have raw string values associated with them_. The ambiguity of `.critical` versus `"unimportant"` above is eliminated. We also disallow applying this macro to symbols that are _not_ members of `Tag`, so a file-scoped `critical` tag is not possible, and that ambiguity is eliminated too.

### String literals

Tags declared as string literals behave more or less the same as before:

```swift
@Test(.tags("unimportant")) func f() { ... }
```

### Expressing tags at the command line

We define a trivial transformation function to/from tag and string: if the first character of a string is a period, then the string is interpreted as the name of a static member tag; otherwise, it is interpreted as the value of a string literal tag. A leading slash is dropped, but indicates that the tag is a string literal tag, so `".oddChoice"` can be "escaped" and correctly interpreted. This format is easy to represent at the command line and easy to understand/explain:

```sh
# Run tests with the symbolic tag .critical or the string tag "unimportant"
swift test --filter-by-tags .critical unimportant
```

### Macro knowledge of tags

One unfortunate caveat here is that the compiler, by way of the testing library's macro target, needs to have knowledge of tags. We'd really prefer it if the macro target had as little knowledge of individual traits as possible, but given the integration tags have (or rather, should have) with tools like Swift Package Manager, it seems unavoidable that other parts of the swift-testing stack also need to understand them.

Macro targets are limited to examining syntax and do not have type information. In the future, we could explore changes to the language and compiler to allow better compile-time context for the testing library's macros and to improve the overall experience for developers when using tags.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
