### PR TITLE
Add an SPI interface for excluding tests when running.

### DIFF
--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -255,5 +255,17 @@ public struct Configuration: Sendable {
 @_spi(ExperimentalTestRunning)
 public func makeTestFilter(matching selection: some Collection<Test.ID>) -> Configuration.TestFilter {
   let selection = Test.ID.Selection(testIDs: selection)
-  return selection.contains
+  return { selection.contains($0) }
+}
+
+/// Make a test filter that excludes certain tests based on their IDs.
+///
+/// - Parameters:
+///   - selection: A set of test IDs to be excluded.
+///
+/// - Returns: A test filter that excludes tests based on `selection`.
+@_spi(ExperimentalTestRunning)
+public func makeTestFilter(excluding selection: some Collection<Test.ID>) -> Configuration.TestFilter {
+  let selection = Test.ID.Selection(testIDs: selection)
+  return { !selection.contains($0, inferAncestors: false) }
 }

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -82,6 +82,9 @@ struct SendableTests: Sendable {
   struct NestedSendableTests: Sendable {
     @Test(.hidden)
     func succeeds() throws {}
+
+    @Test(.hidden)
+    func otherSucceeds() throws {}
   }
 
   @Test(.hidden, arguments: FixtureData.zeroUpTo100)

--- a/Tests/TestingTests/Test.ID.SelectionTests.swift
+++ b/Tests/TestingTests/Test.ID.SelectionTests.swift
@@ -95,4 +95,19 @@ struct Test_ID_SelectionTests {
     #expect(selection.contains(["A", "X", "Y"]))
     #expect(!selection.contains(["X"]))
   }
+
+  @Test("Inverted lookup")
+  func invertedLookup() {
+    let selection = Test.ID.Selection(testIDs: [["A", "B", "C", "D", "E"], ["A", "B", "C"]])
+    #expect(!selection.contains(["A"], inferAncestors: false))
+    #expect(!selection.contains(["A", "B"], inferAncestors: false))
+    #expect(!selection.contains(["A", "B", "J"], inferAncestors: false))
+    #expect(selection.contains(["A", "B", "C"], inferAncestors: false))
+    #expect(selection.contains(["A", "B", "C", "D"], inferAncestors: false))
+    #expect(selection.contains(["A", "B", "C", "D", "E"], inferAncestors: false))
+    #expect(selection.contains(["A", "B", "C", "D", "E", "F"], inferAncestors: false))
+    #expect(!selection.contains(["A", "X"], inferAncestors: false))
+    #expect(!selection.contains(["A", "X", "Y"], inferAncestors: false))
+    #expect(!selection.contains(["X"], inferAncestors: false))
+  }
 }


### PR DESCRIPTION
We have an interface for filtering tests so only a selection of them run. This PR adds an equivalent, yet inverted, interface for excluding tests that should _not_ run.

Resolves rdar://123389027.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
