### PR TITLE
Make event recorder types non-copyable.

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
@@ -15,7 +15,7 @@ extension Event {
   /// The format of the output is not meant to be machine-readable and is
   /// subject to change. For machine-readable output, use ``JUnitXMLRecorder``.
   @_spi(ForToolsIntegrationOnly)
-  public struct ConsoleOutputRecorder: Sendable {
+  public struct ConsoleOutputRecorder: Sendable, ~Copyable {
     /// An enumeration describing options to use when writing events to a
     /// stream.
     public enum Option: Sendable {
@@ -233,8 +233,10 @@ extension Event.ConsoleOutputRecorder {
   ///   with ANSI escape codes used to colorize them. If ANSI escape codes are
   ///   not enabled or if no tag colors are set, returns the empty string.
   fileprivate func colorDots(for tags: Set<Tag>) -> String {
+    let tagColors = tagColors
     let unsortedColors = tags.lazy.compactMap { tagColors[$0] }
 
+    let options = options
     var result: String = Set(unsortedColors)
       .sorted(by: <).lazy
       .compactMap { $0.ansiEscapeCode(options: options) }
@@ -288,7 +290,7 @@ extension Event.ConsoleOutputRecorder {
         // text instead of just the symbol.
         write("\(_ansiEscapeCodePrefix)90m\(symbol) \(message.stringValue)\(_resetANSIEscapeCode)\n")
       } else {
-        let colorDots = context.test.map(\.tags).map(colorDots(for:)) ?? ""
+        let colorDots = context.test.map(\.tags).map { self.colorDots(for: $0) } ?? ""
         write("\(symbol) \(colorDots)\(message.stringValue)\n")
       }
     }

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -18,7 +18,7 @@ extension Event {
   /// The format of the output is not meant to be machine-readable and is
   /// subject to change. For machine-readable output, use ``JUnitXMLRecorder``.
   @_spi(ForToolsIntegrationOnly)
-  public struct HumanReadableOutputRecorder: Sendable {
+  public struct HumanReadableOutputRecorder: Sendable, ~Copyable {
     /// A type describing a human-readable message produced by an instance of
     /// ``Event/HumanReadableOutputRecorder``.
     public struct Message: Sendable {

--- a/Sources/Testing/Events/Recorder/Event.JUnitXMLRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.JUnitXMLRecorder.swift
@@ -12,7 +12,7 @@ extension Event {
   /// A type which handles ``Event`` instances and outputs representations of
   /// them as JUnit-compatible XML.
   @_spi(ForToolsIntegrationOnly)
-  public struct JUnitXMLRecorder: Sendable {
+  public struct JUnitXMLRecorder: Sendable, ~Copyable {
     /// The write function for this event recorder.
     var write: @Sendable (String) -> Void
 


### PR DESCRIPTION
This PR makes the event recorder types in swift-testing non-copyable. They can still be captured by an event handler without issue, but cannot be moved around. An event recorder carries with it a large amount of data (the statistics around recorded events that are used to inform later events) and copying them, even inadvertently, can be very expensive.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
