### PR TITLE
Rename `Package@swift-5.11.swift` to `Package@swift-6.0.swift`

### DIFF
--- a/Documentation/Releases.md
+++ b/Documentation/Releases.md
@@ -40,7 +40,7 @@ git checkout -b release/x.y.z
 
 ## Preparing the repository's contents
 
-The package manifest files (Package.swift _and_ Package@swift-5.11.swift) must
+The package manifest files (Package.swift _and_ Package@swift-6.0.swift) must
 be updated so that the release can be used as a package dependency:
 
 1. Take note of any availability definitions (passed to the Swift compiler with

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.11
+// swift-tools-version: 6.0
 
 //
 // This source file is part of the Swift.org open source project


### PR DESCRIPTION
### Motivation:

This package currently can't be built with `main` branch of SwiftPM, since version 5.11 no longer exists.

### Modifications:

 The package manifest should refer to 6.0 instead.

### Result:

This package can be built with Swift 6.0.
