### PR TITLE
Lower programmatic `.comment` trait to SPI

### DIFF
--- a/Sources/Testing/Testing.docc/AddingComments.md
+++ b/Sources/Testing/Testing.docc/AddingComments.md
@@ -3,7 +3,7 @@
 <!--
 This source file is part of the Swift.org open source project
 
-Copyright (c) 2023 Apple Inc. and the Swift project authors
+Copyright (c) 2024 Apple Inc. and the Swift project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
@@ -28,10 +28,10 @@ Seeing comments related to tests in these contexts can help diagnose issues more
 quickly. Comments can be added to test declarations and the testing library will
 automatically capture and show them when issues are recorded.
 
-## Adding a code comment to a test automatically
+## Adding a code comment to a test
 
-The easiest way to include a comment on a test is by adding it as a regular
-Swift code comment placed immediately before the `@Test` attribute:
+To include a comment on a test or suite, write an ordinary Swift code comment
+immediately before its `@Test` or `@Suite` attribute:
 
 ```swift
 // Assumes the standard lunch menu includes a taco
@@ -64,6 +64,9 @@ is because the whitespace and formatting of comments can be meaningful in some
 circumstances or aid in understanding the comment—for example, when a comment
 includes an example code snippet or diagram.
 
+<!-- FIXME: Uncomment this section if/when the `.comment(...)` trait is promoted
+  to non-experimental SPI
+
 ## Adding a comment to a test programmatically
 
 For more precise control over a comment's content, comments can be added to a
@@ -81,7 +84,7 @@ function and specify a comment string:
 func lunchMenu() {
   ...
 }
-```
+``` -->
 
 ## Using test comments effectively
 
@@ -96,5 +99,7 @@ of comments. For more information, review <doc:AssociatingBugs>.
 
 ## Topics
 
-- ``Trait/comment(_:)``
 - ``Comment``
+<!-- FIXME: Uncomment this section if/when the `.comment(...)` trait is promoted
+  to non-experimental SPI.
+- ``Trait/comment(_:)`` -->

--- a/Sources/Testing/Traits/Comment.swift
+++ b/Sources/Testing/Traits/Comment.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -13,6 +13,9 @@
 /// This type may be used to provide context or background information about a
 /// test's purpose, explain how a complex test operates, or include details
 /// which may be helpful when diagnosing issues recorded by a test.
+///
+/// To add a comment to a test or suite, add a code comment before its `@Test`
+/// or `@Suite` attribute. See <doc:AddingComments> for more details.
 ///
 /// - Note: This type is not intended to reference bugs related to a test.
 ///   Instead, use ``Trait/bug(_:relationship:)-duvt`` or
@@ -105,6 +108,7 @@ extension Comment: TestTrait, SuiteTrait {
   }
 }
 
+@_spi(Experimental)
 extension Trait where Self == Comment {
   /// Construct a comment related to a test.
   ///

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -1,14 +1,14 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalEventHandling) @_spi(ExperimentalEventRecording) @_spi(ExperimentalTestRunning) import Testing
+@testable @_spi(Experimental) @_spi(ExperimentalEventHandling) @_spi(ExperimentalEventRecording) @_spi(ExperimentalTestRunning) import Testing
 #if !os(Windows)
 import RegexBuilder
 #endif

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -180,7 +180,7 @@ struct TestsWithStaticMemberAccessBySelfKeyword {
 @Test(.hidden, arguments: [0]) func A(🙂: Int) {}
 
 func asyncTrait() async -> some SuiteTrait & TestTrait {
-  .comment("")
+  .bug("")
 }
 
 @Suite(.hidden, await asyncTrait())

--- a/Tests/TestingTests/Traits/CommentTests.swift
+++ b/Tests/TestingTests/Traits/CommentTests.swift
@@ -1,14 +1,14 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalTestRunning) import Testing
+@testable @_spi(Experimental) @_spi(ExperimentalTestRunning) import Testing
 
 @Suite("Comment Tests", .tags(.traitRelated))
 struct CommentTests {


### PR DESCRIPTION
This lowers the programmatic `.comment(...)` trait to SPI, instead of it being public API.

### Motivation:

As the `AddingComments.md` documentation article discusses, there are two currently two ways to add arbitrary comments to tests: using ordinary Swift code comments, or programmatically by applying a `.comment(...)` trait. We speculatively added the second one, but after further consideration it's not clear how useful it is, and may not justify being fully public API at this time.

### Modifications:

- Make `Trait.comment(_:)` SPI.
- Adjust documentation and tests accordingly.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Resolves rdar://124154537