### PR TITLE
Ensure the total test count is set when outputting XML.

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.JUnitXMLRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.JUnitXMLRecorder.swift
@@ -94,6 +94,7 @@ extension Event.JUnitXMLRecorder {
       let id = test!.id
       let keyPath = id.keyPathRepresentation
       _context.withLock { context in
+        context.testCount += 1
         context.testData[keyPath] = _Context.TestData(id: id, startInstant: instant)
       }
       return nil

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -14,7 +14,8 @@ import RegexBuilder
 #endif
 #if SWT_TARGET_OS_APPLE && canImport(Foundation)
 import Foundation
-#elseif canImport(FoundationXML)
+#endif
+#if canImport(FoundationXML)
 import FoundationXML
 #endif
 
@@ -270,7 +271,11 @@ struct EventRecorderTests {
 #endif
 
 #if canImport(Foundation) || canImport(FoundationXML)
-  @Test("JUnitXMLRecorder outputs valid XML")
+
+  @Test(
+    "JUnitXMLRecorder outputs valid XML",
+    .bug("https://github.com/apple/swift-testing/issues/254", relationship: .verifiesFix)
+  )
   func junitXMLIsValid() async throws {
     let stream = Stream()
 
@@ -280,21 +285,48 @@ struct EventRecorderTests {
     configuration.eventHandler = { event, context in
       eventRecorder.record(event, in: context)
     }
-
     await runTest(for: WrittenTests.self, configuration: configuration)
 
-    // There is no formal schema for us to test against, so we're just testing
-    // that the XML can be parsed by Foundation.
+    // There is no formal schema for us to test against, so we're mostly just
+    // testing that the XML can be parsed by Foundation.
 
     let xmlString = stream.buffer.rawValue
     #expect(xmlString.hasPrefix("<?xml"))
     let xmlData = try #require(xmlString.data(using: .utf8))
     #expect(xmlData.count > 1024)
     let parser = XMLParser(data: xmlData)
+
+    // Set up a delegate that can look for particular XML tags of interest. Keep
+    // in mind that the delegate pattern necessarily means that some of the
+    // testing occurs out of source order.
+    final class JUnitDelegate: NSObject, XMLParserDelegate {
+      var testCount = 0
+      var caughtError: (any Error)?
+
+      func parser(_ parser: XMLParser, didStartElement elementName: String, namespaceURI: String?, qualifiedName qName: String?, attributes attributeDict: [String : String] = [:]) {
+        if elementName == "testsuite" {
+          do {
+            let testCountString = try #require(attributeDict["tests"])
+            testCount = try #require(Int(testCountString))
+          } catch {
+            caughtError = error
+          }
+        }
+      }
+    }
+    let delegate = JUnitDelegate()
+    parser.delegate = delegate
+
+    // Perform the parsing and propagate any errors that occurred.
     #expect(parser.parse())
     if let error = parser.parserError {
       throw error
     }
+    if let caughtError = delegate.caughtError {
+      throw caughtError
+    }
+
+    #expect(delegate.testCount > 0)
   }
 #endif
 }


### PR DESCRIPTION
This was an oversight on my part when initially implementing JUnit/xUnit XML output. Oops!

Resolves #254.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
