### PR TITLE
Adopt swift-syntax 5.10.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
   ],
 
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0"),
+    .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.0"),
   ],
 
   targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
   ],
 
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.0"),
+    .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.1"),
   ],
 
   targets: [

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -33,7 +33,7 @@ let package = Package(
   ],
 
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0"),
+    .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.0"),
   ],
 
   targets: [

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -33,7 +33,7 @@ let package = Package(
   ],
 
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.0"),
+    .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.1"),
   ],
 
   targets: [

--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -168,7 +168,7 @@ extension ConditionMacro {
     // are allowed.
 
     // Include the original arguments first.
-    result += macro.argumentList.lazy.map(Argument.init)
+    result += macro.arguments.lazy.map(Argument.init)
 
     if let trailingClosure = macro.trailingClosure {
       // Since a trailing closure does not (syntactically) include a label, we

--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -212,7 +212,7 @@ public struct AmbiguousRequireMacro: ConditionMacro {
     of macro: some FreestandingMacroExpansionSyntax,
     in context: some MacroExpansionContext
   ) throws -> ExprSyntax {
-    if let argument = macro.argumentList.first {
+    if let argument = macro.arguments.first {
       _checkAmbiguousArgument(argument.expression, in: context)
     }
 

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -34,7 +34,7 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
   static func condition(_ condition: ExprSyntax, isAlways value: Bool, in macro: some FreestandingMacroExpansionSyntax) -> Self {
     Self(
       syntax: Syntax(condition),
-      message: "#\(macro.macro.textWithoutBackticks)(_:_:) will always \(value ? "pass" : "fail") here; use Bool(\(condition)) to silence this warning",
+      message: "#\(macro.macroName.textWithoutBackticks)(_:_:) will always \(value ? "pass" : "fail") here; use Bool(\(condition)) to silence this warning",
       severity: value ? .note : .warning
     )
   }
@@ -50,7 +50,7 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
   static func asExclamationMarkIsEvaluatedEarly(_ expr: AsExprSyntax, in macro: some FreestandingMacroExpansionSyntax) -> Self {
     return Self(
       syntax: Syntax(expr.asKeyword),
-      message: "The expression \(expr.trimmed) will be evaluated before #\(macro.macro.textWithoutBackticks)(_:_:) is invoked; use as? instead of as! to silence this warning",
+      message: "The expression \(expr.trimmed) will be evaluated before #\(macro.macroName.textWithoutBackticks)(_:_:) is invoked; use as? instead of as! to silence this warning",
       severity: .warning
     )
   }


### PR DESCRIPTION
This PR updates our swift-syntax dependency to the 510.0.0 tag.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
