### PR TITLE
Move symbols from SPI group `ExperimentalSourceCodeCapturing` to `ForToolsIntegrationOnly`.

### DIFF
--- a/Sources/Testing/SourceAttribution/Expression.swift
+++ b/Sources/Testing/SourceAttribution/Expression.swift
@@ -88,7 +88,7 @@ public struct Expression: Sendable {
   var kind: Kind
 
   /// The source code of the original captured expression.
-  @_spi(ExperimentalSourceCodeCapturing)
+  @_spi(ForToolsIntegrationOnly)
   public var sourceCode: String {
     switch kind {
     case let .generic(sourceCode), let .stringLiteral(sourceCode, _):
@@ -253,7 +253,7 @@ public struct Expression: Sendable {
   ///     information this instance contains.)
   ///
   /// - Returns: A string describing this instance.
-  @_spi(ExperimentalSourceCodeCapturing)
+  @_spi(ForToolsIntegrationOnly)
   public func expandedDescription(depth: Int = 0, includingTypeNames: Bool = false, includingParenthesesIfNeeded: Bool = true) -> String {
     var result = ""
     switch kind {
@@ -307,7 +307,7 @@ public struct Expression: Sendable {
   }
 
   /// The set of parsed and captured subexpressions contained in this instance.
-  @_spi(ExperimentalSourceCodeCapturing)
+  @_spi(ForToolsIntegrationOnly)
   public var subexpressions: [Expression] {
     switch kind {
     case .generic, .stringLiteral:
@@ -330,7 +330,7 @@ public struct Expression: Sendable {
   ///
   /// If this instance represents an expression other than a string literal, the
   /// value of this property is `nil`.
-  @_spi(ExperimentalSourceCodeCapturing)
+  @_spi(ForToolsIntegrationOnly)
   public var stringLiteralValue: String? {
     if case let .stringLiteral(_, stringValue) = kind {
       return stringValue
@@ -358,7 +358,7 @@ extension Expression: CustomStringConvertible, CustomDebugStringConvertible {
   /// `String.init(describing:)`.
   ///
   /// This initializer does not attempt to parse `sourceCode`.
-  @_spi(ExperimentalSourceCodeCapturing)
+  @_spi(ForToolsIntegrationOnly)
   public init(_ sourceCode: String) {
     self.init(kind: .generic(sourceCode))
   }

--- a/Tests/TestingTests/EventTests.swift
+++ b/Tests/TestingTests/EventTests.swift
@@ -11,7 +11,7 @@
 #if canImport(Foundation)
 import Foundation
 #endif
-@testable @_spi(ExperimentalEventHandling) @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalTestRunning) @_spi(ExperimentalSourceCodeCapturing) import Testing
+@testable @_spi(ExperimentalEventHandling) @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalTestRunning) import Testing
 private import TestingInternals
 
 @Suite("Event Tests")

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalEventHandling) @_spi(ExperimentalTestRunning) @_spi(ExperimentalSourceCodeCapturing) import Testing
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalEventHandling) @_spi(ExperimentalTestRunning) import Testing
 private import TestingInternals
 
 #if canImport(XCTest)

--- a/Tests/TestingTests/Traits/TagListTests.swift
+++ b/Tests/TestingTests/Traits/TagListTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) @_spi(ExperimentalSourceCodeCapturing) @_spi(ForToolsIntegrationOnly) import Testing
+@testable @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) @_spi(ForToolsIntegrationOnly) import Testing
 
 #if canImport(Foundation)
 import Foundation


### PR DESCRIPTION
This PR moves various symbols from the `ExperimentalSourceCodeCapturing` SPI group to the `ForToolsIntegrationOnly` SPI group per the SPI policy outlined [here](https://github.com/apple/swift-testing/blob/main/Documentation/SPI.md).

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
