### PR TITLE
Move `Test.Clock` to SPI groups `Experimental` and `ForToolsIntegrationOnly`.

### DIFF
--- a/Sources/Testing/Events/Clock.swift
+++ b/Sources/Testing/Events/Clock.swift
@@ -10,7 +10,7 @@
 
 private import TestingInternals
 
-@_spi(ExperimentalEventHandling)
+@_spi(Experimental) @_spi(ForToolsIntegrationOnly)
 extension Test {
   /// A clock used to track time when events occur during testing.
   ///
@@ -58,7 +58,7 @@ extension Test {
 
 // MARK: -
 
-@_spi(ExperimentalEventHandling)
+@_spi(Experimental) @_spi(ForToolsIntegrationOnly)
 @available(_clockAPI, *)
 extension SuspendingClock.Instant {
   /// Initialize this instant to the equivalent of the same instant on the
@@ -71,7 +71,6 @@ extension SuspendingClock.Instant {
   }
 }
 
-@_spi(ExperimentalEventHandling)
 extension Test.Clock.Instant {
 #if !SWT_NO_UTC_CLOCK
   /// The duration since 1970 represented by this instance as a tuple of seconds
@@ -144,7 +143,6 @@ extension Test.Clock {
 
 // MARK: - Clock
 
-@_spi(ExperimentalEventHandling)
 @available(_clockAPI, *)
 extension Test.Clock: _Concurrency.Clock {
   public typealias Duration = SuspendingClock.Duration
@@ -175,7 +173,6 @@ extension Test.Clock: _Concurrency.Clock {
 
 // MARK: - Equatable, Hashable, Comparable
 
-@_spi(ExperimentalEventHandling)
 extension Test.Clock.Instant: Equatable, Hashable, Comparable {
   public static func ==(lhs: Self, rhs: Self) -> Bool {
     lhs.suspending == rhs.suspending
@@ -192,7 +189,6 @@ extension Test.Clock.Instant: Equatable, Hashable, Comparable {
 
 // MARK: - InstantProtocol
 
-@_spi(ExperimentalEventHandling)
 @available(_clockAPI, *)
 extension Test.Clock.Instant: InstantProtocol {
   public typealias Duration = Swift.Duration

--- a/Sources/Testing/Expectations/Expectation.swift
+++ b/Sources/Testing/Expectations/Expectation.swift
@@ -17,7 +17,7 @@ public struct Expectation: Sendable {
   ///
   /// If this expectation passed, the value of this property is `nil` because no
   /// error mismatch occurred.
-  @_spi(ExperimentalEventHandling)
+  @_spi(ForToolsIntegrationOnly)
   public var mismatchedErrorDescription: String?
 
   /// A description of the difference between the operands in the expression
@@ -26,7 +26,7 @@ public struct Expectation: Sendable {
   /// If this expectation passed, the value of this property is `nil` because
   /// the difference is only computed when necessary to assist with diagnosing
   /// test failures.
-  @_spi(ExperimentalEventHandling)
+  @_spi(ForToolsIntegrationOnly)
   public var differenceDescription: String?
 
   /// Whether the expectation passed or failed.
@@ -65,7 +65,7 @@ extension Expectation {
     ///
     /// If this expectation passed, the value of this property is `nil` because no
     /// error mismatch occurred.
-    @_spi(ExperimentalEventHandling)
+    @_spi(ForToolsIntegrationOnly)
     public var mismatchedErrorDescription: String?
 
     /// A description of the difference between the operands in the expression
@@ -74,7 +74,7 @@ extension Expectation {
     /// If this expectation passed, the value of this property is `nil` because
     /// the difference is only computed when necessary to assist with diagnosing
     /// test failures.
-    @_spi(ExperimentalEventHandling)
+    @_spi(ForToolsIntegrationOnly)
     public var differenceDescription: String?
 
     /// Whether the expectation passed or failed.

--- a/Sources/_Testing_Foundation/Events/Clock+Date.swift
+++ b/Sources/_Testing_Foundation/Events/Clock+Date.swift
@@ -9,7 +9,7 @@
 //
 
 #if canImport(Foundation) && !SWT_NO_UTC_CLOCK
-@_spi(ExperimentalEventHandling) public import Testing
+@_spi(Experimental) @_spi(ForToolsIntegrationOnly) public import Testing
 public import Foundation
 
 extension Date {
@@ -22,7 +22,7 @@ extension Date {
   /// The resulting instance is equivalent to the wall-clock time represented by
   /// `testClockInstant`. For precise date/time calculations, convert instances
   /// of ``Test/Clock/Instant`` to `SuspendingClock.Instant` instead of `Date`.
-  @_spi(ExperimentalEventHandling)
+  @_spi(Experimental) @_spi(ForToolsIntegrationOnly)
   public init(_ testClockInstant: Test.Clock.Instant) {
     let components = testClockInstant.timeComponentsSince1970
     let secondsSince1970 = TimeInterval(components.seconds) + (TimeInterval(components.attoseconds) / TimeInterval(1_000_000_000_000_000_000))

--- a/Tests/TestingTests/ClockTests.swift
+++ b/Tests/TestingTests/ClockTests.swift
@@ -11,7 +11,7 @@
 #if canImport(Foundation)
 import Foundation
 #endif
-@testable @_spi(ExperimentalEventHandling) import Testing
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 private import TestingInternals
 
 @Suite("Clock API Tests")

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(Experimental) @_spi(ExperimentalEventHandling) @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalTestRunning) import Testing
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalTestRunning) import Testing
 #if !os(Windows)
 import RegexBuilder
 #endif

--- a/Tests/TestingTests/EventTests.swift
+++ b/Tests/TestingTests/EventTests.swift
@@ -11,7 +11,7 @@
 #if canImport(Foundation)
 import Foundation
 #endif
-@testable @_spi(ExperimentalEventHandling) @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalTestRunning) import Testing
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalTestRunning) import Testing
 private import TestingInternals
 
 @Suite("Event Tests")

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalEventHandling) @_spi(ExperimentalTestRunning) import Testing
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalTestRunning) import Testing
 private import TestingInternals
 
 #if canImport(XCTest)

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -10,7 +10,7 @@
 
 #if canImport(XCTest)
 import XCTest
-@testable @_spi(ExperimentalEventHandling) @_spi(ExperimentalTestRunning) @_spi(ForToolsIntegrationOnly) import Testing
+@testable @_spi(Experimental) @_spi(ExperimentalTestRunning) @_spi(ForToolsIntegrationOnly) import Testing
 
 struct MyError: Error, Equatable {
 }

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) @_spi(ForToolsIntegrationOnly) import Testing
+@testable @_spi(ExperimentalTestRunning) @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 #if canImport(Foundation)
 import Foundation
 #endif

--- a/Tests/TestingTests/Test.Case.Argument.IDTests.swift
+++ b/Tests/TestingTests/Test.Case.Argument.IDTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalTestRunning) @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalEventHandling) import Testing
+@testable @_spi(ExperimentalTestRunning) @_spi(ForToolsIntegrationOnly) @_spi(Experimental) import Testing
 #if canImport(Foundation)
 import Foundation
 #endif

--- a/Tests/TestingTests/Test.Case.ArgumentTests.swift
+++ b/Tests/TestingTests/Test.Case.ArgumentTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) import Testing
+@testable @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalTestRunning) @_spi(Experimental) import Testing
 
 @Suite("Test.Case.Argument Tests")
 struct Test_Case_ArgumentTests {

--- a/Tests/TestingTests/TestCaseSelectionTests.swift
+++ b/Tests/TestingTests/TestCaseSelectionTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalTestRunning) @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalEventHandling) import Testing
+@testable @_spi(ExperimentalTestRunning) @_spi(ForToolsIntegrationOnly) @_spi(Experimental) import Testing
 
 @Suite("Test.Case Selection Tests")
 struct TestCaseSelectionTests {

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) @_spi(ForToolsIntegrationOnly) import Testing
+@testable @_spi(ExperimentalTestRunning) @_spi(ForToolsIntegrationOnly) import Testing
 #if canImport(XCTest)
 import XCTest
 #endif

--- a/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
+++ b/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalTestRunning) @_spi(ExperimentalEventHandling) @_spi(ForToolsIntegrationOnly) import Testing
+@testable @_spi(ExperimentalTestRunning) @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
 @Suite("TimeLimitTrait Tests", .tags(.traitRelated))
 struct TimeLimitTraitTests {

--- a/Tests/TestingTests/_Testing_Foundation/FoundationTests.swift
+++ b/Tests/TestingTests/_Testing_Foundation/FoundationTests.swift
@@ -9,8 +9,8 @@
 //
 
 #if canImport(Foundation)
-@testable @_spi(ExperimentalEventHandling) import _Testing_Foundation
-@_spi(ExperimentalEventHandling) import Testing
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import _Testing_Foundation
+@_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 import Foundation
 
 struct FoundationTests {


### PR DESCRIPTION
This PR moves `Test.Clock` to the `Experimental` and `ForToolsIntegrationOnly` SPI groups per the SPI policy outlined
[here](https://github.com/apple/swift-testing/blob/main/Documentation/SPI.md).

`Test.Clock` is a candidate for promotion to API, so it is available both for tools integration and as an experimental interface for developer evaluation.

This PR also moves the `Expectation.mismatchedErrorDescription` and `.differenceDescription` properties to the `ForToolsIntegrationOnly` SPI group as they are the only remaining symbols in the `ExperimentalEventHandling` group.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
