### PR TITLE
Remove a stray `print()` in a test.

### DIFF
--- a/Tests/TestingTests/PlanTests.swift
+++ b/Tests/TestingTests/PlanTests.swift
@@ -240,7 +240,6 @@ struct PlanTests {
     filter.includeHiddenTests = true
     filter.combine(with: Configuration.TestFilter(excluding: [testC.id]))
     configuration.testFilter = filter
-    print(configuration.testFilter.includeHiddenTests)
 
     let plan = await Runner.Plan(tests: tests, configuration: configuration)
     let planTests = plan.steps.map(\.test)


### PR DESCRIPTION
Left a `print()` call in from #231. Oops.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
