### PR TITLE
Add 'README' to Documentation directory, and remove .docc symlink

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,5 +1,15 @@
 # swift-testing documentation
 
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2024 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
 ## API and usage guides
 
 The detailed documentation for `swift-testing` can be found on the

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,36 @@
+# swift-testing documentation
+
+## API and usage guides
+
+The detailed documentation for `swift-testing` can be found on the
+[Swift Package Index](https://swiftpackageindex.com/apple/swift-testing/main/documentation/testing).
+There, you can delve into comprehensive guides, tutorials, and API references to
+make the most out of `swift-testing`.
+
+This documentation is generated using [DocC](https://github.com/apple/swift-docc)
+and is derived from symbol documentation in this project's source code as well
+as supplemental content located in the
+[`Sources/Testing/Testing.docc/`](https://github.com/apple/swift-testing/tree/main/Sources/Testing/Testing.docc)
+directory.
+
+## Vision document
+
+The [Vision document](https://github.com/apple/swift-testing/blob/main/Documentation/Vision.md)
+for `swift-testing` offers a comprehensive discussion of the project's design
+principles and goals. 
+
+## Development and contribution
+
+- The top-level [`README`](https://github.com/apple/swift-testing/blob/main/README.md)
+  gives a high-level overview of the project, shows current CI status, lists the
+  support status of various platforms, and more.
+- [Contributing](https://github.com/apple/swift-testing/blob/main/CONTRIBUTING.md)
+  provides guidance for developing and making project contributions.
+- [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md)
+  describes this project's guidelines for code and documentation style.
+
+## Project maintenance
+
+- The [Releases](https://github.com/apple/swift-testing/blob/main/Documentation/Releases.md)
+  document describes the process of creating and publishing a new release of
+  `swift-testing`—a task which may be performed by project administrators.

--- a/Documentation/Testing.docc
+++ b/Documentation/Testing.docc
@@ -1,1 +1,0 @@
-../Sources/Testing/Testing.docc


### PR DESCRIPTION
This adds a new `README` file to the `Documentation/` subdirectory with links to all the documentation resources related to this project. It also deletes the `Testing.docc` symlink in this directory.

### Motivation:

The main motivation is to delete the symlink because it causes searching for content in IDEs to incorrectly behave as though each Markdown .md file is at two locations in the filesystem, resulting in duplicate matches. But to ensure the .docc bundle is still easy to find, I've added a README file containing a link to it.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
