### PR TITLE
Diagnose ambiguous uses of `#require()` with an argument of type `Bool?`.

### DIFF
--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -69,6 +69,33 @@
   sourceLocation: SourceLocation = SourceLocation()
 ) -> T = #externalMacro(module: "TestingMacros", type: "RequireMacro")
 
+/// Unwrap an optional boolean value or, if it is `nil`, fail and throw an
+/// error.
+///
+/// - Parameters:
+///   - optionalValue: The optional value to be unwrapped.
+///   - comment: A comment describing the expectation.
+///   - sourceLocation: The source location to which recorded expectations and
+///     issues should be attributed.
+///
+/// - Returns: The unwrapped value of `value`.
+///
+/// - Throws: An instance of ``ExpectationFailedError`` if `value` is `nil`.
+///
+/// If `value` is `nil`, an ``Issue`` is recorded for the test that is running
+/// in the current task and an instance of ``ExpectationFailedError`` is thrown.
+///
+/// This overload of ``require(_:_:sourceLocation:)-6w9oo`` checks if
+/// `optionalValue` may be ambiguous (i.e. it is unclear if the developer
+/// intended to check for a boolean value or unwrap an optional boolean value)
+/// and provides additional compile-time diagnostics when it is.
+@_documentation(visibility: private)
+@freestanding(expression) public macro require(
+  _ optionalValue: Bool?,
+  _ comment: @autoclosure () -> Comment? = nil,
+  sourceLocation: SourceLocation = SourceLocation()
+) -> Bool = #externalMacro(module: "TestingMacros", type: "AmbiguousRequireMacro")
+
 // MARK: - Matching errors by type
 
 /// Check that an expression always throws an error of a given type.

--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -57,12 +57,14 @@
 ///   - sourceLocation: The source location to which recorded expectations and
 ///     issues should be attributed.
 ///
-/// - Returns: The unwrapped value of `value`.
+/// - Returns: The unwrapped value of `optionalValue`.
 ///
-/// - Throws: An instance of ``ExpectationFailedError`` if `value` is `nil`.
+/// - Throws: An instance of ``ExpectationFailedError`` if `optionalValue` is
+///   `nil`.
 ///
-/// If `value` is `nil`, an ``Issue`` is recorded for the test that is running
-/// in the current task and an instance of ``ExpectationFailedError`` is thrown.
+/// If `optionalValue` is `nil`, an ``Issue`` is recorded for the test that is
+/// running in the current task and an instance of ``ExpectationFailedError`` is
+/// thrown.
 @freestanding(expression) public macro require<T>(
   _ optionalValue: T?,
   _ comment: @autoclosure () -> Comment? = nil,
@@ -78,12 +80,14 @@
 ///   - sourceLocation: The source location to which recorded expectations and
 ///     issues should be attributed.
 ///
-/// - Returns: The unwrapped value of `value`.
+/// - Returns: The unwrapped value of `optionalValue`.
 ///
-/// - Throws: An instance of ``ExpectationFailedError`` if `value` is `nil`.
+/// - Throws: An instance of ``ExpectationFailedError`` if `optionalValue` is
+///   `nil`.
 ///
-/// If `value` is `nil`, an ``Issue`` is recorded for the test that is running
-/// in the current task and an instance of ``ExpectationFailedError`` is thrown.
+/// If `optionalValue` is `nil`, an ``Issue`` is recorded for the test that is
+/// running in the current task and an instance of ``ExpectationFailedError`` is
+/// thrown.
 ///
 /// This overload of ``require(_:_:sourceLocation:)-6w9oo`` checks if
 /// `optionalValue` may be ambiguous (i.e. it is unclear if the developer

--- a/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
+++ b/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
@@ -98,10 +98,10 @@ private func _diagnoseTrivialBooleanValue(from expr: ExprSyntax, for macro: some
 ///
 /// This function handles expressions such as `!foo` or `!(bar)`.
 private func _negatedExpression(_ expr: ExprSyntax, in context: some MacroExpansionContext) -> ExprSyntax? {
-  let expr = _removeParentheses(from: expr) ?? expr
+  let expr = removeParentheses(from: expr) ?? expr
   if let op = expr.as(PrefixOperatorExprSyntax.self),
      op.operator.tokenKind == .prefixOperator("!") {
-    return _removeParentheses(from: op.expression) ?? op.expression
+    return removeParentheses(from: op.expression) ?? op.expression
   }
 
   return nil
@@ -117,12 +117,12 @@ private func _negatedExpression(_ expr: ExprSyntax, in context: some MacroExpans
 ///
 /// This function handles expressions such as `(foo)` or `((foo, bar))`. It does
 /// not remove interior parentheses (e.g. `(foo, (bar))`.)
-private func _removeParentheses(from expr: ExprSyntax) -> ExprSyntax? {
+func removeParentheses(from expr: ExprSyntax) -> ExprSyntax? {
   if let tuple = expr.as(TupleExprSyntax.self),
       tuple.elements.count == 1,
      let elementExpr = tuple.elements.first,
      elementExpr.label == nil {
-    return _removeParentheses(from: elementExpr.expression) ?? elementExpr.expression
+    return removeParentheses(from: elementExpr.expression) ?? elementExpr.expression
   }
 
   return nil
@@ -478,7 +478,7 @@ private func _parseCondition(from expr: ExprSyntax, for macro: some Freestanding
 
   // Parentheses are parsed as if they were tuples, so (true && false) appears
   // to the parser as a tuple containing one expression, `true && false`.
-  if let expr = _removeParentheses(from: expr) {
+  if let expr = removeParentheses(from: expr) {
     return _parseCondition(from: expr, for: macro, in: context)
   }
 

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -317,7 +317,7 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
   static func optionalBoolExprIsAmbiguous(_ boolExpr: ExprSyntax) -> Self {
     Self(
       syntax: Syntax(boolExpr),
-      message: "The requirement '\(boolExpr.trimmed)' is ambiguous.",
+      message: "Requirement '\(boolExpr.trimmed)' is ambiguous.",
       severity: .warning,
       fixIts: [
         FixIt(

--- a/Sources/TestingMacros/TestingMacrosMain.swift
+++ b/Sources/TestingMacros/TestingMacrosMain.swift
@@ -26,6 +26,7 @@ struct TestingMacrosMain: CompilerPlugin {
       TestDeclarationMacro.self,
       ExpectMacro.self,
       RequireMacro.self,
+      AmbiguousRequireMacro.self,
       TagMacro.self,
     ]
   }

--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -292,6 +292,30 @@ struct ConditionMacroTests {
     #expect(diagnostics.count == 0)
   }
 
+  @Test("#require(Bool?) produces a diagnostic")
+  func requireOptionalBoolProducesDiagnostic() throws {
+    let input = "#requireAmbiguous(expression)"
+    let (_, diagnostics) = try parse(input)
+
+    try #require(diagnostics.count == 3)
+    #expect(diagnostics[0].diagMessage.severity == .warning)
+    #expect(diagnostics[0].message.contains("is ambiguous"))
+    #expect(diagnostics[1].diagMessage.severity == .note)
+    #expect(diagnostics[1].message.contains("?? false"))
+    #expect(diagnostics[2].diagMessage.severity == .note)
+    #expect(diagnostics[2].message.contains("as Bool?"))
+  }
+
+  @Test("#require(as Bool?) suppresses its diagnostic")
+  func requireOptionalBoolSuppressedWithExplicitType() throws {
+    // Note we do not need to test "as Bool" (non-optional) because an
+    // expression of type Bool rather than Bool? won't trigger the additional
+    // diagnostics in the first place.
+    let input = "#requireAmbiguous(expression as Bool?)"
+    let (_, diagnostics) = try parse(input)
+    #expect(diagnostics.isEmpty)
+  }
+
   @Test("Macro expansion is performed within a test function")
   func macroExpansionInTestFunction() throws {
     let input = ##"""

--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -292,9 +292,16 @@ struct ConditionMacroTests {
     #expect(diagnostics.count == 0)
   }
 
-  @Test("#require(Bool?) produces a diagnostic")
-  func requireOptionalBoolProducesDiagnostic() throws {
-    let input = "#requireAmbiguous(expression)"
+  @Test("#require(Bool?) produces a diagnostic",
+    arguments: [
+      "#requireAmbiguous(expression)",
+      "#requireAmbiguous((expression))",
+      "#requireAmbiguous(a + b)",
+      "#requireAmbiguous((a + b))",
+      "#requireAmbiguous((a) + (b))",
+    ]
+  )
+  func requireOptionalBoolProducesDiagnostic(input: String) throws {
     let (_, diagnostics) = try parse(input)
 
     let diagnostic = try #require(diagnostics.first)
@@ -305,12 +312,21 @@ struct ConditionMacroTests {
     #expect(diagnostic.fixIts[1].message.message.contains("?? false"))
   }
 
-  @Test("#require(as Bool?) suppresses its diagnostic")
-  func requireOptionalBoolSuppressedWithExplicitType() throws {
+  @Test("#require(as Bool?) suppresses its diagnostic",
+    arguments: [
+      "#requireAmbiguous(expression as Bool?)",
+      "#requireAmbiguous((expression as Bool?))",
+      "#requireAmbiguous((expression) as Bool?)",
+      "#requireAmbiguous(a + b as Bool?)",
+      "#requireAmbiguous((a + b) as Bool?)",
+      "#requireAmbiguous((a) + (b) as Bool?)",
+      "#requireAmbiguous(((a) + (b)) as Bool?)",
+    ]
+  )
+  func requireOptionalBoolSuppressedWithExplicitType(input: String) throws {
     // Note we do not need to test "as Bool" (non-optional) because an
     // expression of type Bool rather than Bool? won't trigger the additional
     // diagnostics in the first place.
-    let input = "#requireAmbiguous(expression as Bool?)"
     let (_, diagnostics) = try parse(input)
     #expect(diagnostics.isEmpty)
   }

--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -297,13 +297,12 @@ struct ConditionMacroTests {
     let input = "#requireAmbiguous(expression)"
     let (_, diagnostics) = try parse(input)
 
-    try #require(diagnostics.count == 3)
-    #expect(diagnostics[0].diagMessage.severity == .warning)
-    #expect(diagnostics[0].message.contains("is ambiguous"))
-    #expect(diagnostics[1].diagMessage.severity == .note)
-    #expect(diagnostics[1].message.contains("?? false"))
-    #expect(diagnostics[2].diagMessage.severity == .note)
-    #expect(diagnostics[2].message.contains("as Bool?"))
+    let diagnostic = try #require(diagnostics.first)
+    #expect(diagnostic.diagMessage.severity == .warning)
+    #expect(diagnostic.message.contains("is ambiguous"))
+    #expect(diagnostic.fixIts.count == 2)
+    #expect(diagnostic.fixIts[0].message.message.contains("as Bool?"))
+    #expect(diagnostic.fixIts[1].message.message.contains("?? false"))
   }
 
   @Test("#require(as Bool?) suppresses its diagnostic")

--- a/Tests/TestingMacrosTests/TestSupport/Parse.swift
+++ b/Tests/TestingMacrosTests/TestSupport/Parse.swift
@@ -21,6 +21,7 @@ import SwiftSyntaxMacroExpansion
 fileprivate let allMacros: [String: any Macro.Type] = [
   "expect": ExpectMacro.self,
   "require": RequireMacro.self,
+  "requireAmbiguous": AmbiguousRequireMacro.self, // different name needed only for unit testing
   "Suite": SuiteDeclarationMacro.self,
   "Test": TestDeclarationMacro.self,
 ]


### PR DESCRIPTION
This PR adds new diagnostics when `#require()` is passed an argument of type `Bool?` because such an argument may be ambiguously interpreted. If the test author writes:

```swift
try #require(love?.isFleeting)
```

Do they mean to unwrap the optional boolean value and return it, or do they mean to test if `isFleeting` is true or false?

With this change, an expression such as that one that returns a value of type `Bool?` will produce a diagnostic of the form:

![Screenshot 2024-03-08 at 4 41 30 PM](https://github.com/apple/swift-testing/assets/4145863/248105f8-1d48-4c9b-96b9-e6e3b066b4ca)

(The diagnostics are presented as fix-its in Xcode.)

Resolves rdar://105727852.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
