### PR TITLE
Ensure that type names used in extensions are correctly parsed.

### DIFF
--- a/Sources/Testing/Parameterization/TypeInfo.swift
+++ b/Sources/Testing/Parameterization/TypeInfo.swift
@@ -33,8 +33,8 @@ public struct TypeInfo: Sendable {
   /// - Parameters:
   ///   - type: The type which this instance should describe.
   init(describing type: Any.Type) {
-    qualifiedName = _typeName(type, qualified: true)
-    unqualifiedName = _typeName(type, qualified: false)
+    qualifiedName = fullyQualifiedName(of: type)
+    unqualifiedName = String(describing: type)
   }
 
   /// Initialize an instance of this type describing the type of the specified

--- a/Sources/Testing/Support/Additions/TypeAdditions.swift
+++ b/Sources/Testing/Support/Additions/TypeAdditions.swift
@@ -16,9 +16,30 @@
 /// - Returns: The components of `type`'s fully-qualified name. For example, if
 ///   `type` is named `Example.MyClass`, the result is `["Example", "MyClass"]`.
 func nameComponents(of type: Any.Type) -> [String] {
-  _typeName(type, qualified: true)
+  var result = _typeName(type, qualified: true)
     .split(separator: ".")
     .map(String.init)
+
+  // If a type is extended in another module and then referenced by name, its
+  // name according to the _typeName(_:qualified:) SPI will be prefixed with
+  // "(extension in MODULE_NAME):". For our purposes, we never want to preserve
+  // that prefix.
+  if let firstComponent = result.first, firstComponent.starts(with: "(extension in ") {
+    result[0] = String(firstComponent.split(separator: ":", maxSplits: 1).last!)
+  }
+
+  return result
+}
+
+/// Get the fully-qualified name of a type.
+///
+/// - Parameters:
+///   - type: The type whose fully-qualified name should be returned.
+///
+/// - Returns: The fully-qualified name of `type`. For example, if `type` is
+///   named `Example.MyClass`, the result is `"Example.MyClass"`.
+func fullyQualifiedName(of type: Any.Type) -> String {
+  nameComponents(of: type).joined(separator: ".")
 }
 
 /// Check if a type is a Swift `enum` type.

--- a/Sources/Testing/Test+Macro.swift
+++ b/Sources/Testing/Test+Macro.swift
@@ -110,7 +110,7 @@ extension Test {
     traits: [any SuiteTrait],
     sourceLocation: SourceLocation
   ) -> Self {
-    let typeName = _typeName(containingType, qualified: false)
+    let typeName = String(describing: containingType)
     return Self(name: typeName, displayName: displayName, traits: traits, sourceLocation: sourceLocation, containingType: containingType)
   }
 }

--- a/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
+++ b/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
@@ -186,7 +186,7 @@ struct TimeLimitTraitTests {
         taskGroup.cancelAll()
       }
     }
-    #expect(timeAwaited < .seconds(1))
+    #expect(timeAwaited < .seconds(5)) // less than the 60 second sleep
   }
 
   @available(_clockAPI, *)

--- a/Tests/TestingTests/TypeInfoTests.swift
+++ b/Tests/TestingTests/TypeInfoTests.swift
@@ -38,4 +38,20 @@ struct TypeInfoTests {
     let typeInfo = TypeInfo(describing: type)
     #expect(typeInfo == expectedTypeInfo)
   }
+
+  @Test func typeNameInExtensionIsMungedCorrectly() {
+    #expect(_typeName(String.NestedType.self, qualified: true) == "(extension in TestingTests):Swift.String.NestedType")
+    #expect(fullyQualifiedName(of: String.NestedType.self) == "Swift.String.NestedType")
+  }
+
+  @Test func typeNameOfFunctionIsMungedCorrectly() {
+    typealias T = (Int, String) -> Bool
+    #expect(fullyQualifiedName(of: T.self) == "(Swift.Int, Swift.String) -> Swift.Bool")
+  }
+}
+
+// MARK: - Fixtures
+
+extension String {
+  enum NestedType {}
 }


### PR DESCRIPTION
We use the internal runtime function `_typeName(_:qualified:)` to get fully qualified type names in a few places. If a type is referenced from an extension to that type in another module, the resulting string is prefixed with something like `"(extension in OtherModule):"` which messes with test plan graphing and our general expectations about the names of types.

This PR normalizes how we get fully-qualified type names so that we always go through a particular function that is aware of this prefix and knows how to remove it.

The extra string is emitted [here](https://github.com/apple/swift/blob/b0f3338d255d1d19ae0feedef132f1da4b5d5c11/lib/Demangling/NodePrinter.cpp#L1474) by the demangler.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
