### PR TITLE
Represent type information for test parameters and their runtime arguments

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -158,16 +158,28 @@ private func _capitalizedTitle(for test: Test?) -> String {
 extension Test.Case {
   /// The arguments of this test case, formatted for presentation, prefixed by
   /// their corresponding parameter label when available.
-  fileprivate var labeledArguments: String {
+  ///
+  /// - Parameters:
+  ///   - includeTypeNames: Whether the qualified type name of each argument's
+  ///     runtime type should be included. Defaults to `false`.
+  fileprivate func labeledArguments(includingQualifiedTypeNames includeTypeNames: Bool = false) -> String {
     arguments.lazy
       .map { argument in
         let valueDescription = String(describingForTest: argument.value)
 
         let label = argument.parameter.secondName ?? argument.parameter.firstName
-        guard label != "_" else {
-          return valueDescription
+        let labeledArgument = if label == "_" {
+          valueDescription
+        } else {
+          "\(label) → \(valueDescription)"
         }
-        return "\(label) → \(valueDescription)"
+
+        if includeTypeNames {
+          let typeInfo = TypeInfo(describingTypeOf: argument.value)
+          return "\(labeledArgument) (\(typeInfo.qualifiedTypeName))"
+        } else {
+          return labeledArgument
+        }
       }
       .joined(separator: ", ")
   }
@@ -315,7 +327,7 @@ extension Event.HumanReadableOutputRecorder {
         0
       }
       let labeledArguments = if let testCase = eventContext.testCase {
-        testCase.labeledArguments
+        testCase.labeledArguments()
       } else {
         ""
       }
@@ -373,7 +385,7 @@ extension Event.HumanReadableOutputRecorder {
       return [
         Message(
           symbol: .default,
-          stringValue: "Passing \(testCase.arguments.count.counting("argument")) \(testCase.labeledArguments) to \(testName)"
+          stringValue: "Passing \(testCase.arguments.count.counting("argument")) \(testCase.labeledArguments(includingQualifiedTypeNames: verbose)) to \(testName)"
         )
       ]
 

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -176,7 +176,7 @@ extension Test.Case {
 
         if includeTypeNames {
           let typeInfo = TypeInfo(describingTypeOf: argument.value)
-          return "\(labeledArgument) (\(typeInfo.qualifiedTypeName))"
+          return "\(labeledArgument) (\(typeInfo.qualifiedName))"
         } else {
           return labeledArgument
         }

--- a/Sources/Testing/Parameterization/Test.Case.swift
+++ b/Sources/Testing/Parameterization/Test.Case.swift
@@ -145,7 +145,7 @@ extension Test {
       self.index = index
       self.firstName = firstName
       self.secondName = secondName
-      self.typeInfo = TypeInfo(type)
+      self.typeInfo = TypeInfo(describing: type)
     }
   }
 }

--- a/Sources/Testing/Parameterization/Test.Case.swift
+++ b/Sources/Testing/Parameterization/Test.Case.swift
@@ -127,6 +127,26 @@ extension Test {
 
     /// The second name of this parameter, if specified.
     public var secondName: String?
+
+    /// Information about the type of this parameter.
+    ///
+    /// The value of this property represents the type of the parameter, but
+    /// arguments passed to this parameter may be of different types. For
+    /// example, an argument may be a subclass or conforming type of the
+    /// declared parameter type.
+    ///
+    /// For information about runtime type of an argument to a parameterized
+    /// test, use ``TypeInfo/init(describingTypeOf:)``, passing the argument
+    /// value obtained by calling ``Test/Case/Argument/value``.
+    @_spi(ForToolsIntegrationOnly)
+    public var typeInfo: TypeInfo
+
+    init(index: Int, firstName: String, secondName: String? = nil, type: Any.Type) {
+      self.index = index
+      self.firstName = firstName
+      self.secondName = secondName
+      self.typeInfo = TypeInfo(type)
+    }
   }
 }
 
@@ -137,7 +157,7 @@ extension Test.Case.Argument.ID: Codable {}
 
 // MARK: - Equatable, Hashable
 
-extension Test.Parameter: Equatable {}
+extension Test.Parameter: Hashable {}
 extension Test.Case.Argument.ID: Hashable {}
 
 // MARK: - Snapshotting
@@ -181,6 +201,11 @@ extension Test.Case.Argument {
     /// `String(reflecting:)`.
     public var valueDebugDescription: String?
 
+    /// Information about the type of this parameterized test argument's
+    /// ``Test/Case/Argument/value`` property.
+    @_spi(ForToolsIntegrationOnly)
+    public var valueTypeInfo: TypeInfo
+
     /// The parameter of the test function to which this argument was passed.
     public var parameter: Test.Parameter
 
@@ -193,6 +218,7 @@ extension Test.Case.Argument {
       id = argument.id
       valueDescription = String(describingForTest: argument.value)
       valueDebugDescription = String(reflecting: argument.value)
+      valueTypeInfo = TypeInfo(describingTypeOf: argument.value)
       parameter = argument.parameter
     }
   }

--- a/Sources/Testing/Parameterization/TypeInfo.swift
+++ b/Sources/Testing/Parameterization/TypeInfo.swift
@@ -14,18 +14,18 @@
 public struct TypeInfo: Sendable {
   /// The complete name of this type, with the names of all referenced types
   /// fully-qualified by their module names when possible.
-  public var qualifiedTypeName: String
+  public var qualifiedName: String
 
   /// A simplified name of this type, by leaving the names of all referenced
   /// types unqualified, i.e. without module name prefixes.
-  public var unqualifiedTypeName: String
+  public var unqualifiedName: String
 
   init(
-    qualifiedTypeName: String,
-    unqualifiedTypeName: String
+    qualifiedName: String,
+    unqualifiedName: String
   ) {
-    self.qualifiedTypeName = qualifiedTypeName
-    self.unqualifiedTypeName = unqualifiedTypeName
+    self.qualifiedName = qualifiedName
+    self.unqualifiedName = unqualifiedName
   }
 
   /// Initialize an instance of this type describing the specified type.
@@ -33,8 +33,8 @@ public struct TypeInfo: Sendable {
   /// - Parameters:
   ///   - type: The type which this instance should describe.
   init(describing type: Any.Type) {
-    qualifiedTypeName = _typeName(type, qualified: true)
-    unqualifiedTypeName = _typeName(type, qualified: false)
+    qualifiedName = _typeName(type, qualified: true)
+    unqualifiedName = _typeName(type, qualified: false)
   }
 
   /// Initialize an instance of this type describing the type of the specified
@@ -51,11 +51,11 @@ public struct TypeInfo: Sendable {
 
 extension TypeInfo: CustomStringConvertible, CustomDebugStringConvertible {
   public var description: String {
-    unqualifiedTypeName
+    unqualifiedName
   }
 
   public var debugDescription: String {
-    qualifiedTypeName
+    qualifiedName
   }
 }
 

--- a/Sources/Testing/Parameterization/TypeInfo.swift
+++ b/Sources/Testing/Parameterization/TypeInfo.swift
@@ -32,7 +32,7 @@ public struct TypeInfo: Sendable {
   ///
   /// - Parameters:
   ///   - type: The type which this instance should describe.
-  init(_ type: Any.Type) {
+  init(describing type: Any.Type) {
     qualifiedTypeName = _typeName(type, qualified: true)
     unqualifiedTypeName = _typeName(type, qualified: false)
   }
@@ -43,7 +43,7 @@ public struct TypeInfo: Sendable {
   /// - Parameters:
   ///   - value: The value whose type this instance should describe.
   init(describingTypeOf value: some Any) {
-    self.init(type(of: value as Any))
+    self.init(describing: type(of: value as Any))
   }
 }
 

--- a/Sources/Testing/Parameterization/TypeInfo.swift
+++ b/Sources/Testing/Parameterization/TypeInfo.swift
@@ -1,0 +1,68 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+/// A description of the type of a value encountered during testing or a
+/// parameter of a test function.
+@_spi(ForToolsIntegrationOnly)
+public struct TypeInfo: Sendable {
+  /// The complete name of this type, with the names of all referenced types
+  /// fully-qualified by their module names when possible.
+  public var qualifiedTypeName: String
+
+  /// A simplified name of this type, by leaving the names of all referenced
+  /// types unqualified, i.e. without module name prefixes.
+  public var unqualifiedTypeName: String
+
+  init(
+    qualifiedTypeName: String,
+    unqualifiedTypeName: String
+  ) {
+    self.qualifiedTypeName = qualifiedTypeName
+    self.unqualifiedTypeName = unqualifiedTypeName
+  }
+
+  /// Initialize an instance of this type describing the specified type.
+  ///
+  /// - Parameters:
+  ///   - type: The type which this instance should describe.
+  init(_ type: Any.Type) {
+    qualifiedTypeName = _typeName(type, qualified: true)
+    unqualifiedTypeName = _typeName(type, qualified: false)
+  }
+
+  /// Initialize an instance of this type describing the type of the specified
+  /// value.
+  ///
+  /// - Parameters:
+  ///   - value: The value whose type this instance should describe.
+  init(describingTypeOf value: some Any) {
+    self.init(type(of: value as Any))
+  }
+}
+
+// MARK: - CustomStringConvertible, CustomDebugStringConvertible
+
+extension TypeInfo: CustomStringConvertible, CustomDebugStringConvertible {
+  public var description: String {
+    unqualifiedTypeName
+  }
+
+  public var debugDescription: String {
+    qualifiedTypeName
+  }
+}
+
+// MARK: - Equatable, Hashable
+
+extension TypeInfo: Hashable {}
+
+// MARK: - Codable
+
+extension TypeInfo: Codable {}

--- a/Sources/Testing/SourceAttribution/Expression.swift
+++ b/Sources/Testing/SourceAttribution/Expression.swift
@@ -212,7 +212,7 @@ public struct Expression: Sendable {
     switch kind {
     case let .generic(sourceCode), let .stringLiteral(sourceCode, _):
       result = if includingTypeNames, let runtimeValueTypeInfo {
-        "\(sourceCode): \(runtimeValueTypeInfo.qualifiedTypeName)"
+        "\(sourceCode): \(runtimeValueTypeInfo.qualifiedName)"
       } else {
         sourceCode
       }

--- a/Sources/Testing/SourceAttribution/Expression.swift
+++ b/Sources/Testing/SourceAttribution/Expression.swift
@@ -113,20 +113,19 @@ public struct Expression: Sendable {
   }
 
   /// A description, captured using ``String/init(describingForTest:)``, of
-  /// the runtime value of this subexpression.
+  /// the runtime value of this expression.
   ///
-  /// If the runtime value of this subexpression has not been evaluated, the
-  /// value of this property is `nil`.
+  /// If the runtime value of this expression has not been evaluated, the value
+  /// of this property is `nil`.
   @_spi(ExperimentalSourceCodeCapturing)
   public var runtimeValueDescription: String?
 
-  /// The fully-qualified name of the type of this subexpression's runtime
-  /// value.
+  /// Information about the type of the runtime value of this expression.
   ///
-  /// If the runtime value of this subexpression has not been evaluated, the
+  /// If the runtime value of this expression has not been evaluated, the value
   /// value of this property is `nil`.
-  @_spi(ExperimentalSourceCodeCapturing)
-  public var fullyQualifiedTypeNameOfRuntimeValue: String?
+  @_spi(ForToolsIntegrationOnly)
+  public var runtimeValueTypeInfo: TypeInfo?
 
   /// Copy this instance and capture the runtime value corresponding to it.
   ///
@@ -140,10 +139,10 @@ public struct Expression: Sendable {
 
     if let value {
       result.runtimeValueDescription = String(describingForTest: value)
-      result.fullyQualifiedTypeNameOfRuntimeValue = _typeName(type(of: value as Any), qualified: true)
+      result.runtimeValueTypeInfo = TypeInfo(describingTypeOf: value)
     } else {
       result.runtimeValueDescription = nil
-      result.fullyQualifiedTypeNameOfRuntimeValue = nil
+      result.runtimeValueTypeInfo = nil
     }
 
     return result
@@ -212,8 +211,8 @@ public struct Expression: Sendable {
     var result = ""
     switch kind {
     case let .generic(sourceCode), let .stringLiteral(sourceCode, _):
-      result = if includingTypeNames, let fullyQualifiedTypeNameOfRuntimeValue {
-        "\(sourceCode): \(fullyQualifiedTypeNameOfRuntimeValue)"
+      result = if includingTypeNames, let runtimeValueTypeInfo {
+        "\(sourceCode): \(runtimeValueTypeInfo.qualifiedTypeName)"
       } else {
         sourceCode
       }

--- a/Sources/Testing/Test+Macro.swift
+++ b/Sources/Testing/Test+Macro.swift
@@ -149,7 +149,7 @@ extension Test {
   ///
   /// - Warning: This type alias is used to implement the `@Test` macro. Do not
   ///   use it directly.
-  public typealias __Parameter = (firstName: String, secondName: String?)
+  public typealias __Parameter = (firstName: String, secondName: String?, type: Any.Type)
 
   /// Create an instance of ``Test`` for a function.
   ///
@@ -178,7 +178,7 @@ extension [Test.__Parameter] {
   /// parameter instances from the position of the tuple in the original array.
   fileprivate var parameters: [Test.Parameter] {
     enumerated().map { index, parameter in
-      Test.Parameter(index: index, firstName: parameter.firstName, secondName: parameter.secondName)
+      Test.Parameter(index: index, firstName: parameter.firstName, secondName: parameter.secondName, type: parameter.type)
     }
   }
 }

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -202,6 +202,7 @@ struct TestDeclarationMacroTests {
       ("@Test @_unavailableFromAsync func f() {}", nil, "__requiringTry"),
       ("@Test(arguments: []) func f(i: borrowing Int) {}", nil, "copy"),
       ("@Test(arguments: []) func f(_ i: borrowing Int) {}", nil, "copy"),
+      ("@Test(arguments: []) func f(f: () -> String) {}", "(() -> String).self", nil),
       ("struct S {\n\t@Test func testF() {} }", nil, "__invokeXCTestCaseMethod"),
       ("struct S {\n\t@Test func testF() throws {} }", nil, "__invokeXCTestCaseMethod"),
       ("struct S {\n\t@Test func testF() async {} }", nil, "__invokeXCTestCaseMethod"),

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -361,17 +361,17 @@ final class IssueTests: XCTestCase {
     expression = expression.capturingRuntimeValues(987 as Int)
     XCTAssertEqual(expression.sourceCode, "abc123")
     XCTAssertEqual(expression.runtimeValueDescription, "987")
-    XCTAssertEqual(expression.runtimeValueTypeInfo?.qualifiedTypeName, "Swift.Int")
+    XCTAssertEqual(expression.runtimeValueTypeInfo?.qualifiedName, "Swift.Int")
 
     expression = expression.capturingRuntimeValues(ExpressionValueAndTypeCapture_Value())
     XCTAssertEqual(expression.sourceCode, "abc123")
     XCTAssertEqual(expression.runtimeValueDescription, "ExpressionValueAndTypeCapture_Value()")
-    XCTAssertEqual(expression.runtimeValueTypeInfo?.qualifiedTypeName, "TestingTests.IssueTests.ExpressionValueAndTypeCapture_Value")
+    XCTAssertEqual(expression.runtimeValueTypeInfo?.qualifiedName, "TestingTests.IssueTests.ExpressionValueAndTypeCapture_Value")
 
     expression = expression.capturingRuntimeValues((123, "abc") as (Int, String), ())
     XCTAssertEqual(expression.sourceCode, "abc123")
     XCTAssertEqual(expression.runtimeValueDescription, #"(123, "abc")"#)
-    XCTAssertEqual(expression.runtimeValueTypeInfo?.qualifiedTypeName, "(Swift.Int, Swift.String)")
+    XCTAssertEqual(expression.runtimeValueTypeInfo?.qualifiedName, "(Swift.Int, Swift.String)")
   }
 
   func testIsAndAsComparisons() async {

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalEventHandling) @_spi(ExperimentalTestRunning) @_spi(ExperimentalSnapshotting) @_spi(ExperimentalSourceCodeCapturing) import Testing
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalEventHandling) @_spi(ExperimentalTestRunning) @_spi(ExperimentalSnapshotting) @_spi(ExperimentalSourceCodeCapturing) import Testing
 private import TestingInternals
 
 #if canImport(XCTest)
@@ -356,22 +356,22 @@ final class IssueTests: XCTestCase {
     var expression = Expression.__fromSyntaxNode("abc123")
     XCTAssertEqual(expression.sourceCode, "abc123")
     XCTAssertNil(expression.runtimeValueDescription)
-    XCTAssertNil(expression.fullyQualifiedTypeNameOfRuntimeValue)
+    XCTAssertNil(expression.runtimeValueTypeInfo)
 
     expression = expression.capturingRuntimeValues(987 as Int)
     XCTAssertEqual(expression.sourceCode, "abc123")
     XCTAssertEqual(expression.runtimeValueDescription, "987")
-    XCTAssertEqual(expression.fullyQualifiedTypeNameOfRuntimeValue, "Swift.Int")
+    XCTAssertEqual(expression.runtimeValueTypeInfo?.qualifiedTypeName, "Swift.Int")
 
     expression = expression.capturingRuntimeValues(ExpressionValueAndTypeCapture_Value())
     XCTAssertEqual(expression.sourceCode, "abc123")
     XCTAssertEqual(expression.runtimeValueDescription, "ExpressionValueAndTypeCapture_Value()")
-    XCTAssertEqual(expression.fullyQualifiedTypeNameOfRuntimeValue, "TestingTests.IssueTests.ExpressionValueAndTypeCapture_Value")
+    XCTAssertEqual(expression.runtimeValueTypeInfo?.qualifiedTypeName, "TestingTests.IssueTests.ExpressionValueAndTypeCapture_Value")
 
     expression = expression.capturingRuntimeValues((123, "abc") as (Int, String), ())
     XCTAssertEqual(expression.sourceCode, "abc123")
     XCTAssertEqual(expression.runtimeValueDescription, #"(123, "abc")"#)
-    XCTAssertEqual(expression.fullyQualifiedTypeNameOfRuntimeValue, "(Swift.Int, Swift.String)")
+    XCTAssertEqual(expression.runtimeValueTypeInfo?.qualifiedTypeName, "(Swift.Int, Swift.String)")
   }
 
   func testIsAndAsComparisons() async {

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalParameterizedTesting) @_spi(ExperimentalTestRunning) import Testing
+@testable @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalParameterizedTesting) @_spi(ExperimentalTestRunning) import Testing
 
 @Test(/* name unspecified */ .hidden)
 @Sendable func freeSyncFunction() {}
@@ -43,6 +43,7 @@ struct TestWithPrecedingAttribute {
 private enum FixtureData {
   static let zeroUpTo100 = 0 ..< 100
   static let smallStringArray = ["a", "b", "c", "d"]
+  static let stringReturningClosureArray = [{ @Sendable in "" }]
 }
 
 @Suite(.hidden)
@@ -100,6 +101,9 @@ struct SendableTests: Sendable {
 
   @Test(.hidden, arguments: FixtureData.zeroUpTo100)
   func parameterizedConsumingAsync(i: consuming Int) async { }
+
+  @Test(.hidden, arguments: FixtureData.stringReturningClosureArray)
+  func parameterizedAcceptingFunction(f: @Sendable () -> String) {}
 }
 
 @Suite("Named Sendable test type", .hidden)
@@ -330,6 +334,9 @@ struct MiscellaneousTests {
       #expect(firstParameter.index == 0)
       #expect(firstParameter.firstName == "i")
       #expect(firstParameter.secondName == nil)
+      let firstParameterTypeInfo = try #require(firstParameter.typeInfo)
+      #expect(firstParameterTypeInfo.qualifiedTypeName == "Swift.Int")
+      #expect(firstParameterTypeInfo.unqualifiedTypeName == "Int")
     } catch {}
 
     do {
@@ -344,6 +351,9 @@ struct MiscellaneousTests {
       #expect(secondParameter.index == 1)
       #expect(secondParameter.firstName == "j")
       #expect(secondParameter.secondName == "k")
+      let secondParameterTypeInfo = try #require(secondParameter.typeInfo)
+      #expect(secondParameterTypeInfo.qualifiedTypeName == "Swift.String")
+      #expect(secondParameterTypeInfo.unqualifiedTypeName == "String")
     } catch {}
   }
 
@@ -404,7 +414,7 @@ struct MiscellaneousTests {
     let monomorphicTestFunctionParameters = try #require(monomorphicTestFunction.parameters)
     #expect(monomorphicTestFunctionParameters.isEmpty)
 
-    let parameterizedTestFunction = Test(arguments: 0 ..< 100, parameters: [Test.Parameter(index: 0, firstName: "i")]) { _ in }
+    let parameterizedTestFunction = Test(arguments: 0 ..< 100, parameters: [Test.Parameter(index: 0, firstName: "i", type: Int.self)]) { _ in }
     #expect(parameterizedTestFunction.isParameterized)
     let parameterizedTestFunctionTestCases = try #require(parameterizedTestFunction.testCases)
     #expect(parameterizedTestFunctionTestCases.underestimatedCount == 100)
@@ -414,8 +424,8 @@ struct MiscellaneousTests {
     #expect(parameterizedTestFunctionFirstParameter.firstName == "i")
 
     let parameterizedTestFunction2 = Test(arguments: 0 ..< 100, 0 ..< 100, parameters: [
-      Test.Parameter(index: 0, firstName: "i"),
-      Test.Parameter(index: 1, firstName: "j", secondName: "value"),
+      Test.Parameter(index: 0, firstName: "i", type: Int.self),
+      Test.Parameter(index: 1, firstName: "j", secondName: "value", type: Int.self),
     ]) { _, _ in }
     #expect(parameterizedTestFunction2.isParameterized)
     let parameterizedTestFunction2TestCases = try #require(parameterizedTestFunction2.testCases)

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -335,8 +335,8 @@ struct MiscellaneousTests {
       #expect(firstParameter.firstName == "i")
       #expect(firstParameter.secondName == nil)
       let firstParameterTypeInfo = try #require(firstParameter.typeInfo)
-      #expect(firstParameterTypeInfo.qualifiedTypeName == "Swift.Int")
-      #expect(firstParameterTypeInfo.unqualifiedTypeName == "Int")
+      #expect(firstParameterTypeInfo.qualifiedName == "Swift.Int")
+      #expect(firstParameterTypeInfo.unqualifiedName == "Int")
     } catch {}
 
     do {
@@ -352,8 +352,8 @@ struct MiscellaneousTests {
       #expect(secondParameter.firstName == "j")
       #expect(secondParameter.secondName == "k")
       let secondParameterTypeInfo = try #require(secondParameter.typeInfo)
-      #expect(secondParameterTypeInfo.qualifiedTypeName == "Swift.String")
-      #expect(secondParameterTypeInfo.unqualifiedTypeName == "String")
+      #expect(secondParameterTypeInfo.qualifiedName == "Swift.String")
+      #expect(secondParameterTypeInfo.unqualifiedName == "String")
     } catch {}
   }
 

--- a/Tests/TestingTests/Test.Case.Argument.IDTests.swift
+++ b/Tests/TestingTests/Test.Case.Argument.IDTests.swift
@@ -19,7 +19,7 @@ struct Test_Case_Argument_IDTests {
   func oneCodableParameter() async throws {
     let test = Test(
       arguments: [123],
-      parameters: [Test.Parameter(index: 0, firstName: "value")]
+      parameters: [Test.Parameter(index: 0, firstName: "value", type: Int.self)]
     ) { _ in }
     let testCases = try #require(test.testCases)
     let testCase = try #require(testCases.first { _ in true })
@@ -33,7 +33,7 @@ struct Test_Case_Argument_IDTests {
   func oneCustomParameter() async throws {
     let test = Test(
       arguments: [MyCustomTestArgument(x: 123, y: "abc")],
-      parameters: [Test.Parameter(index: 0, firstName: "value")]
+      parameters: [Test.Parameter(index: 0, firstName: "value", type: MyCustomTestArgument.self)]
     ) { _ in }
     let testCases = try #require(test.testCases)
     let testCase = try #require(testCases.first { _ in true })
@@ -50,7 +50,7 @@ struct Test_Case_Argument_IDTests {
   func oneIdentifiableParameter() async throws {
     let test = Test(
       arguments: [MyIdentifiableArgument(id: "abc")],
-      parameters: [Test.Parameter(index: 0, firstName: "value")]
+      parameters: [Test.Parameter(index: 0, firstName: "value", type: MyIdentifiableArgument.self)]
     ) { _ in }
     let testCases = try #require(test.testCases)
     let testCase = try #require(testCases.first { _ in true })
@@ -64,7 +64,7 @@ struct Test_Case_Argument_IDTests {
   func oneRawRepresentableParameter() async throws {
     let test = Test(
       arguments: [MyRawRepresentableArgument(rawValue: "abc")],
-      parameters: [Test.Parameter(index: 0, firstName: "value")]
+      parameters: [Test.Parameter(index: 0, firstName: "value", type: MyRawRepresentableArgument.self)]
     ) { _ in }
     let testCases = try #require(test.testCases)
     let testCase = try #require(testCases.first { _ in true })

--- a/Tests/TestingTests/Test.Case.ArgumentTests.swift
+++ b/Tests/TestingTests/Test.Case.ArgumentTests.swift
@@ -141,8 +141,8 @@ struct Test_Case_ArgumentTests {
       #expect(value.1 == 123)
       #expect(argument.parameter.index == 0)
       #expect(argument.parameter.firstName == "x")
-      #expect(argument.parameter.typeInfo.qualifiedTypeName == "(key: Swift.String, value: Swift.Int)")
-      #expect(argument.parameter.typeInfo.unqualifiedTypeName == "(key: String, value: Int)")
+      #expect(argument.parameter.typeInfo.qualifiedName == "(key: Swift.String, value: Swift.Int)")
+      #expect(argument.parameter.typeInfo.unqualifiedName == "(key: String, value: Int)")
     }
 
     await runTestFunction(named: "oneDictionaryElementTupleParameter(x:)", in: ParameterizedTests.self, configuration: configuration)

--- a/Tests/TestingTests/Test.Case.ArgumentTests.swift
+++ b/Tests/TestingTests/Test.Case.ArgumentTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) import Testing
+@testable @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) import Testing
 
 @Suite("Test.Case.Argument Tests")
 struct Test_Case_ArgumentTests {
@@ -141,6 +141,8 @@ struct Test_Case_ArgumentTests {
       #expect(value.1 == 123)
       #expect(argument.parameter.index == 0)
       #expect(argument.parameter.firstName == "x")
+      #expect(argument.parameter.typeInfo.qualifiedTypeName == "(key: Swift.String, value: Swift.Int)")
+      #expect(argument.parameter.typeInfo.unqualifiedTypeName == "(key: String, value: Int)")
     }
 
     await runTestFunction(named: "oneDictionaryElementTupleParameter(x:)", in: ParameterizedTests.self, configuration: configuration)

--- a/Tests/TestingTests/TestCaseSelectionTests.swift
+++ b/Tests/TestingTests/TestCaseSelectionTests.swift
@@ -14,7 +14,7 @@
 struct TestCaseSelectionTests {
   @Test("Multiple arguments passed to one parameter, selecting one case")
   func oneParameterSelectingOneCase() async throws {
-    let fixtureTest = Test(arguments: ["a", "b"], parameters: [Test.Parameter(index: 0, firstName: "value")]) { value in
+    let fixtureTest = Test(arguments: ["a", "b"], parameters: [Test.Parameter(index: 0, firstName: "value", type: String.self)]) { value in
       #expect(value == "a")
     }
 
@@ -41,7 +41,7 @@ struct TestCaseSelectionTests {
 
   @Test("Multiple arguments passed to one parameter, selecting a subset of cases")
   func oneParameterSelectingMultipleCases() async throws {
-    let fixtureTest = Test(arguments: ["a", "b", "c"], parameters: [Test.Parameter(index: 0, firstName: "value")]) { value in
+    let fixtureTest = Test(arguments: ["a", "b", "c"], parameters: [Test.Parameter(index: 0, firstName: "value", type: String.self)]) { value in
       #expect(value != "b")
     }
 
@@ -77,8 +77,8 @@ struct TestCaseSelectionTests {
     let fixtureTest = Test(
       arguments: ["a", "b"], [1, 2],
       parameters: [
-        Test.Parameter(index: 0, firstName: "stringValue"),
-        Test.Parameter(index: 1, firstName: "intValue"),
+        Test.Parameter(index: 0, firstName: "stringValue", type: String.self),
+        Test.Parameter(index: 1, firstName: "intValue", type: Int.self),
       ]
     ) { stringValue, intValue in
       #expect(stringValue == "b" && intValue == 2)
@@ -117,7 +117,7 @@ struct TestCaseSelectionTests {
     let fixtureTest = Test(arguments: [
       MyCustomTestArgument(x: 1, y: "a"),
       MyCustomTestArgument(x: 2, y: "b"),
-    ], parameters: [Test.Parameter(index: 0, firstName: "value")]) { arg in
+    ], parameters: [Test.Parameter(index: 0, firstName: "value", type: MyCustomTestArgument.self)]) { arg in
       #expect(arg.x == 1 && arg.y == "a")
     }
 
@@ -147,7 +147,7 @@ struct TestCaseSelectionTests {
     let fixtureTest = Test(arguments: [
       MyCustomIdentifiableArgument(id: "a"),
       MyCustomIdentifiableArgument(id: "b"),
-    ], parameters: [Test.Parameter(index: 0, firstName: "value")]) { arg in
+    ], parameters: [Test.Parameter(index: 0, firstName: "value", type: MyCustomIdentifiableArgument.self)]) { arg in
       #expect(arg.id == "a")
     }
 
@@ -177,7 +177,7 @@ struct TestCaseSelectionTests {
     let fixtureTest = Test(arguments: [
       MyCustomRawRepresentableArgument(rawValue: "a"),
       MyCustomRawRepresentableArgument(rawValue: "b"),
-    ], parameters: [Test.Parameter(index: 0, firstName: "value")]) { arg in
+    ], parameters: [Test.Parameter(index: 0, firstName: "value", type: MyCustomRawRepresentableArgument.self)]) { arg in
       #expect(arg.rawValue == "a")
     }
 

--- a/Tests/TestingTests/TypeInfoTests.swift
+++ b/Tests/TestingTests/TypeInfoTests.swift
@@ -1,0 +1,41 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable @_spi(ForToolsIntegrationOnly) import Testing
+
+@Suite("TypeInfo Tests")
+struct TypeInfoTests {
+  @Test(arguments: [
+    (
+      String.self,
+      TypeInfo(qualifiedTypeName: "Swift.String", unqualifiedTypeName: "String")
+    ),
+    (
+      [String].self,
+      TypeInfo(qualifiedTypeName: "Swift.Array<Swift.String>", unqualifiedTypeName: "Array<String>")
+    ),
+    (
+      [Test].self,
+      TypeInfo(qualifiedTypeName: "Swift.Array<Testing.Test>", unqualifiedTypeName: "Array<Test>")
+    ),
+    (
+      (key: String, value: Int).self,
+      TypeInfo(qualifiedTypeName: "(key: Swift.String, value: Swift.Int)", unqualifiedTypeName: "(key: String, value: Int)")
+    ),
+    (
+      (() -> String).self,
+      TypeInfo(qualifiedTypeName: "() -> Swift.String", unqualifiedTypeName: "() -> String")
+    ),
+  ] as [(Any.Type, TypeInfo)])
+  func initWithType(type: Any.Type, expectedTypeInfo: TypeInfo) {
+    let typeInfo = TypeInfo(type)
+    #expect(typeInfo == expectedTypeInfo)
+  }
+}

--- a/Tests/TestingTests/TypeInfoTests.swift
+++ b/Tests/TestingTests/TypeInfoTests.swift
@@ -35,7 +35,7 @@ struct TypeInfoTests {
     ),
   ] as [(Any.Type, TypeInfo)])
   func initWithType(type: Any.Type, expectedTypeInfo: TypeInfo) {
-    let typeInfo = TypeInfo(type)
+    let typeInfo = TypeInfo(describing: type)
     #expect(typeInfo == expectedTypeInfo)
   }
 }

--- a/Tests/TestingTests/TypeInfoTests.swift
+++ b/Tests/TestingTests/TypeInfoTests.swift
@@ -15,23 +15,23 @@ struct TypeInfoTests {
   @Test(arguments: [
     (
       String.self,
-      TypeInfo(qualifiedTypeName: "Swift.String", unqualifiedTypeName: "String")
+      TypeInfo(qualifiedName: "Swift.String", unqualifiedName: "String")
     ),
     (
       [String].self,
-      TypeInfo(qualifiedTypeName: "Swift.Array<Swift.String>", unqualifiedTypeName: "Array<String>")
+      TypeInfo(qualifiedName: "Swift.Array<Swift.String>", unqualifiedName: "Array<String>")
     ),
     (
       [Test].self,
-      TypeInfo(qualifiedTypeName: "Swift.Array<Testing.Test>", unqualifiedTypeName: "Array<Test>")
+      TypeInfo(qualifiedName: "Swift.Array<Testing.Test>", unqualifiedName: "Array<Test>")
     ),
     (
       (key: String, value: Int).self,
-      TypeInfo(qualifiedTypeName: "(key: Swift.String, value: Swift.Int)", unqualifiedTypeName: "(key: String, value: Int)")
+      TypeInfo(qualifiedName: "(key: Swift.String, value: Swift.Int)", unqualifiedName: "(key: String, value: Int)")
     ),
     (
       (() -> String).self,
-      TypeInfo(qualifiedTypeName: "() -> Swift.String", unqualifiedTypeName: "() -> String")
+      TypeInfo(qualifiedName: "() -> Swift.String", unqualifiedName: "() -> String")
     ),
   ] as [(Any.Type, TypeInfo)])
   func initWithType(type: Any.Type, expectedTypeInfo: TypeInfo) {


### PR DESCRIPTION
This adds support for collecting and representing type information for parameters of test functions which have them, and runtime arguments passed to them.

### Motivation:

When examining test results, it's not always obvious what the type of an argument to a parameterized test function was. A string description of the value is captured and included in results, but this does not always explicitly indicate a value's type. This PR includes support for capturing a representation of a type, in both qualified and unqualified formats, so that tools can display this and provide more detailed and actionable results.

### Modifications:

- Add a new type `TypeInfo`, currently SPI, which provides information about a type.
- Expose an instance of `TypeInfo` from `Test.Case.Argument.Snapshot`, `Test.Parameter`, and `Expression`.
- Enhance the `@Test` macro to include the type of a function parameter.
- Include the qualified representation of each argument's type when `--verbose` mode is enabled in `HumanReadableOutputRecorder`.
- Add and adjust unit tests.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Resolves rdar://119614405
