### PR TITLE
Move event recorders from SPI group `ExperimentalEventRecording` to `ForToolsIntegrationOnly`.

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
@@ -14,7 +14,7 @@ extension Event {
   ///
   /// The format of the output is not meant to be machine-readable and is
   /// subject to change. For machine-readable output, use ``JUnitXMLRecorder``.
-  @_spi(ExperimentalEventRecording)
+  @_spi(ForToolsIntegrationOnly)
   public struct ConsoleOutputRecorder: Sendable {
     /// An enumeration describing options to use when writing events to a
     /// stream.

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -17,7 +17,7 @@ extension Event {
   ///
   /// The format of the output is not meant to be machine-readable and is
   /// subject to change. For machine-readable output, use ``JUnitXMLRecorder``.
-  @_spi(ExperimentalEventRecording)
+  @_spi(ForToolsIntegrationOnly)
   public struct HumanReadableOutputRecorder: Sendable {
     /// A type describing a human-readable message produced by an instance of
     /// ``Event/HumanReadableOutputRecorder``.

--- a/Sources/Testing/Events/Recorder/Event.JUnitXMLRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.JUnitXMLRecorder.swift
@@ -11,7 +11,7 @@
 extension Event {
   /// A type which handles ``Event`` instances and outputs representations of
   /// them as JUnit-compatible XML.
-  @_spi(ExperimentalEventRecording)
+  @_spi(ForToolsIntegrationOnly)
   public struct JUnitXMLRecorder: Sendable {
     /// The write function for this event recorder.
     var write: @Sendable (String) -> Void

--- a/Sources/Testing/Events/Recorder/Event.Symbol.swift
+++ b/Sources/Testing/Events/Recorder/Event.Symbol.swift
@@ -11,7 +11,7 @@
 extension Event {
   /// An enumeration describing the symbols used as prefixes when recording an
   /// event.
-  @_spi(ExperimentalEventRecording)
+  @_spi(ForToolsIntegrationOnly)
   public enum Symbol: Sendable {
     /// The default symbol to use.
     case `default`

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(Experimental) @_spi(ExperimentalEventHandling) @_spi(ExperimentalEventRecording) @_spi(ExperimentalTestRunning) import Testing
+@testable @_spi(Experimental) @_spi(ExperimentalEventHandling) @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalTestRunning) import Testing
 #if !os(Windows)
 import RegexBuilder
 #endif


### PR DESCRIPTION
This PR moves various event recorder types to the `ForToolsIntegrationOnly` SPI group per the SPI policy outlined
[here](https://github.com/apple/swift-testing/blob/main/Documentation/SPI.md).

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
