### PR TITLE
Fix typo in AddingTags document

### DIFF
--- a/Sources/Testing/Testing.docc/AddingTags.md
+++ b/Sources/Testing/Testing.docc/AddingTags.md
@@ -77,7 +77,7 @@ be set to:
 
 ```json
 {
-  "critical": "red",
+  "critical": "orange",
   ".legallyRequired": "#66FFCC"
 }
 ```


### PR DESCRIPTION
I have fixed a value in json file because it was not consistent with the previous sentence.
> For example, to set the color of the tag `"critical"` to orange