### PR TITLE
Capture substructure of arguments and evaluated subexpressions of expectations

### DIFF
--- a/Sources/Testing/Parameterization/Test.Case.swift
+++ b/Sources/Testing/Parameterization/Test.Case.swift
@@ -191,20 +191,10 @@ extension Test.Case.Argument {
     /// The ID of this parameterized test argument, if any.
     public var id: Test.Case.Argument.ID?
 
-    /// A description of this parameterized test argument's
-    /// ``Test/Case/Argument/value`` property, formatted using
-    /// `String(describingForTest:)`.
-    public var valueDescription: String
-
-    /// A debug description of this parameterized test argument's
-    /// ``Test/Case/Argument/value`` property, formatted using
-    /// `String(reflecting:)`.
-    public var valueDebugDescription: String?
-
-    /// Information about the type of this parameterized test argument's
+    /// A representation of this parameterized test argument's
     /// ``Test/Case/Argument/value`` property.
     @_spi(ForToolsIntegrationOnly)
-    public var valueTypeInfo: TypeInfo
+    public var value: Expression.Value
 
     /// The parameter of the test function to which this argument was passed.
     public var parameter: Test.Parameter
@@ -216,9 +206,7 @@ extension Test.Case.Argument {
     ///   - argument: The original test case argument to snapshot.
     init(snapshotting argument: Test.Case.Argument) {
       id = argument.id
-      valueDescription = String(describingForTest: argument.value)
-      valueDebugDescription = String(reflecting: argument.value)
-      valueTypeInfo = TypeInfo(describingTypeOf: argument.value)
+      value = Expression.Value(reflecting: argument.value)
       parameter = argument.parameter
     }
   }


### PR DESCRIPTION
This introduces logic and SPI for capturing the substructure of arguments and evaluated subexpressions of failed expectations.

### Motivation:

This facilitates more progress towards actionable failure information by allowing more details to be shown in test results.

### Modifications:

- Introduce an SPI `Expression.Value` type which represents the details of a particular value.
- Consolidate some existing properties here, including `Expression.runtimeValueDescription` and `Expression.runtimeTypeInfo`.
- Adopt this as well in `Test.Case.Argument.Snapshot`, consolidating analogous properties like `valueDescription` and `valueTypeInfo`.
- Add new tests and adjust existing ones.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Resolves rdar://123767150
