### PR TITLE
Fix build when `SWT_NO_ENVIRONMENT_VARIABLES` is set.

### DIFF
--- a/Sources/Testing/Support/Environment.swift
+++ b/Sources/Testing/Support/Environment.swift
@@ -20,8 +20,10 @@ enum Environment {
   /// Storage for the simulated environment.
   ///
   /// The mechanism by which this dictionary is initially populated depends on
-  /// platform-specific implementation details.
-  private static let _environment = Locked<[String: String]>()
+  /// platform-specific implementation details. Callers should not read from
+  /// this dictionary directly; use ``variable(named:)`` or ``flag(named:)``
+  /// instead.
+  static let simulatedEnvironment = Locked<[String: String]>()
 #endif
 
   /// Get the environment variable with the specified name.
@@ -33,7 +35,7 @@ enum Environment {
   ///   is not set for the current process.
   static func variable(named name: String) -> String? {
 #if SWT_NO_ENVIRONMENT_VARIABLES
-    _environment.rawValue[name]
+    simulatedEnvironment.rawValue[name]
 #elseif SWT_TARGET_OS_APPLE || os(Linux)
     getenv(name).flatMap { String(validatingUTF8: $0) }
 #elseif os(Windows)

--- a/Tests/TestingTests/Support/EnvironmentTests.swift
+++ b/Tests/TestingTests/Support/EnvironmentTests.swift
@@ -75,7 +75,7 @@ extension Environment {
   @discardableResult
   static func setVariable(_ value: String?, named name: String) -> Bool {
 #if SWT_NO_ENVIRONMENT_VARIABLES
-    $_environment.withLock { environment in
+    simulatedEnvironment.withLock { environment in
       environment[name] = value
     }
     return true


### PR DESCRIPTION
The build is broken when `SWT_NO_ENVIRONMENT_VARIABLES` is set. This PR fixes that by adjusting call sites that use `Environment._environment` (since `Locked` is no longer a property wrapper and we moved `setVariable(_:named:)` to the test target.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
