### PR TITLE
Replace unsafe '-define-availability' flags with experimental AvailabilityMacro feature

### DIFF
--- a/Documentation/Releases.md
+++ b/Documentation/Releases.md
@@ -43,10 +43,6 @@ git checkout -b release/x.y.z
 The package manifest files (Package.swift _and_ Package@swift-6.0.swift) must
 be updated so that the release can be used as a package dependency:
 
-1. Take note of any availability definitions (passed to the Swift compiler with
-   the `-define-availability` option.) Search for these definitions in the
-   package source and replace them with their values. For example, replace all
-   `_distantFuture` uses with `macOS 99.0, iOS 99.0, watchOS 99.0, tvOS 99.0`.
 1. Delete any unsafe flags from `var packageSettings` as well as elsewhere in
    the package manifest files.
 1. Open the "Documentation/Testing.docc/TemporaryGettingStarted.md" file and

--- a/Package.swift
+++ b/Package.swift
@@ -114,18 +114,8 @@ extension Array where Element == PackageDescription.SwiftSetting {
   /// Settings intended to be applied to every Swift target in this package.
   /// Analogous to project-level build settings in an Xcode project.
   static var packageSettings: Self {
-    [
-      .unsafeFlags([
-        "-require-explicit-sendable",
-
-        "-Xfrontend", "-define-availability", "-Xfrontend", "_mangledTypeNameAPI:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0",
-        "-Xfrontend", "-define-availability", "-Xfrontend", "_backtraceAsyncAPI:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0",
-        "-Xfrontend", "-define-availability", "-Xfrontend", "_clockAPI:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0",
-        "-Xfrontend", "-define-availability", "-Xfrontend", "_regexAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0",
-        "-Xfrontend", "-define-availability", "-Xfrontend", "_swiftVersionAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0",
-
-        "-Xfrontend", "-define-availability", "-Xfrontend", "_distantFuture:macOS 99.0, iOS 99.0, watchOS 99.0, tvOS 99.0",
-      ]),
+    availabilityMacroSettings + [
+      .unsafeFlags(["-require-explicit-sendable"]),
       .enableExperimentalFeature("StrictConcurrency"),
       .enableUpcomingFeature("ExistentialAny"),
 
@@ -133,6 +123,23 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .enableUpcomingFeature("InternalImportsByDefault"),
 
       .define("SWT_TARGET_OS_APPLE", .when(platforms: [.macOS, .iOS, .macCatalyst, .watchOS, .tvOS, .visionOS])),
+    ]
+  }
+
+  /// Settings which define commonly-used OS availability macros.
+  ///
+  /// These leverage a pseudo-experimental feature in the Swift compiler for
+  /// setting availability definitions, which was added in
+  /// [apple/swift#65218](https://github.com/apple/swift/pull/65218).
+  private static var availabilityMacroSettings: Self {
+    [
+      .enableExperimentalFeature("AvailabilityMacro=_mangledTypeNameAPI:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0"),
+      .enableExperimentalFeature("AvailabilityMacro=_backtraceAsyncAPI:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0"),
+      .enableExperimentalFeature("AvailabilityMacro=_clockAPI:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0"),
+      .enableExperimentalFeature("AvailabilityMacro=_regexAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0"),
+      .enableExperimentalFeature("AvailabilityMacro=_swiftVersionAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0"),
+
+      .enableExperimentalFeature("AvailabilityMacro=_distantFuture:macOS 99.0, iOS 99.0, watchOS 99.0, tvOS 99.0"),
     ]
   }
 }

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -114,18 +114,8 @@ extension Array where Element == PackageDescription.SwiftSetting {
   /// Settings intended to be applied to every Swift target in this package.
   /// Analogous to project-level build settings in an Xcode project.
   static var packageSettings: Self {
-    [
-      .unsafeFlags([
-        "-require-explicit-sendable",
-
-        "-Xfrontend", "-define-availability", "-Xfrontend", "_mangledTypeNameAPI:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0",
-        "-Xfrontend", "-define-availability", "-Xfrontend", "_backtraceAsyncAPI:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0",
-        "-Xfrontend", "-define-availability", "-Xfrontend", "_clockAPI:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0",
-        "-Xfrontend", "-define-availability", "-Xfrontend", "_regexAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0",
-        "-Xfrontend", "-define-availability", "-Xfrontend", "_swiftVersionAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0",
-
-        "-Xfrontend", "-define-availability", "-Xfrontend", "_distantFuture:macOS 99.0, iOS 99.0, watchOS 99.0, tvOS 99.0",
-      ]),
+    availabilityMacroSettings + [
+      .unsafeFlags(["-require-explicit-sendable"]),
       .enableExperimentalFeature("StrictConcurrency"),
       .enableUpcomingFeature("ExistentialAny"),
 
@@ -133,6 +123,23 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .enableUpcomingFeature("InternalImportsByDefault"),
 
       .define("SWT_TARGET_OS_APPLE", .when(platforms: [.macOS, .iOS, .macCatalyst, .watchOS, .tvOS, .visionOS])),
+    ]
+  }
+
+  /// Settings which define commonly-used OS availability macros.
+  ///
+  /// These leverage a pseudo-experimental feature in the Swift compiler for
+  /// setting availability definitions, which was added in
+  /// [apple/swift#65218](https://github.com/apple/swift/pull/65218).
+  private static var availabilityMacroSettings: Self {
+    [
+      .enableExperimentalFeature("AvailabilityMacro=_mangledTypeNameAPI:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0"),
+      .enableExperimentalFeature("AvailabilityMacro=_backtraceAsyncAPI:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0"),
+      .enableExperimentalFeature("AvailabilityMacro=_clockAPI:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0"),
+      .enableExperimentalFeature("AvailabilityMacro=_regexAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0"),
+      .enableExperimentalFeature("AvailabilityMacro=_swiftVersionAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0"),
+
+      .enableExperimentalFeature("AvailabilityMacro=_distantFuture:macOS 99.0, iOS 99.0, watchOS 99.0, tvOS 99.0"),
     ]
   }
 }


### PR DESCRIPTION
This replaces the `-define-availability` flags in this package's `Package.swift` with the pseudo-experimental `AvailabilityMacro=...` feature.

### Motivation:

We want to use availability macros throughout swift-testing's codebase to simplify things and reduce the possibility of errors or inconsistencies. So far, this has only been possible by passing the `-define-availability` frontend compiler flag, but passing flags this way is considered unsafe and cannot be used in release versions of the package. This means that each time we prepare a new tag for release, we have needed to perform a manual step of replacing each availability macro with its actual versions, and we'd prefer to not need to do this step.

### Modifications:

- Replace all `-define-availability` settings with `AvailabilityMacro=...` experimental feature.
- Remove a now-obsolete step from our release preparation procedure documentation.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
