### PR TITLE
Polish `XCTestScaffold` and `Tag` docs.

### DIFF
--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -106,12 +106,6 @@ public enum XCTestScaffold: Sendable {
   /// The format of the output is not meant to be machine-readable and is
   /// subject to change.
   ///
-  /// ### Filtering tests
-  ///
-  /// This function does not support the `--filter` argument passed to
-  /// `swift test`. Instead, use one of several environment variables to control
-  /// which tests run.
-  ///
   /// ### Configuring output
   ///
   /// By default, this function uses

--- a/Sources/Testing/Testing.docc/AddingTags.md
+++ b/Sources/Testing/Testing.docc/AddingTags.md
@@ -26,9 +26,9 @@ source files, and even test targets.
 
 ## Adding tags
 
-To add a tag to a test, use the ``Trait/tags(_:)-505n9`` trait. These traits
-take sequences of tags as arguments, and those tags are then applied to the
-corresponding test at runtime. If they are applied to a test suite, then all
+To add a tag to a test, use the ``Trait/tags(_:)-505n9`` trait. This trait takes
+a sequence of tags as its argument, and those tags are then applied to the
+corresponding test at runtime. If any tags are applied to a test suite, then all
 tests in that suite inherit those tags.
 
 The testing library does not assign any semantic meaning to any tags, nor does
@@ -104,6 +104,21 @@ struct Food {
                               // to Tag
 }
 ```
+
+## Built-in tags
+
+The testing library predefines the following symbolic tags that can be used in
+any test target and applied to any test:
+
+- ``Tag/red``
+- ``Tag/orange``
+- ``Tag/yellow``
+- ``Tag/green``
+- ``Tag/blue``
+- ``Tag/purple``
+
+The testing library does not assign any semantic meaning to these tags, nor does
+the presence or absence of these tags affect how the testing library runs tests.
 
 ## Customizing a tag's appearance
 


### PR DESCRIPTION
This PR does a bit of editorial work on the documentation for `XCTestScaffold` and tags:

1. Deletes an orphaned paragraph from `XCTestScaffold`'s markup;
1. Fixes a grammatical error in the tags article describing the `tags(_:)` trait; and
1. Adds a section to the tags article listing the predefined symbolic tags in the testing library.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
