### PR TITLE
Move `Test.xcTestCompatibleSelector` to SPI group `ForToolsIntegrationOnly`.

### DIFF
--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -65,7 +65,7 @@ public struct Test: Sendable {
   ///
   /// On platforms that do not support Objective-C interop, the value of this
   /// property is always `nil`.
-  @_spi(ExperimentalTestRunning)
+  @_spi(ForToolsIntegrationOnly)
   public var xcTestCompatibleSelector: __XCTestCompatibleSelector?
 
   /// Storage for the ``testCases`` property.


### PR DESCRIPTION
This PR moves `Test.xcTestCompatibleSelector` to the `ForToolsIntegrationOnly` SPI group per the SPI policy outlined
[here](https://github.com/apple/swift-testing/blob/main/Documentation/SPI.md).

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
