### PR TITLE
Document `#expect { ... } throws: { ... }` in XCTest migration article

### DIFF
--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -350,6 +350,7 @@ their equivalents in the testing library:
 | `XCTAssertLessThanOrEqual(x, y)` | `#expect(x <= y)` |
 | `XCTAssertLessThan(x, y)` | `#expect(x < y)` |
 | `XCTAssertThrowsError(try f())` | `#expect(throws: (any Error).self) { try f() }` |
+| `XCTAssertThrowsError(try f()) { error in … }` | `#expect { try f() } throws: { error in return … }` |
 | `XCTAssertNoThrow(try f())` | `#expect(throws: Never.self) { try f() }` |
 | `try XCTUnwrap(x)` | `try #require(x)` |
 | `XCTFail("…")` | `Issue.record("…")` |


### PR DESCRIPTION
This adds a mention of the existing `#expect { ... } throws: { ... }` expectation API to our [Migrating a test from XCTest](https://swiftpackageindex.com/apple/swift-testing/main/documentation/testing/migratingfromxctest) article.

### Motivation:

A few people have asked what the analogous API is for `XCTAssertThrowsError` in XCTest—specifically, when passing a trailing `errorHandler` closure to that function.

### Modifications:

- Add a row to the table of examples showing this API.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
