### PR TITLE
Improve 16-color console output.

### DIFF
--- a/Tests/TestingTests/Traits/TagListTests.swift
+++ b/Tests/TestingTests/Traits/TagListTests.swift
@@ -182,6 +182,26 @@ struct TagListTests {
   }
 #endif
 #endif
+
+  @Test("Tag colors are converted to 16-color correctly",
+    arguments: [
+      // Predefined colors (orange and purple are special-cased)
+      (Tag.Color.red, 91), (.orange, 33), (.yellow, 93), (.green, 92), (.blue, 94), (.purple, 95),
+
+      // Grays
+      (.rgb(0, 0, 0), 30), (.rgb(255, 255, 255), 97), (.rgb(100, 100, 100), 90), (.rgb(200, 200, 200), 37),
+
+      // Dark colors
+      (.rgb(100, 0, 0), 31), (.rgb(100, 100, 0), 33), (.rgb(0, 100, 0), 32), (.rgb(0, 100, 100), 36), (.rgb(0, 0, 100), 34), (.rgb(100, 0, 100), 35),
+
+      // Bright colors
+      (.rgb(200, 0, 0), 91), (.rgb(200, 200, 0), 93), (.rgb(0, 200, 0), 92), (.rgb(0, 200, 200), 96), (.rgb(0, 0, 200), 94), (.rgb(200, 0, 200), 95),
+    ]
+  )
+  func tagColorsTo16Color(tagColor: Tag.Color, ansiEscapeCodeValue: Int) {
+    let ansiEscapeCode = tagColor.closest16ColorEscapeCode().dropFirst() // drop the \e
+    #expect(ansiEscapeCode.contains("\(ansiEscapeCodeValue)m"))
+  }
 }
 
 // MARK: - Fixtures

--- a/Tests/TestingTests/Traits/TagListTests.swift
+++ b/Tests/TestingTests/Traits/TagListTests.swift
@@ -43,6 +43,7 @@ struct TagListTests {
       Tag(kind: .staticMember("blue")),
       Tag(kind: .staticMember("purple"))
     ])
+    #expect(trait.tags.allSatisfy { $0.isPredefinedColor })
   }
 
   @Test("Tag.description property", arguments: [
@@ -180,6 +181,14 @@ struct TagListTests {
       try Testing.loadTagColors(fromFileInDirectoryAtPath: "Directory/That/Does/Not/Exist")
     }
   }
+
+  @Test("Invalid tag color decoding", arguments: [##""#NOTHEX""##, #""garbageColorName""#])
+  func noTagColorsReadFromBadPath(tagColorJSON: String) throws {
+    let tagColorJSONData = try #require(tagColorJSON.data(using: .utf8))
+    #expect(throws: (any Error).self) {
+      _ = try JSONDecoder().decode(Tag.Color.self, from: tagColorJSONData)
+    }
+  }
 #endif
 #endif
 
@@ -201,6 +210,16 @@ struct TagListTests {
   func tagColorsTo16Color(tagColor: Tag.Color, ansiEscapeCodeValue: Int) {
     let ansiEscapeCode = tagColor.closest16ColorEscapeCode().dropFirst() // drop the \e
     #expect(ansiEscapeCode.contains("\(ansiEscapeCodeValue)m"))
+  }
+
+  @Test("Tag color sorting")
+  func tagColorSorting() {
+    // By hue
+    #expect(Tag.Color.rgb(200, 0, 0) < .rgb(0, 0, 200))
+    // By saturation
+    #expect(Tag.Color.rgb(100, 50, 50) < .rgb(100, 0, 0))
+    // By value
+    #expect(Tag.Color.rgb(0, 0, 0) < .rgb(100, 100, 100))
   }
 }
 


### PR DESCRIPTION
For terminals/consoles that only support 16 colors (e.g. the non-graphical Linux command line), we currently drop the ball for a lot of tag colors. This PR adds mapping from tag colors with arbitrary RGB values to the typical 4-bit color space used by ANSI-compatible terminals.

To experiment with 16-color mode, use a terminal application without 256-color or true-color support, or manually opt in by clearing the environment variable `COLORTERM` and setting the environment variable `TERM` to `"xterm-16color"` or compatible.

Tag colors remain an **experimental** feature. To add colors to tags in your package, see [the documentation](https://swiftpackageindex.com/apple/swift-testing/main/documentation/testing/addingtags#Customizing-a-tags-appearance).

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
