### PR TITLE
Move remaining SPI to SPI group `ForToolsIntegrationOnly`.

### DIFF
--- a/Sources/Testing/Parameterization/Test.Case.ID.swift
+++ b/Sources/Testing/Parameterization/Test.Case.ID.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@_spi(ExperimentalTestRunning)
+@_spi(ForToolsIntegrationOnly)
 extension Test.Case: Identifiable {
   /// The ID of a test case.
   ///

--- a/Sources/Testing/Parameterization/Test.Case.swift
+++ b/Sources/Testing/Parameterization/Test.Case.swift
@@ -20,7 +20,7 @@ extension Test {
     public struct Argument: Sendable {
       /// A type representing the stable, unique identifier of a parameterized
       /// test argument.
-      @_spi(ExperimentalTestRunning)
+      @_spi(ForToolsIntegrationOnly)
       public struct ID: Sendable {
         /// The raw bytes of this instance's identifier.
         public var bytes: [UInt8]
@@ -44,7 +44,7 @@ extension Test {
       /// ## See Also
       ///
       /// - ``CustomTestArgumentEncodable``
-      @_spi(ExperimentalTestRunning)
+      @_spi(ForToolsIntegrationOnly)
       public var id: ID? {
         // FIXME: Capture the error and propagate to the user, not as a test
         // failure but as an advisory warning. A missing argument ID will

--- a/Sources/Testing/Running/SkipInfo.swift
+++ b/Sources/Testing/Running/SkipInfo.swift
@@ -9,7 +9,7 @@
 //
 
 /// A type representing the details of a skipped test.
-@_spi(ExperimentalTestRunning)
+@_spi(ForToolsIntegrationOnly)
 public struct SkipInfo: Sendable {
   /// A user-specified comment describing this skip, if any.
   public var comment: Comment?

--- a/Sources/Testing/Test.ID.swift
+++ b/Sources/Testing/Test.ID.swift
@@ -55,7 +55,7 @@ extension Test: Identifiable {
     ///     module name) of the corresponding test.
     ///   - sourceLocation: The source location of the corresponding test. For
     ///     test suite types, pass `nil`.
-    @_spi(ExperimentalTestRunning)
+    @_spi(ForToolsIntegrationOnly)
     public init(moduleName: String, nameComponents: [String], sourceLocation: SourceLocation?) {
       self.moduleName = moduleName
       self.nameComponents = nameComponents
@@ -69,7 +69,7 @@ extension Test: Identifiable {
     ///   - type: The test suite type.
     ///
     /// This initializer produces a test ID corresponding to the given type.
-    @_spi(ExperimentalTestRunning)
+    @_spi(ForToolsIntegrationOnly)
     public init(type: Any.Type) {
       self.init(Testing.nameComponents(of: type))
     }

--- a/Tests/TestingTests/EventTests.swift
+++ b/Tests/TestingTests/EventTests.swift
@@ -11,7 +11,7 @@
 #if canImport(Foundation)
 import Foundation
 #endif
-@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalTestRunning) import Testing
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 private import TestingInternals
 
 @Suite("Event Tests")

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ForToolsIntegrationOnly) @_spi(ExperimentalTestRunning) import Testing
+@testable @_spi(ForToolsIntegrationOnly) import Testing
 
 @Test(/* name unspecified */ .hidden)
 @Sendable func freeSyncFunction() {}

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -10,7 +10,7 @@
 
 #if canImport(XCTest)
 import XCTest
-@testable @_spi(Experimental) @_spi(ExperimentalTestRunning) @_spi(ForToolsIntegrationOnly) import Testing
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
 struct MyError: Error, Equatable {
 }

--- a/Tests/TestingTests/SkipInfoTests.swift
+++ b/Tests/TestingTests/SkipInfoTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalTestRunning) import Testing
+@testable @_spi(ForToolsIntegrationOnly) import Testing
 
 @Suite("SkipInfo Tests")
 struct SkipInfoTests {

--- a/Tests/TestingTests/Test.Case.Argument.IDTests.swift
+++ b/Tests/TestingTests/Test.Case.Argument.IDTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalTestRunning) @_spi(ForToolsIntegrationOnly) @_spi(Experimental) import Testing
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 #if canImport(Foundation)
 import Foundation
 #endif

--- a/Tests/TestingTests/Test.Case.ArgumentTests.swift
+++ b/Tests/TestingTests/Test.Case.ArgumentTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ForToolsIntegrationOnly) @_spi(Experimental) import Testing
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
 @Suite("Test.Case.Argument Tests")
 struct Test_Case_ArgumentTests {

--- a/Tests/TestingTests/TestCaseSelectionTests.swift
+++ b/Tests/TestingTests/TestCaseSelectionTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ForToolsIntegrationOnly) @_spi(Experimental) import Testing
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
 @Suite("Test.Case Selection Tests")
 struct TestCaseSelectionTests {

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ExperimentalTestRunning) @_spi(ForToolsIntegrationOnly) import Testing
+@testable @_spi(ForToolsIntegrationOnly) import Testing
 #if canImport(XCTest)
 import XCTest
 #endif

--- a/Tests/TestingTests/Traits/CustomExecutionTraitTests.swift
+++ b/Tests/TestingTests/Traits/CustomExecutionTraitTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ForToolsIntegrationOnly) @_spi(Experimental) import Testing
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
 private struct CustomTrait: CustomExecutionTrait, TestTrait {
   var before: Confirmation


### PR DESCRIPTION
This PR moves all remaining SPI under old group names to the `ForToolsIntegrationOnly` SPI group per the SPI policy outlined [here](https://github.com/apple/swift-testing/blob/main/Documentation/SPI.md).

I don't think I've missed anything, but please open issues or PRs if you find something still under an old group name.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
