### PR TITLE
Fix a couple of typos in `invalidTagExpressions(input:)`.

### DIFF
--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -261,7 +261,7 @@ struct TestDeclarationMacroTests {
     #expect(!output.contains("displayName:"))
   }
 
-  @Test("Invalid tag expressions are allowed",
+  @Test("Valid tag expressions are allowed",
     arguments: [
       #"@Test(.tags(.f)) func f() {}"#,
       #"@Test(Tag.List.tags(.f)) func f() {}"#,
@@ -271,12 +271,11 @@ struct TestDeclarationMacroTests {
       #"@Test(Testing.Tag.List.tags("abc")) func f() {}"#,
       #"@Test(.tags(Tag.f)) func f() {}"#,
       #"@Test(.tags(Testing.Tag.f)) func f() {}"#,
-      #"@Test(.tags(Tag.f)) func f() {}"#,
       #"@Test(.tags(.Foo.Bar.f)) func f() {}"#,
       #"@Test(.tags(Testing.Tag.Foo.Bar.f)) func f() {}"#,
     ]
   )
-  func invalidTagExpressions(input: String) throws {
+  func validTagExpressions(input: String) throws {
     let (_, diagnostics) = try parse(input)
 
     #expect(diagnostics.isEmpty)


### PR DESCRIPTION
Fix a couple of typos in `invalidTagExpressions(input:)`. And rename it.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
