### PR TITLE
Allow combining `TestFilter` instances with `OR`-like semantics.

### DIFF
--- a/Sources/Testing/Running/Configuration.TestFilter.swift
+++ b/Sources/Testing/Running/Configuration.TestFilter.swift
@@ -58,7 +58,7 @@ extension Configuration {
       ///     filters.
       ///
       /// The result of a test filter with this kind is the combination of the
-      /// results of its subfilters using `operator`.
+      /// results of its subfilters using `op`.
       indirect case combined(_ lhs: Kind, _ rhs: Kind, _ op: CombinationOperator)
     }
 

--- a/Tests/TestingTests/PlanTests.swift
+++ b/Tests/TestingTests/PlanTests.swift
@@ -337,7 +337,7 @@ struct PlanTests {
     #expect(planTests.contains(testB))
   }
 
-  @Test("Combining test filters with ||")
+  @Test("Combining test filters with .or")
   func combiningTestFilterWithOr() async throws {
     let outerTestType = try #require(await test(for: SendableTests.self))
     let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self))


### PR DESCRIPTION
This PR extends the `combining(with:)` and `combine(with:)` functions of `Configuration.TestFilter` to allow specifying whether combinations use `AND`- or `OR`-like semantics.

Because of how test graphs are constructed, these operations aren't trivially equivalent to the Swift standard library `&&` and `||` operators defined for boolean operands, but they have the same overall effect.

This PR introduces a new enumeration in `Configuration.TestFilter` that covers the two operators; I had at one point in development declared public/SPI operator functions so that you could write `f1.combine(with: f2, using: &&)`, but the operator functions had the signature `(Test?, Test?) -> Test?` which while correct for our use cases would probably _not_ be correct in the general context of comparing two instances of `Test?` and could be accidentally misused. An enumeration, while slightly less _Swifty!™_, is unambiguous.

We do not currently make use of `OR`-like semantics anywhere in the testing library, but adding them opens up new possibilities for tools like Swift Package Manager in the future.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
