### PR TITLE
Introduce a snapshot type for Error values

### DIFF
--- a/Sources/Testing/Issues/ErrorSnapshot.swift
+++ b/Sources/Testing/Issues/ErrorSnapshot.swift
@@ -1,0 +1,42 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+/// A serializable snapshot of an `Error` value.
+///
+/// This type conforms to `Error` as well, meaning it can be thrown and treated
+/// as an error, however it is not considered equal to the underlying error it
+/// is a snapshot of.
+@_spi(ForToolsIntegrationOnly)
+public struct ErrorSnapshot: Error {
+  /// A description of this instance's underlying error, formatted using
+  /// ``Swift/String/init(describingForTest:)``.
+  public var description: String
+
+  /// Information about the type of this instance's underlying error.
+  public var typeInfo: TypeInfo
+
+  /// Initialize an instance of this type by taking a snapshot of the specified
+  /// error.
+  ///
+  /// - Parameters:
+  ///   - error: The underlying error to snapshot.
+  public init(snapshotting error: any Error) {
+    description = String(describingForTest: error)
+    typeInfo = TypeInfo(describingTypeOf: error)
+  }
+}
+
+// MARK: - CustomStringConvertible
+
+extension ErrorSnapshot: CustomStringConvertible {}
+
+// MARK: - Codable
+
+extension ErrorSnapshot: Codable {}

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -1378,4 +1378,13 @@ struct IssueCodingTests {
 
     #expect(String(describing: decoded) == String(describing: issueSnapshot))
   }
+
+  @Test func errorSnapshot() throws {
+    let issue = Issue(kind: .errorCaught(NSError(domain: "Domain", code: 13)), comments: [])
+    let underlyingError = try #require(issue.error)
+
+    let issueSnapshot = Issue.Snapshot(snapshotting: issue)
+    let errorSnapshot = try #require(issueSnapshot.error)
+    #expect(String(describing: errorSnapshot) == String(describing: underlyingError))
+  }
 }


### PR DESCRIPTION
This introduces a new serializable "snapshot" type for representing `Error` values.

### Motivation:

The `Issue.Kind.errorCaught(_ error: any Error)` enum case stores an `Error` value, but when taking a snapshot of an `Issue`, we currently only capture a textual description of the error because `Error` is not `Codable`. Sometimes, though, is it is useful to have a real `Error` value on the receiving (i.e. deserializing) end of the snapshot, even if it is not identical to the original error, for the purpose of propagating that error or representing it via mechanisms which expect an `Error` value.

### Modifications:

- Add `ErrorSnapshot` as SPI.
- Replace the `String` associated value describing an error in `Issue.Kind.Snapshot.errorCaught(_:)` with `ErrorSnapshot`.
- Add a derived `error` property to `Issue.Snapshot`, returning the `ErrorSnapshot` (if any).

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
