### PR TITLE
Move snapshot types from SPI group `ExperimentalSnapshotting` to `ForToolsIntegrationOnly`.

### DIFF
--- a/Sources/Testing/Events/Event.swift
+++ b/Sources/Testing/Events/Event.swift
@@ -285,7 +285,7 @@ extension Event {
 
 extension Event {
   /// A serializable event that occurred during testing.
-  @_spi(ExperimentalSnapshotting)
+  @_spi(ForToolsIntegrationOnly)
   public struct Snapshot: Sendable, Codable {
 
     /// The kind of event.
@@ -321,7 +321,7 @@ extension Event {
 
 extension Event.Kind {
   /// A serializable enumeration describing the various kinds of event that can be observed.
-  @_spi(ExperimentalSnapshotting)
+  @_spi(ForToolsIntegrationOnly)
   public enum Snapshot: Sendable, Codable {
     /// A test run started.
     ///

--- a/Sources/Testing/Expectations/Expectation.swift
+++ b/Sources/Testing/Expectations/Expectation.swift
@@ -56,7 +56,7 @@ public struct ExpectationFailedError: Error {
 
 extension Expectation {
   /// A serializable type describing an expectation that has been evaluated.
-  @_spi(ExperimentalSnapshotting)
+  @_spi(ForToolsIntegrationOnly)
   public struct Snapshot: Sendable, Codable {
     /// The expression evaluated by this expectation.
     public var evaluatedExpression: Expression

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -180,7 +180,7 @@ extension Issue.Kind: CustomStringConvertible {
 
 extension Issue {
   /// A serializable type describing a failure or warning which occurred during a test.
-  @_spi(ExperimentalSnapshotting)
+  @_spi(ForToolsIntegrationOnly)
   public struct Snapshot: Sendable, Codable {
     /// The kind of issue this value represents.
     public var kind: Kind.Snapshot
@@ -222,7 +222,7 @@ extension Issue {
 
 extension Issue.Kind {
   /// Serializable kinds of issues which may be recorded.
-  @_spi(ExperimentalSnapshotting)
+  @_spi(ForToolsIntegrationOnly)
   public enum Snapshot: Sendable, Codable {
     /// An issue which occurred unconditionally, for example by using
     /// ``Issue/record(_:fileID:filePath:line:column:)``.

--- a/Sources/Testing/Parameterization/Test.Case.swift
+++ b/Sources/Testing/Parameterization/Test.Case.swift
@@ -164,7 +164,7 @@ extension Test.Case.Argument.ID: Hashable {}
 
 extension Test.Case {
   /// A serializable snapshot of a ``Test/Case`` instance.
-  @_spi(ExperimentalSnapshotting)
+  @_spi(ForToolsIntegrationOnly)
   public struct Snapshot: Sendable, Codable {
     /// The ID of this test case.
     public var id: ID
@@ -186,7 +186,7 @@ extension Test.Case {
 
 extension Test.Case.Argument {
   /// A serializable snapshot of a ``Test/Case/Argument`` instance.
-  @_spi(ExperimentalSnapshotting)
+  @_spi(ForToolsIntegrationOnly)
   public struct Snapshot: Sendable, Codable {
     /// The ID of this parameterized test argument, if any.
     public var id: Test.Case.Argument.ID?

--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -322,7 +322,7 @@ extension Runner.Plan {
 
 extension Runner.Plan {
   /// A serializable snapshot of a ``Runner/Plan-swift.struct`` instance.
-  @_spi(ExperimentalSnapshotting)
+  @_spi(ForToolsIntegrationOnly)
   public struct Snapshot: Sendable {
     /// The graph of the steps in this runner plan.
     private var _stepGraph: Graph<String, Step.Snapshot?> = .init(value: nil)
@@ -384,7 +384,7 @@ extension Runner.Plan.Snapshot: Codable {
 
 extension Runner.Plan.Step {
   /// A serializable snapshot of a ``Runner/Plan-swift.struct/Step`` instance.
-  @_spi(ExperimentalSnapshotting)
+  @_spi(ForToolsIntegrationOnly)
   public struct Snapshot: Sendable, Codable {
     /// The test referenced by this instance.
     public var test: Test.Snapshot
@@ -406,7 +406,7 @@ extension Runner.Plan.Step {
 extension Runner.Plan.Action {
   /// A serializable snapshot of a ``Runner/Plan-swift.struct/Step/Action``
   /// instance.
-  @_spi(ExperimentalSnapshotting)
+  @_spi(ForToolsIntegrationOnly)
   public enum Snapshot: Sendable, Codable {
     /// The test should be run.
     ///

--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -165,7 +165,7 @@ extension Test: Equatable, Hashable {
 
 extension Test {
   /// A serializable snapshot of a ``Test`` instance.
-  @_spi(ExperimentalSnapshotting)
+  @_spi(ForToolsIntegrationOnly)
   public struct Snapshot: Sendable, Codable, Identifiable {
     /// The ID of this test.
     public var id: Test.ID

--- a/Tests/TestingTests/EventTests.swift
+++ b/Tests/TestingTests/EventTests.swift
@@ -11,7 +11,7 @@
 #if canImport(Foundation)
 import Foundation
 #endif
-@testable @_spi(ExperimentalEventHandling) @_spi(ExperimentalSnapshotting) @_spi(ExperimentalTestRunning) @_spi(ExperimentalSourceCodeCapturing) import Testing
+@testable @_spi(ExperimentalEventHandling) @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalTestRunning) @_spi(ExperimentalSourceCodeCapturing) import Testing
 private import TestingInternals
 
 @Suite("Event Tests")

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalEventHandling) @_spi(ExperimentalTestRunning) @_spi(ExperimentalSnapshotting) @_spi(ExperimentalSourceCodeCapturing) import Testing
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalEventHandling) @_spi(ExperimentalTestRunning) @_spi(ExperimentalSourceCodeCapturing) import Testing
 private import TestingInternals
 
 #if canImport(XCTest)

--- a/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
+++ b/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalSnapshotting) @_spi(ExperimentalTestRunning) @_spi(ForToolsIntegrationOnly) import Testing
+@testable @_spi(ExperimentalTestRunning) @_spi(ForToolsIntegrationOnly) import Testing
 
 #if canImport(Foundation)
 import Foundation

--- a/Tests/TestingTests/Test.SnapshotTests.swift
+++ b/Tests/TestingTests/Test.SnapshotTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@_spi(ExperimentalSnapshotting) import Testing
+@_spi(ForToolsIntegrationOnly) import Testing
 
 #if canImport(Foundation)
 import Foundation


### PR DESCRIPTION
This PR moves various `Snapshot` types to the `ForToolsIntegrationOnly` SPI group per the SPI policy outlined
[here](https://github.com/apple/swift-testing/blob/main/Documentation/SPI.md).

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
