### PR TITLE
Make `Event.Context` non-copyable.

### DIFF
--- a/Sources/Testing/Events/Event.swift
+++ b/Sources/Testing/Events/Event.swift
@@ -209,7 +209,7 @@ extension Event {
   ///
   /// An instance of this type is provided along with each ``Event`` that is
   /// passed to an ``Event/Handler``.
-  public struct Context: Sendable {
+  public struct Context: Sendable, ~Copyable {
     /// The test for which this instance's associated ``Event`` occurred, if
     /// any.
     ///

--- a/Tests/TestingTests/Test.Case.ArgumentTests.swift
+++ b/Tests/TestingTests/Test.Case.ArgumentTests.swift
@@ -19,7 +19,7 @@ struct Test_Case_ArgumentTests {
       guard case .testCaseStarted = event.kind else {
         return
       }
-      let testCase = try #require(context.testCase)
+      let testCase = try #require(context.testCase as Test.Case?)
       try #require(testCase.arguments.count == 1)
 
       let argument = testCase.arguments[0]
@@ -38,7 +38,7 @@ struct Test_Case_ArgumentTests {
       guard case .testCaseStarted = event.kind else {
         return
       }
-      let testCase = try #require(context.testCase)
+      let testCase = try #require(context.testCase as Test.Case?)
       try #require(testCase.arguments.count == 2)
 
       do {
@@ -65,7 +65,7 @@ struct Test_Case_ArgumentTests {
       guard case .testCaseStarted = event.kind else {
         return
       }
-      let testCase = try #require(context.testCase)
+      let testCase = try #require(context.testCase as Test.Case?)
       try #require(testCase.arguments.count == 1)
 
       let argument = testCase.arguments[0]
@@ -84,7 +84,7 @@ struct Test_Case_ArgumentTests {
       guard case .testCaseStarted = event.kind else {
         return
       }
-      let testCase = try #require(context.testCase)
+      let testCase = try #require(context.testCase as Test.Case?)
       try #require(testCase.arguments.count == 1)
 
       let argument = testCase.arguments[0]
@@ -105,7 +105,7 @@ struct Test_Case_ArgumentTests {
       guard case .testCaseStarted = event.kind else {
         return
       }
-      let testCase = try #require(context.testCase)
+      let testCase = try #require(context.testCase as Test.Case?)
       try #require(testCase.arguments.count == 2)
 
       do {
@@ -132,7 +132,7 @@ struct Test_Case_ArgumentTests {
       guard case .testCaseStarted = event.kind else {
         return
       }
-      let testCase = try #require(context.testCase)
+      let testCase = try #require(context.testCase as Test.Case?)
       try #require(testCase.arguments.count == 1)
 
       let argument = testCase.arguments[0]


### PR DESCRIPTION
`Event.Context` contains a significant amount of data (a copy of the current test, current test case, and all parameterized inputs to the test.) It should not be possible to accidentally make a copy of this data.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
