### PR TITLE
Ensure `indirect` is applied consistently to `Event.Kind(.Snapshot)` enum cases

### DIFF
--- a/Sources/Testing/Events/Event.swift
+++ b/Sources/Testing/Events/Event.swift
@@ -127,7 +127,7 @@ public struct Event: Sendable {
     /// ``Configuration/repetitionPolicy-swift.property`` property can be set to
     /// allow for more iterations.
     @_spi(ExperimentalTestRunning)
-    case iterationEnded(_ index: Int)
+    indirect case iterationEnded(_ index: Int)
 
     /// A test run ended.
     ///
@@ -332,7 +332,7 @@ extension Event.Kind {
     /// ``Configuration/repetitionPolicy-swift.property`` property can be set to
     /// allow for more iterations.
     @_spi(ExperimentalTestRunning)
-    case iterationStarted(_ index: Int)
+    indirect case iterationStarted(_ index: Int)
 
     /// A step in the runner plan started.
     ///


### PR DESCRIPTION
This fixes two instances where the `indirect` keyword was inconsistently applied to cases of the `Event.Kind` and `Event.Kind.Snapshot` enums.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
