### PR TITLE
Move `Event` from SPI group `ExperimentalEventHandling` to `ForToolsIntegrationOnly`.

### DIFF
--- a/Sources/Testing/Events/Event.swift
+++ b/Sources/Testing/Events/Event.swift
@@ -9,7 +9,7 @@
 //
 
 /// An event that occurred during testing.
-@_spi(ExperimentalEventHandling)
+@_spi(ForToolsIntegrationOnly)
 public struct Event: Sendable {
   /// An enumeration describing the various kinds of event that can be observed.
   public enum Kind: Sendable {
@@ -203,7 +203,6 @@ public struct Event: Sendable {
 
 // MARK: - Event handling
 
-@_spi(ExperimentalEventHandling)
 extension Event {
   /// A function that handles events that occur while tests are running.
   ///
@@ -285,7 +284,6 @@ extension Event {
 
 extension Event {
   /// A serializable event that occurred during testing.
-  @_spi(ForToolsIntegrationOnly)
   public struct Snapshot: Sendable, Codable {
 
     /// The kind of event.
@@ -321,7 +319,6 @@ extension Event {
 
 extension Event.Kind {
   /// A serializable enumeration describing the various kinds of event that can be observed.
-  @_spi(ForToolsIntegrationOnly)
   public enum Snapshot: Sendable, Codable {
     /// A test run started.
     ///

--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -176,11 +176,11 @@ public struct Configuration: Sendable {
   /// By default, events of this kind are not delivered to event handlers
   /// because they occur frequently in a typical test run and can generate
   /// significant backpressure on the event handler.
-  @_spi(ExperimentalEventHandling)
+  @_spi(ForToolsIntegrationOnly)
   public var deliverExpectationCheckedEvents = false
 
   /// The event handler to which events should be passed when they occur.
-  @_spi(ExperimentalEventHandling)
+  @_spi(ForToolsIntegrationOnly)
   public var eventHandler: Event.Handler = { _, _ in }
 
   // MARK: - Test selection

--- a/Tests/TestingTests/BacktraceTests.swift
+++ b/Tests/TestingTests/BacktraceTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalEventHandling) @_spi(ExperimentalTestRunning) import Testing
+@testable @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalTestRunning) import Testing
 #if canImport(Foundation)
 import Foundation
 #endif

--- a/Tests/TestingTests/ConfirmationTests.swift
+++ b/Tests/TestingTests/ConfirmationTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalEventHandling) @_spi(ExperimentalTestRunning) import Testing
+@testable @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalTestRunning) import Testing
 
 @Suite("Confirmation Tests")
 struct ConfirmationTests {

--- a/Tests/TestingTests/KnownIssueTests.swift
+++ b/Tests/TestingTests/KnownIssueTests.swift
@@ -10,7 +10,7 @@
 
 #if canImport(XCTest)
 import XCTest
-@testable @_spi(ExperimentalEventHandling) @_spi(ExperimentalTestRunning) import Testing
+@testable @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalTestRunning) import Testing
 
 final class KnownIssueTests: XCTestCase {
   func testIssueIsKnownPropertyIsSetCorrectly() async {

--- a/Tests/TestingTests/ObjCInteropTests.swift
+++ b/Tests/TestingTests/ObjCInteropTests.swift
@@ -9,7 +9,7 @@
  */
 
 import XCTest
-@testable @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) import Testing
+@testable @_spi(ExperimentalTestRunning) @_spi(ForToolsIntegrationOnly) import Testing
 
 final class NonXCTestCaseClassTests: NSObject {
   @Test("Methods on non-XCTestCase subclasses are supported")

--- a/Tests/TestingTests/PlanIterationTests.swift
+++ b/Tests/TestingTests/PlanIterationTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) import Testing
+@testable @_spi(ExperimentalTestRunning) @_spi(ForToolsIntegrationOnly) import Testing
 
 @Suite("Configuration.RepetitionPolicy Tests")
 struct PlanIterationTests {

--- a/Tests/TestingTests/Runner.RuntimeStateTests.swift
+++ b/Tests/TestingTests/Runner.RuntimeStateTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalEventHandling) @_spi(ExperimentalTestRunning) import Testing
+@testable @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalTestRunning) import Testing
 
 @Suite("Runner.RuntimeState Tests")
 struct Runner_RuntimeStateTests {

--- a/Tests/TestingTests/SourceLocationTests.swift
+++ b/Tests/TestingTests/SourceLocationTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalEventHandling) @_spi(ExperimentalTestRunning) import Testing
+@testable @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalTestRunning) import Testing
 
 @Suite("SourceLocation Tests")
 struct SourceLocationTests {

--- a/Tests/TestingTests/Traits/CustomExecutionTraitTests.swift
+++ b/Tests/TestingTests/Traits/CustomExecutionTraitTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) @_spi(Experimental) import Testing
+@testable @_spi(ExperimentalTestRunning) @_spi(ForToolsIntegrationOnly) @_spi(Experimental) import Testing
 
 private struct CustomTrait: CustomExecutionTrait, TestTrait {
     var before: Confirmation

--- a/Tests/TestingTests/Traits/SerialTraitTests.swift
+++ b/Tests/TestingTests/Traits/SerialTraitTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(Experimental) @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) import Testing
+@testable @_spi(Experimental) @_spi(ExperimentalTestRunning) @_spi(ForToolsIntegrationOnly) import Testing
 
 @Suite("Serial Trait Tests", .tags("trait"))
 struct SerialTraitTests {


### PR DESCRIPTION
This PR moves `Event` and `Configuration.eventHandler` to the `ForToolsIntegrationOnly` SPI group per the SPI policy outlined [here](https://github.com/apple/swift-testing/blob/main/Documentation/SPI.md).

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
