### PR TITLE
Move `Configuration` to SPI group `ForToolsIntegrationOnly`.

### DIFF
--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -9,7 +9,7 @@
 //
 
 /// A type containing settings for preparing and running tests.
-@_spi(ExperimentalTestRunning)
+@_spi(ForToolsIntegrationOnly)
 public struct Configuration: Sendable {
   /// Initialize an instance of this type representing the default
   /// configuration.

--- a/Tests/TestingTests/KnownIssueTests.swift
+++ b/Tests/TestingTests/KnownIssueTests.swift
@@ -10,7 +10,7 @@
 
 #if canImport(XCTest)
 import XCTest
-@testable @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalTestRunning) import Testing
+@testable @_spi(ForToolsIntegrationOnly) import Testing
 
 final class KnownIssueTests: XCTestCase {
   func testIssueIsKnownPropertyIsSetCorrectly() async {

--- a/Tests/TestingTests/Runner.RuntimeStateTests.swift
+++ b/Tests/TestingTests/Runner.RuntimeStateTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalTestRunning) import Testing
+@testable @_spi(ForToolsIntegrationOnly) import Testing
 
 @Suite("Runner.RuntimeState Tests")
 struct Runner_RuntimeStateTests {

--- a/Tests/TestingTests/SourceLocationTests.swift
+++ b/Tests/TestingTests/SourceLocationTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalTestRunning) import Testing
+@testable @_spi(ForToolsIntegrationOnly) import Testing
 
 @Suite("SourceLocation Tests")
 struct SourceLocationTests {

--- a/Tests/TestingTests/Traits/CustomExecutionTraitTests.swift
+++ b/Tests/TestingTests/Traits/CustomExecutionTraitTests.swift
@@ -8,72 +8,72 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalTestRunning) @_spi(ForToolsIntegrationOnly) @_spi(Experimental) import Testing
+@testable @_spi(ForToolsIntegrationOnly) @_spi(Experimental) import Testing
 
 private struct CustomTrait: CustomExecutionTrait, TestTrait {
-    var before: Confirmation
-    var after: Confirmation
-    func execute(_ function: @escaping @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws {
-        before()
-        defer {
-            after()
-        }
-        try await function()
+  var before: Confirmation
+  var after: Confirmation
+  func execute(_ function: @escaping @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws {
+    before()
+    defer {
+      after()
     }
+    try await function()
+  }
 }
 
 private struct CustomThrowingErrorTrait: CustomExecutionTrait, TestTrait {
-    fileprivate struct CustomTraitError: Error {}
+  fileprivate struct CustomTraitError: Error {}
 
-    func execute(_ function: @escaping @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws {
-        throw CustomTraitError()
-    }
+  func execute(_ function: @escaping @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws {
+    throw CustomTraitError()
+  }
 }
 
 @Suite("CustomExecutionTrait Tests")
 struct CustomExecutionTraitTests {
-    @Test("Execute code before and after a non-parameterized test.")
-    func executeCodeBeforeAndAfterNonParameterizedTest() async {
-        // `expectedCount` is 2 because we run it both for the test and the test case
-        await confirmation("Code was run before the test", expectedCount: 2) { before in
-            await confirmation("Code was run after the test", expectedCount: 2) { after in
-                await Test(CustomTrait(before: before, after: after)) {
-                    // do nothing
-                }.run()
-            }
-        }
+  @Test("Execute code before and after a non-parameterized test.")
+  func executeCodeBeforeAndAfterNonParameterizedTest() async {
+    // `expectedCount` is 2 because we run it both for the test and the test case
+    await confirmation("Code was run before the test", expectedCount: 2) { before in
+      await confirmation("Code was run after the test", expectedCount: 2) { after in
+        await Test(CustomTrait(before: before, after: after)) {
+          // do nothing
+        }.run()
+      }
     }
+  }
 
-    @Test("Execute code before and after a parameterized test.")
-    func executeCodeBeforeAndAfterParameterizedTest() async {
-        // `expectedCount` is 3 because we run it both for the test and each test case
-        await confirmation("Code was run before the test", expectedCount: 3) { before in
-            await confirmation("Code was run after the test", expectedCount: 3) { after in
-                await Test(CustomTrait(before: before, after: after), arguments: ["Hello", "World"]) { _ in
-                    // do nothing
-                }.run()
-            }
-        }
+  @Test("Execute code before and after a parameterized test.")
+  func executeCodeBeforeAndAfterParameterizedTest() async {
+    // `expectedCount` is 3 because we run it both for the test and each test case
+    await confirmation("Code was run before the test", expectedCount: 3) { before in
+      await confirmation("Code was run after the test", expectedCount: 3) { after in
+        await Test(CustomTrait(before: before, after: after), arguments: ["Hello", "World"]) { _ in
+          // do nothing
+        }.run()
+      }
     }
+  }
 
-    @Test("Custom execution trait throws an error")
-    func customExecutionTraitThrowsAnError() async throws {
-        var configuration = Configuration()
-        await confirmation("Error thrown", expectedCount: 1) { errorThrownConfirmation in
-            configuration.eventHandler = { event, _ in
-                guard case let .issueRecorded(issue) = event.kind,
-                      case let .errorCaught(error) = issue.kind else {
-                    return
-                }
-
-                #expect(error is CustomThrowingErrorTrait.CustomTraitError)
-                errorThrownConfirmation()
-            }
-
-            await Test(CustomThrowingErrorTrait()) {
-                // Make sure this does not get reached
-                Issue.record("Expected trait to fail the test. Should not have reached test body.")
-            }.run(configuration: configuration)
+  @Test("Custom execution trait throws an error")
+  func customExecutionTraitThrowsAnError() async throws {
+    var configuration = Configuration()
+    await confirmation("Error thrown", expectedCount: 1) { errorThrownConfirmation in
+      configuration.eventHandler = { event, _ in
+        guard case let .issueRecorded(issue) = event.kind,
+              case let .errorCaught(error) = issue.kind else {
+          return
         }
+
+        #expect(error is CustomThrowingErrorTrait.CustomTraitError)
+        errorThrownConfirmation()
+      }
+
+      await Test(CustomThrowingErrorTrait()) {
+        // Make sure this does not get reached
+        Issue.record("Expected trait to fail the test. Should not have reached test body.")
+      }.run(configuration: configuration)
     }
+  }
 }


### PR DESCRIPTION
This PR moves `Configuration` to the `ForToolsIntegrationOnly` SPI group per the SPI policy outlined [here](https://github.com/apple/swift-testing/blob/main/Documentation/SPI.md).

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
