### PR TITLE
Guard the use of `FILE *` in C++ with the `SWT_NO_FILE_IO` condition.

### DIFF
--- a/Sources/TestingInternals/include/Stubs.h
+++ b/Sources/TestingInternals/include/Stubs.h
@@ -16,6 +16,7 @@
 
 SWT_ASSUME_NONNULL_BEGIN
 
+#if !SWT_NO_FILE_IO
 /// The C file handle type.
 ///
 /// This typedef is necessary because `FILE *` may be imported into Swift as
@@ -31,6 +32,7 @@ typedef FILE *SWT_FILEHandle;
 static SWT_FILEHandle swt_stderr(void) {
   return stderr;
 }
+#endif
 
 /// Get the current C error.
 ///
@@ -40,6 +42,7 @@ static int swt_errno(void) {
   return errno;
 }
 
+#if !SWT_NO_FILE_IO
 #if __has_include(<sys/stat.h>) && defined(S_ISFIFO)
 /// Check if a given `mode_t` value indicates that a file is a pipe (FIFO.)
 ///
@@ -49,6 +52,7 @@ static int swt_errno(void) {
 static bool swt_S_ISFIFO(mode_t mode) {
   return S_ISFIFO(mode);
 }
+#endif
 #endif
 
 SWT_ASSUME_NONNULL_END


### PR DESCRIPTION
This PR just uses the same `SWT_NO_FILE_IO` condition to guard uses of `FILE *` in our C++ internal target. This will aid porting to embedded platforms that do not support standard C I/O.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
