### PR TITLE
Adopt `lexicalContext` from swift-syntax-6.0.0.

### DIFF
--- a/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
@@ -94,9 +94,17 @@ extension FunctionDeclSyntax {
       if signature.effectSpecifiers?.asyncSpecifier != nil {
         selector += "WithCompletionHandler"
         colonToken = .colonToken()
-      } else if signature.effectSpecifiers?.throwsSpecifier != nil {
-        selector += "AndReturnError"
-        colonToken = .colonToken()
+      } else {
+        let hasThrowsSpecifier: Bool
+#if canImport(SwiftSyntax600)
+        hasThrowsSpecifier = signature.effectSpecifiers?.throwsClause != nil
+#else
+        hasThrowsSpecifier = signature.effectSpecifiers?.throwsSpecifier != nil
+#endif
+        if hasThrowsSpecifier {
+          selector += "AndReturnError"
+          colonToken = .colonToken()
+        }
       }
       return ObjCSelectorPieceListSyntax {
         ObjCSelectorPieceSyntax(name: .identifier(selector), colon: colonToken)

--- a/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
@@ -87,3 +87,24 @@ func diagnoseIssuesWithTags(in traitExprs: [ExprSyntax], addedTo attribute: Attr
     }
   }
 }
+
+#if canImport(SwiftSyntax600)
+/// Diagnose issues with the lexical context containing a declaration.
+///
+/// - Parameters:
+///   - decl: The declaration to inspect.
+///   - testAttribute: The `@Test` attribute applied to `decl`.
+///   - context: The macro context in which the expression is being parsed.
+///
+/// - Returns: An array of zero or more diagnostic messages related to the
+///   lexical context containing `decl`.
+func diagnoseIssuesWithLexicalContext(
+  containing decl: some DeclSyntaxProtocol,
+  attribute: AttributeSyntax,
+  in context: some MacroExpansionContext
+) -> [DiagnosticMessage] {
+  context.lexicalContext
+    .filter { !$0.isProtocol((any DeclGroupSyntax).self) }
+    .map { .containingNodeUnsupported($0, whenUsing: attribute) }
+}
+#endif

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -138,8 +138,13 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
       result = ("subscript", "a")
     case .enumCaseDecl:
       result = ("enumeration case", "an")
+#if canImport(SwiftSyntax600)
+    case .typeAliasDecl:
+      result = ("typealias", "a")
+#else
     case .typealiasDecl:
       result = ("typealias", "a")
+#endif
     case .macroDecl:
       result = ("macro", "a")
     case .protocolDecl:

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -225,6 +225,27 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
     )
   }
 
+#if canImport(SwiftSyntax600)
+  /// Create a diagnostic message stating that the given attribute cannot be
+  /// used within a lexical context.
+  ///
+  /// - Parameters:
+  ///   - node: The lexical context preventing the use of `attribute`.
+  ///   - attribute: The `@Test` or `@Suite` attribute.
+  ///
+  /// - Returns: A diagnostic message.
+  static func containingNodeUnsupported(_ node: some SyntaxProtocol, whenUsing attribute: AttributeSyntax) -> Self {
+    // It would be great if the diagnostic pointed to the containing lexical
+    // context that was unsupported, but that node may be synthesized and does
+    // not have reliable location information.
+    Self(
+      syntax: Syntax(attribute),
+      message: "The @\(attribute.attributeNameText) attribute cannot be applied within \(_kindString(for: node, includeA: true)).",
+      severity: .error
+    )
+  }
+#endif
+
   /// Create a diagnostic message stating that the given attribute has no effect
   /// when applied to the given extension declaration.
   ///
@@ -406,7 +427,6 @@ extension MacroExpansionContext {
   ///   - message: The diagnostic message to emit. The `node` and `position`
   ///     arguments to `Diagnostic.init()` are derived from the message's
   ///     `syntax` property.
-  ///   - fixIts: Any Fix-Its to apply.
   func diagnose(_ message: DiagnosticMessage) {
     diagnose(
       Diagnostic(
@@ -416,6 +436,16 @@ extension MacroExpansionContext {
         fixIts: message.fixIts
       )
     )
+  }
+
+  /// Emit a sequence of diagnostic messages.
+  ///
+  /// - Parameters:
+  ///   - messages: The diagnostic messages to emit.
+  func diagnose(_ messages: some Sequence<DiagnosticMessage>) {
+    for message in messages {
+      diagnose(message)
+    }
   }
 
   /// Emit a diagnostic message for debugging purposes during development of the

--- a/Tests/TestingMacrosTests/TestSupport/Parse.swift
+++ b/Tests/TestingMacrosTests/TestSupport/Parse.swift
@@ -35,8 +35,17 @@ func parse(_ sourceCode: String, activeMacros activeMacroNames: [String] = [], r
   }
   let operatorTable = OperatorTable.standardOperators
   let originalSyntax = try operatorTable.foldAll(Parser.parse(source: sourceCode))
+#if canImport(SwiftSyntax600)
+  let context = BasicMacroExpansionContext(lexicalContext: [], expansionDiscriminator: "", sourceFiles: [:])
+  let syntax = try operatorTable.foldAll(
+    originalSyntax.expand(macros: activeMacros) { syntax in
+      BasicMacroExpansionContext(sharingWith: context, lexicalContext: syntax.allMacroLexicalContexts())
+    }
+  )
+#else
   let context = BasicMacroExpansionContext(expansionDiscriminator: "", sourceFiles: [:])
   let syntax = try operatorTable.foldAll(originalSyntax.expand(macros: activeMacros, in: context))
+#endif
   var sourceCode = String(describing: syntax.formatted().trimmed)
   if removeWhitespace {
     sourceCode = sourceCode.filter { !$0.isWhitespace }

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -431,15 +431,15 @@ final class RunnerTests: XCTestCase {
     await fulfillment(of: [expectationCheckedAndPassed, expectationCheckedAndFailed], timeout: 0.0)
   }
 
-  func testPoundIfTrueTestFunctionRuns() async throws {
-    @Suite(.hidden) struct S {
+  @Suite(.hidden) struct PoundIfTrueTest {
 #if true
-      @Test(.hidden) func f() {}
-      @Test(.hidden) func g() {}
+    @Test(.hidden) func f() {}
+    @Test(.hidden) func g() {}
 #endif
-      @Test(.hidden) func h() {}
-    }
+    @Test(.hidden) func h() {}
+  }
 
+  func testPoundIfTrueTestFunctionRuns() async throws {
     let testStarted = expectation(description: "Test started")
     testStarted.expectedFulfillmentCount = 4
     var configuration = Configuration()
@@ -448,19 +448,19 @@ final class RunnerTests: XCTestCase {
         testStarted.fulfill()
       }
     }
-    await runTest(for: S.self, configuration: configuration)
+    await runTest(for: PoundIfTrueTest.self, configuration: configuration)
     await fulfillment(of: [testStarted], timeout: 0.0)
   }
 
-  func testPoundIfFalseTestFunctionDoesNotRun() async throws {
-    @Suite(.hidden) struct S {
+  @Suite(.hidden) struct PoundIfFalseTest {
 #if false
-      @Test(.hidden) func f() {}
-      @Test(.hidden) func g() {}
+    @Test(.hidden) func f() {}
+    @Test(.hidden) func g() {}
 #endif
-      @Test(.hidden) func h() {}
-    }
+    @Test(.hidden) func h() {}
+  }
 
+  func testPoundIfFalseTestFunctionDoesNotRun() async throws {
     let testStarted = expectation(description: "Test started")
     testStarted.expectedFulfillmentCount = 2
     var configuration = Configuration()
@@ -469,21 +469,21 @@ final class RunnerTests: XCTestCase {
         testStarted.fulfill()
       }
     }
-    await runTest(for: S.self, configuration: configuration)
+    await runTest(for: PoundIfFalseTest.self, configuration: configuration)
     await fulfillment(of: [testStarted], timeout: 0.0)
   }
 
-  func testPoundIfFalseElseTestFunctionRuns() async throws {
-    @Suite(.hidden) struct S {
+  @Suite(.hidden) struct PoundIfFalseElseTest {
 #if false
 #elseif false
 #else
-      @Test(.hidden) func f() {}
-      @Test(.hidden) func g() {}
+    @Test(.hidden) func f() {}
+    @Test(.hidden) func g() {}
 #endif
-      @Test(.hidden) func h() {}
-    }
+    @Test(.hidden) func h() {}
+  }
 
+  func testPoundIfFalseElseTestFunctionRuns() async throws {
     let testStarted = expectation(description: "Test started")
     testStarted.expectedFulfillmentCount = 4
     var configuration = Configuration()
@@ -492,21 +492,21 @@ final class RunnerTests: XCTestCase {
         testStarted.fulfill()
       }
     }
-    await runTest(for: S.self, configuration: configuration)
+    await runTest(for: PoundIfFalseElseTest.self, configuration: configuration)
     await fulfillment(of: [testStarted], timeout: 0.0)
   }
 
-  func testPoundIfFalseElseIfTestFunctionRuns() async throws {
-    @Suite(.hidden) struct S {
+  @Suite(.hidden) struct PoundIfFalseElseIfTest {
 #if false
 #elseif false
 #elseif true
-      @Test(.hidden) func f() {}
-      @Test(.hidden) func g() {}
+    @Test(.hidden) func f() {}
+    @Test(.hidden) func g() {}
 #endif
-      @Test(.hidden) func h() {}
-    }
+    @Test(.hidden) func h() {}
+  }
 
+  func testPoundIfFalseElseIfTestFunctionRuns() async throws {
     let testStarted = expectation(description: "Test started")
     testStarted.expectedFulfillmentCount = 4
     var configuration = Configuration()
@@ -515,35 +515,35 @@ final class RunnerTests: XCTestCase {
         testStarted.fulfill()
       }
     }
-    await runTest(for: S.self, configuration: configuration)
+    await runTest(for: PoundIfFalseElseIfTest.self, configuration: configuration)
     await fulfillment(of: [testStarted], timeout: 0.0)
   }
 
-  func testNoasyncTestsAreCallable() async throws {
-    @Suite(.hidden) struct S {
-      @Test(.hidden)
-      @available(*, noasync)
-      func noAsync() {}
+  @Suite(.hidden) struct NoasyncTestsAreCallableTests {
+    @Test(.hidden)
+    @available(*, noasync)
+    func noAsync() {}
 
-      @Test(.hidden)
-      @available(*, noasync)
-      func noAsyncThrows() throws {}
+    @Test(.hidden)
+    @available(*, noasync)
+    func noAsyncThrows() throws {}
 
-      @Test(.hidden)
-      @_unavailableFromAsync
-      func unavailableFromAsync() {}
+    @Test(.hidden)
+    @_unavailableFromAsync
+    func unavailableFromAsync() {}
 
-      @Test(.hidden)
-      @_unavailableFromAsync(message: "")
-      func unavailableFromAsyncWithMessage() {}
+    @Test(.hidden)
+    @_unavailableFromAsync(message: "")
+    func unavailableFromAsyncWithMessage() {}
 
 #if !SWT_NO_GLOBAL_ACTORS
-      @Test(.hidden)
-      @available(*, noasync) @MainActor
-      func noAsyncThrowsMainActor() throws {}
+    @Test(.hidden)
+    @available(*, noasync) @MainActor
+    func noAsyncThrowsMainActor() throws {}
 #endif
-    }
+  }
 
+  func testNoasyncTestsAreCallable() async throws {
     let testStarted = expectation(description: "Test started")
 #if !SWT_NO_GLOBAL_ACTORS
     testStarted.expectedFulfillmentCount = 6
@@ -556,7 +556,7 @@ final class RunnerTests: XCTestCase {
         testStarted.fulfill()
       }
     }
-    await runTest(for: S.self, configuration: configuration)
+    await runTest(for: NoasyncTestsAreCallableTests.self, configuration: configuration)
     await fulfillment(of: [testStarted], timeout: 0.0)
   }
 


### PR DESCRIPTION
This PR conditionally adopts the new `lexicalContext` member of `MacroExpansionContext` added in https://github.com/apple/swift-syntax/pull/1554. If the SwiftSyntax600 pseudo-module is available, then this member should be available for use and can be used to perform additional diagnostics for tests and to get the names of their containing types.

With this PR, if built against an older toolchain (5.11 or earlier), the old hacky "is there leading whitespace?" mechanism is still used.

A future PR will recursively perform suite-level diagnostics on the lexical contexts containing tests and suites, so that a test cannot be (easily) inserted into a type that cannot be used as a suite.

Resolves rdar://109439578.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
