### PR TITLE
Avoid direct calls to `fwrite()` and `fputs()`.

### DIFF
--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -53,10 +53,7 @@ private import TestingInternals
     }
   } catch {
 #if !SWT_NO_FILE_IO
-    FileHandle.stderr.withUnsafeCFILEHandle { stderr in
-      fputs(String(describing: error), stderr)
-      fflush(stderr)
-    }
+    try? FileHandle.stderr.write(String(describing: error))
 #endif
 
     exitCode.withLock { exitCode in
@@ -156,10 +153,7 @@ func configurationForSwiftPMEntryPoint(withArguments args: [String]) throws -> C
 
     // Set up the XML recorder.
     let xmlRecorder = Event.JUnitXMLRecorder { string in
-      file.withUnsafeCFILEHandle { file in
-        fputs(string, file)
-        fflush(file)
-      }
+      try? file.write(string)
     }
 
     let oldEventHandler = configuration.eventHandler
@@ -242,10 +236,7 @@ func configurationForSwiftPMEntryPoint(withArguments args: [String]) throws -> C
 func runTests(options: [Event.ConsoleOutputRecorder.Option], configuration: Configuration) async {
   let eventRecorder = Event.ConsoleOutputRecorder(options: options) { string in
 #if !SWT_NO_FILE_IO
-    FileHandle.stderr.withUnsafeCFILEHandle { stderr in
-      fputs(string, stderr)
-      fflush(stderr)
-    }
+    try? FileHandle.stderr.write(string)
 #endif
   }
 

--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -140,10 +140,7 @@ public enum XCTestScaffold: Sendable {
       options: .for(.stderr)
     )
 #if SWT_TARGET_OS_APPLE
-    FileHandle.stderr.withUnsafeCFILEHandle { stderr in
-      fputs(message, stderr)
-      fflush(stderr)
-    }
+    try? FileHandle.stderr.write(message)
 #else
     print(message)
 #endif

--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -177,7 +177,7 @@ extension FileHandle {
   ///
   /// - Parameters:
   ///   - string: The string to write.
-  ///   - flushAfterward: Whether or not to flush the file (with `fflush()`
+  ///   - flushAfterward: Whether or not to flush the file (with `fflush()`)
   ///     after writing. If `true`, `fflush()` is called even if an error
   ///     occurred while writing.
   ///

--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -170,6 +170,39 @@ struct FileHandle: ~Copyable, Sendable {
 #endif
 }
 
+// MARK: - Writing
+
+extension FileHandle {
+  /// Write a string to this file handle.
+  ///
+  /// - Parameters:
+  ///   - string: The string to write.
+  ///   - flushAfterward: Whether or not to flush the file (with `fflush()`
+  ///     after writing. If `true`, `fflush()` is called even if an error
+  ///     occurred while writing.
+  ///
+  /// - Throws: Any error that occurred while writing `string`. If an error
+  ///   occurs while flushing the file, it is not thrown.
+  ///
+  /// `string` is converted to a UTF-8 C string (UTF-16 on Windows) and written
+  /// to this file handle.
+  func write(_ string: String, flushAfterward: Bool = true) throws {
+    try withUnsafeCFILEHandle { file in
+      defer {
+        if flushAfterward {
+          _ = fflush(file)
+        }
+      }
+
+      try string.withCString { string in
+        if EOF == fputs(string, file) {
+          throw CError(rawValue: swt_errno())
+        }
+      }
+    }
+  }
+}
+
 // MARK: - Attributes
 
 extension FileHandle {


### PR DESCRIPTION
This PR was originally going to resolve what looked like a bug on Windows re: Unicode support, but testing shows that it actually isn't needed. However, the overall code changes make `FileHandle` a bit nicer/less-redundant to use, so I'm opening a PR with them anyway. 🚀

~~Ensure terminal output on Windows is interpreted as Unicode.~~

~~Right now, we use `fputs()` to write to `stderr` on all platforms. On Linux and Darwin, this is fine because we can generally assume terminals use UTF-8 there (technically this is an unsafe assumption, but in practice it hasn't been an issue.)~~

~~On Windows, the console may not be configured with the UTF-8 pseudo-codepage (65001) and may instead still be using a locale-specific codepage like Latin-1 (1252).~~

~~Microsoft specifically [recommends](https://learn.microsoft.com/en-us/windows/console/console-code-pages) using the `"w"` functions when reading from or writing to the console. By doing so, we can ensure our output is correctly interpreted as Unicode.~~

~~Microsoft also [documents](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fputs-fputws?view=msvc-170) that `fputs()` doesn't work with streams opened as Unicode, but `fputws()` works with ANSI and Unicode streams, so that's another reason to switch.~~

_[One line description of your change]_

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
