### PR TITLE
Add additional warnings for unimplemented platform-specific stuff.

### DIFF
--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -334,6 +334,9 @@ extension [Event.ConsoleOutputRecorder.Option] {
     // Windows does not set the "TERM" variable, so assume it supports 256-color
     // ANSI escape codes.
     true
+#else
+#warning("Platform-specific implementation missing: terminal colors unavailable")
+    return false
 #endif
   }
 #endif

--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -73,6 +73,7 @@ public struct Backtrace: Sendable {
 #elseif os(Windows)
         initializedCount = Int(RtlCaptureStackBackTrace(0, ULONG(addresses.count), addresses.baseAddress!, nil))
 #else
+#warning("Platform-specific implementation missing: backtraces unavailable")
         initializedCount = 0
 #endif
       }

--- a/Sources/Testing/Support/Environment.swift
+++ b/Sources/Testing/Support/Environment.swift
@@ -66,7 +66,7 @@ enum Environment {
     }
 #else
 #warning("Platform-specific implementation missing: environment variables unavailable")
-    nil
+    return nil
 #endif
   }
 

--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -255,6 +255,9 @@ extension FileHandle {
       }
       return FILE_TYPE_PIPE == GetFileType(handle)
     }
+#else
+#warning("Platform-specific implementation missing: cannot tell if a file is a pipe")
+    return false
 #endif
   }
 }

--- a/Sources/TestingInternals/Discovery.cpp
+++ b/Sources/TestingInternals/Discovery.cpp
@@ -260,7 +260,7 @@ static void enumerateTypeMetadataSections(const SectionEnumerator& body) {
   }
 }
 
-#else
+#elif defined(__linux__) || defined(_WIN32)
 #pragma mark - Linux/Windows implementation
 
 /// Specifies the address range corresponding to a section.
@@ -311,6 +311,10 @@ static void enumerateTypeMetadataSections(const SectionEnumerator& body) {
     return true;
   }, const_cast<SectionEnumerator *>(&body));
 }
+#else
+#warning Platform-specific implementation missing: Runtime test discovery unavailable
+template <typename SectionEnumerator>
+static void enumerateTypeMetadataSections(const SectionEnumerator& body) {}
 #endif
 
 #pragma mark -

--- a/Tests/TestingTests/Support/EnvironmentTests.swift
+++ b/Tests/TestingTests/Support/EnvironmentTests.swift
@@ -95,7 +95,7 @@ extension Environment {
     }
 #else
 #warning("Platform-specific implementation missing: environment variables unavailable")
-    false
+    return false
 #endif
   }
 }


### PR DESCRIPTION
We don't have a _huge_ amount of platform-specific code, but what we do have tends to look like:

```swift
func spinWidget() -> Widget {
#if SWT_TARGET_OS_APPLE // shorthand for os(macOS) || os(iOS) || ...
  return apple_impl()
#elseif os(Linux)
  return linux_impl()
#elseif os(Windows)
  return WindowsImplExW()
#endif
}
```

But this makes it harder to add new platform support because there's no `#else` branch to take for such a platform. Lots of platforms out there are POSIX-like and can often share code with either Darwin or Linux (or both), but we don't want to make that assumption without a human engineer double-checking. So we have a convention of adding to functions like this one an `#else` case of the general form:

```swift
#else
#warning("Platform-specific implementation missing: Widget spinning unavailable")
  return defaultWidget
#endif
```

This `#else` case allows other platforms to build successfully while still producing helpful diagnostics that can be fixed over time.

This PR adds additional warnings where platform-specific code may be unimplemented.

Note: I didn't really touch `FileHandle` because its `#else` paths already assume support for the C standard library. If a new platform does not support C standard file I/O via the functions in [stdio.h](https://en.cppreference.com/w/c/io), whoever is adding support for that platform should define `SWT_NO_FILE_IO` in the package manifest.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
