### PR TITLE
Add experimental support for event streaming using JSON.

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.JUnitXMLRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.JUnitXMLRecorder.swift
@@ -205,6 +205,15 @@ extension Event.JUnitXMLRecorder {
     string.lazy.map(_escapeForXML).joined()
   }
 
+  /// Record the specified event by generating a representation of it in this
+  /// instance's output format and writing it to this instance's destination.
+  ///
+  /// - Parameters:
+  ///   - event: The event to record.
+  ///   - context: The context associated with the event.
+  ///
+  /// - Returns: Whether any output was produced and written to this instance's
+  ///   destination.
   @discardableResult public func record(_ event: borrowing Event, in context: borrowing Event.Context) -> Bool {
     if let output = _record(event, in: context) {
       write(output)

--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -322,8 +322,8 @@ private func _eventHandlerForStreamingEvents(toFileAtPath path: String) throws -
       }
 
 #if DEBUG
-      // We don't actually JSONEncoder() to produce output containing newline
-      // characters, so in debug builds we'll log a diagnostic message.
+      // We don't actually expect JSONEncoder() to produce output containing
+      // newline characters, so in debug builds we'll log a diagnostic message.
       if snapshotJSON.contains(where: isASCIINewline) {
         let message = Event.ConsoleOutputRecorder.warning(
           "JSONEncoder() produced one or more newline characters while encoding an event snapshot with kind '\(event.kind)'. Please file a bug report at https://github.com/apple/swift-testing/issues/new",


### PR DESCRIPTION
This PR adds a new command-line argument to the SwiftPM entry point that allows callers to stream snapshots of events to a file or named pipe. Note that this argument has not (yet) been added to `swift test`, so to use it you must first call `swift build --build-tests`, then invoke the executable build product directly.

This functionality would be useful for clients like VSCode that want to gather detailed, structured output as it is generated. The existing XML-based output is of course structured, but is only available and parseable after the test process finishes, and may fail to decode if the test process crashes.

~~The output format consists of JSON blobs representing each event along with its associated test and test case (where applicable.) The events are encoded to JSON, then the size of the JSON is transmitted as a 64-bit little-endian integer followed by the JSON itself. The lengths are binary and UTF-8 is assumed for the JSON. (We considered using [JSONL](https://jsonlines.org/), but it's significantly harder to decode when using e.g. standard C file streams, which makes it harder for us to test.)~~ We're usin' JSONL.

Any writeable file path can be passed. A regular file can be used, however most platforms will not allow reading from a regular file while it is open for writing. Instead, on platforms where it is supported, a named pipe can be used. On Darwin and Linux, you can use [`mkfifo()`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/mkfifo.html). On Windows, you can use [`CreateNamedPipeA()`](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createnamedpipea). Bash and Windows PowerShell have equivalents that can be used instead of C functions if needed.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
