### PR TITLE
Support multiple `--filter` and `--skip` arguments.

### DIFF
--- a/Sources/Testing/Running/Configuration.TestFilter.swift
+++ b/Sources/Testing/Running/Configuration.TestFilter.swift
@@ -180,6 +180,25 @@ extension Configuration.TestFilter {
   public init(excludingAllOf tags: some Collection<Tag>) {
     self.init(tags: tags, anyOf: false, membership: .excluding)
   }
+
+  /// Initialize this instance to represent a regular expression matched against
+  /// a test's ID.
+  ///
+  /// - Parameters:
+  ///   - membership: How to interpret the result when predicating tests.
+  ///   - regex: The regular expression to predicate test IDs against.
+  ///
+  /// The caller is responsible for ensuring that `regex` is safe to send across
+  /// isolation boundaries. Regular expressions parsed from strings are
+  /// generally sendable.
+  @available(_regexAPI, *)
+  init(membership: Membership, matching regex: Regex<AnyRegexOutput>) {
+    let regex = UncheckedSendable(rawValue: regex)
+    self.init(membership: membership) { test in
+      let id = String(describing: test.id)
+      return id.contains(regex.rawValue)
+    }
+  }
 }
 
 // MARK: - Operations

--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -169,36 +169,25 @@ func configurationForSwiftPMEntryPoint(withArguments args: [String]) throws -> C
 #endif
 
   // Filtering
-  // NOTE: Regex is not marked Sendable, but because the regexes we use are
-  // constructed solely from a string, they are safe to send across isolation
-  // boundaries.
   var filters = [Configuration.TestFilter]()
-  if let filterArgIndex = args.firstIndex(of: "--filter"), filterArgIndex < args.endIndex {
-    guard #available(_regexAPI, *) else {
-      throw _EntryPointError.featureUnavailable("The '--filter' option is not supported on this OS version.")
+  func testFilter(forArgumentsWithLabel label: String, membership: Configuration.TestFilter.Membership) throws -> Configuration.TestFilter {
+    let matchingArgs = args.indices.lazy
+      .filter { args[$0] == label && $0 < args.endIndex }
+      .map { args[args.index(after: $0)] }
+    if matchingArgs.isEmpty {
+      return .unfiltered
     }
 
-    let filterArg = args[args.index(after: filterArgIndex)]
-    let regex = try UncheckedSendable(rawValue: Regex(filterArg))
-    let filter = Configuration.TestFilter(membership: .including) { test in
-      let id = String(describing: test.id)
-      return id.contains(regex.rawValue)
-    }
-    filters.append(filter)
-  }
-  if let skipArgIndex = args.firstIndex(of: "--skip"), skipArgIndex < args.endIndex {
     guard #available(_regexAPI, *) else {
-      throw _EntryPointError.featureUnavailable("The '--skip' option is not supported on this OS version.")
+      throw _EntryPointError.featureUnavailable("The `\(label)' option is not supported on this OS version.")
     }
-
-    let skipArg = args[args.index(after: skipArgIndex)]
-    let regex = try UncheckedSendable(rawValue: Regex(skipArg))
-    let filter = Configuration.TestFilter(membership: .excluding) { test in
-      let id = String(describing: test.id)
-      return id.contains(regex.rawValue)
-    }
-    filters.append(filter)
+    return try matchingArgs.lazy
+      .map { try Regex($0) }
+      .map { Configuration.TestFilter(membership: membership, matching: $0) }
+      .reduce(into: .unfiltered) { $0.combine(with: $1, using: .or) }
   }
+  filters.append(try testFilter(forArgumentsWithLabel: "--filter", membership: .including))
+  filters.append(try testFilter(forArgumentsWithLabel: "--skip", membership: .excluding))
 
   configuration.testFilter = filters.reduce(.unfiltered) { $0.combining(with: $1) }
 

--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -171,7 +171,7 @@ func configurationForSwiftPMEntryPoint(withArguments args: [String]) throws -> C
   // Filtering
   var filters = [Configuration.TestFilter]()
   func testFilter(forArgumentsWithLabel label: String, membership: Configuration.TestFilter.Membership) throws -> Configuration.TestFilter {
-    let matchingArgs = args.indices.lazy
+    let matchingArgs: [String] = args.indices.lazy
       .filter { args[$0] == label && $0 < args.endIndex }
       .map { args[args.index(after: $0)] }
     if matchingArgs.isEmpty {

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -26,7 +26,7 @@ struct SwiftPMTests {
   func parallel() throws {
     var configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH"])
     #expect(configuration.isParallelizationEnabled)
-    
+
     configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--parallel"])
     #expect(configuration.isParallelizationEnabled)
 
@@ -55,6 +55,20 @@ struct SwiftPMTests {
     let planTests = plan.steps.map(\.test)
     #expect(planTests.contains(test1))
     #expect(!planTests.contains(test2))
+  }
+
+  @Test("Multiple --filter arguments")
+  @available(_regexAPI, *)
+  func multipleFilter() async throws {
+    let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--filter", "hello", "--filter", "sorry"])
+    let test1 = Test(name: "hello") {}
+    let test2 = Test(name: "goodbye") {}
+    let test3 = Test(name: "sorry") {}
+    let plan = await Runner.Plan(tests: [test1, test2, test3], configuration: configuration)
+    let planTests = plan.steps.map(\.test)
+    #expect(planTests.contains(test1))
+    #expect(!planTests.contains(test2))
+    #expect(planTests.contains(test3))
   }
 
   @Test("--filter or --skip argument with bad regex")


### PR DESCRIPTION
SwiftPM supports passing multiple filter regexen into a test target. swift-testing should support it too.

Resolves #252.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
