### PR TITLE
Add .hidden trait to a few fixture tests which lack it

### DIFF
--- a/Tests/TestingTests/EventTests.swift
+++ b/Tests/TestingTests/EventTests.swift
@@ -14,6 +14,7 @@ import Foundation
 @testable @_spi(ExperimentalEventHandling) @_spi(ExperimentalSnapshotting) @_spi(ExperimentalTestRunning) @_spi(ExperimentalSourceCodeCapturing) import Testing
 private import TestingInternals
 
+@Suite("Event Tests")
 struct EventTests {
 #if canImport(Foundation)
   @Test("Event's and Event.Kinds's Codable Conformances",

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -1353,6 +1353,7 @@ final class IssueTests: XCTestCase {
 }
 #endif
 
+@Suite("Issue Codable Conformance Tests")
 struct IssueCodingTests {
 
   @Test("Codable",

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -25,7 +25,7 @@
 // This type ensures the parser can correctly infer that f() is a member
 // function even though @Test is preceded by another attribute or is embedded in
 // a #if statement.
-struct TestWithPrecedingAttribute {
+@Suite(.hidden) struct TestWithPrecedingAttribute {
   @inlinable @Test(.hidden) func f() {}
 
 #if true

--- a/Tests/TestingTests/Test.Case.ArgumentTests.swift
+++ b/Tests/TestingTests/Test.Case.ArgumentTests.swift
@@ -151,22 +151,23 @@ struct Test_Case_ArgumentTests {
 
 // MARK: - Fixture tests
 
+@Suite(.hidden)
 private struct ParameterizedTests {
-  @Test(arguments: ["value"])
+  @Test(.hidden, arguments: ["value"])
   func oneParameter(x: String) {}
 
-  @Test(arguments: ["value"], [123])
+  @Test(.hidden, arguments: ["value"], [123])
   func twoParameters(x: String, y: Int) {}
 
-  @Test(arguments: [("value")])
+  @Test(.hidden, arguments: [("value")])
   func one1TupleParameter(x: (String)) {}
 
-  @Test(arguments: [("value", 123)])
+  @Test(.hidden, arguments: [("value", 123)])
   func one2TupleParameter(x: (String, Int)) {}
 
-  @Test(arguments: ["value": 123])
+  @Test(.hidden, arguments: ["value": 123])
   func twoDictionaryElementParameters(x: String, y: Int) {}
 
-  @Test(arguments: ["value": 123])
+  @Test(.hidden, arguments: ["value": 123])
   func oneDictionaryElementTupleParameter(x: (key: String, value: Int)) {}
 }

--- a/Tests/TestingTests/Traits/CustomExecutionTraitTests.swift
+++ b/Tests/TestingTests/Traits/CustomExecutionTraitTests.swift
@@ -30,7 +30,8 @@ private struct CustomThrowingErrorTrait: CustomExecutionTrait, TestTrait {
     }
 }
 
-struct CustomTraitTest {
+@Suite("CustomExecutionTrait Tests")
+struct CustomExecutionTraitTests {
     @Test("Execute code before and after a non-parameterized test.")
     func executeCodeBeforeAndAfterNonParameterizedTest() async {
         // `expectedCount` is 2 because we run it both for the test and the test case

--- a/Tests/TestingTests/ZipTests.swift
+++ b/Tests/TestingTests/ZipTests.swift
@@ -10,6 +10,7 @@
 
 @testable @_spi(ExperimentalTestRunning) import Testing
 
+@Suite("zip Tests")
 struct ZipTests {
   @Test("Zipped collections are not combinatoric")
   func zippedCollections() async throws {


### PR DESCRIPTION
Add the `.hidden` trait to a few fixture tests which lack it, and improve the display names on a few other suites I saw along the way.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
