### PR TITLE
Fix a stray warning in a test.

### DIFF
--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -94,7 +94,6 @@ struct SwiftPMTests {
   @available(_regexAPI, *)
   func filterAndSkipAndHidden() async throws {
     let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--filter", "hello", "--skip", "hello2"])
-    let testFilter = try #require(configuration.testFilter)
     let test1 = Test(name: "hello") {}
     let test2 = Test(name: "hello2") {}
     let test3 = Test(.hidden, name: "hello") {}


### PR DESCRIPTION
Fix a (harmless) warning introduced in #231.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
