### PR TITLE
`swift test --list` should write to `stdout` rather than calling `print()`.

### DIFF
--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -27,7 +27,11 @@ private import TestingInternals
     let args = CommandLine.arguments()
     if args.count == 2 && args[1] == "--list-tests" {
       for testID in await listTestsForSwiftPM(Test.all) {
+#if SWT_TARGET_OS_APPLE && !SWT_NO_FILE_IO
+        try? FileHandle.stdout.write("\(testID)\n")
+#else
         print(testID)
+#endif
       }
     } else {
       var configuration = try configurationForSwiftPMEntryPoint(withArguments: args)

--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -139,7 +139,7 @@ public enum XCTestScaffold: Sendable {
       "This version of Swift Package Manager supports running swift-testing tests directly. Ignoring call to \(#function).",
       options: .for(.stderr)
     )
-#if SWT_TARGET_OS_APPLE
+#if SWT_TARGET_OS_APPLE && !SWT_NO_FILE_IO
     try? FileHandle.stderr.write(message)
 #else
     print(message)

--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -28,6 +28,14 @@ struct FileHandle: ~Copyable, Sendable {
   /// Whether or not to close `_fileHandle` when this instance is deinitialized.
   private var _closeWhenDone: Bool
 
+  /// The C standard output stream.
+  static var stdout: Self {
+    // The value of stdout might change over time on some platforms, so this
+    // property needs to be computed each time. Fortunately, creating a new
+    // instance of this type from an existing C file handle is cheap.
+    Self(unsafeCFILEHandle: swt_stdout(), closeWhenDone: false)
+  }
+
   /// The C standard error stream.
   static var stderr: Self {
     // The value of stderr might change over time on some platforms, so this

--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -28,19 +28,17 @@ struct FileHandle: ~Copyable, Sendable {
   /// Whether or not to close `_fileHandle` when this instance is deinitialized.
   private var _closeWhenDone: Bool
 
+  // The value of stdout or stderr might change over time on some platforms, so
+  // these properties need to be computed each time. Fortunately, creating a new
+  // instance of this type from an existing C file handle is cheap.
+
   /// The C standard output stream.
   static var stdout: Self {
-    // The value of stdout might change over time on some platforms, so this
-    // property needs to be computed each time. Fortunately, creating a new
-    // instance of this type from an existing C file handle is cheap.
     Self(unsafeCFILEHandle: swt_stdout(), closeWhenDone: false)
   }
 
   /// The C standard error stream.
   static var stderr: Self {
-    // The value of stderr might change over time on some platforms, so this
-    // property needs to be computed each time. Fortunately, creating a new
-    // instance of this type from an existing C file handle is cheap.
     Self(unsafeCFILEHandle: swt_stderr(), closeWhenDone: false)
   }
 

--- a/Sources/TestingInternals/include/Stubs.h
+++ b/Sources/TestingInternals/include/Stubs.h
@@ -24,6 +24,15 @@ SWT_ASSUME_NONNULL_BEGIN
 /// current platform.
 typedef FILE *SWT_FILEHandle;
 
+/// Get the standard output stream.
+///
+/// This function is provided because directly accessing `stdout` from Swift
+/// triggers concurrency warnings on some platforms about accessing shared
+/// mutable state.
+static SWT_FILEHandle swt_stdout(void) {
+  return stdout;
+}
+
 /// Get the standard error stream.
 ///
 /// This function is provided because directly accessing `stderr` from Swift

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -17,6 +17,25 @@ private import TestingInternals
 #if os(macOS) || os(Linux) || os(Windows)
 @Suite("FileHandle Tests")
 struct FileHandleTests {
+  // FileHandle is non-copyable, so it cannot yet be used as a test parameter.
+  func canGet(_ fileHandle: borrowing FileHandle) {
+    // This test function doesn't really do much other than check that the
+    // standard I/O files can be accessed.
+    fileHandle.withUnsafeCFILEHandle { fileHandle in
+      #expect(EOF != feof(fileHandle))
+    }
+  }
+
+  @Test("Can get stdout")
+  func canGetStdout() {
+    canGet(.stdout)
+  }
+
+  @Test("Can get stderr")
+  func canGetStderr() {
+    canGet(.stderr)
+  }
+
   @Test("Can get file descriptor")
   func fileDescriptor() throws {
     let fileHandle = try FileHandle.temporary()


### PR DESCRIPTION
I'm seeing some data getting dropped when calling `print()` while handling `swift test --list`, specifically when the list of tests is short. I suspect that `print()` is buffering in a way that's not entirely compatible with the piping that SwiftPM performs.

This issue is specific to Darwin and how it handles standard I/O buffering. I don't have a great explanation as to _why_ though, since `print()` ultimately calls `fwrite(stdout)` which should buffer the same way as `fputs(stdout)`. I do know that Linux and Windows _aren't_ affected. We have the same problem already in `XCTestScaffold` which is why that type _also_ special-cases Darwin when avoiding `print()`.

Repro case is to create a new package with `swift package init --enable-experimental-swift-testing` and then run `swift test list`: you should see `moduleName.example()` in the output, but from what I can see it isn't present. Other packages with more tests don't display the same issue.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
