### PR TITLE
Fix typo

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -39,7 +39,7 @@ principles and goals.
 - [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md)
   describes this project's guidelines for code and documentation style.
 - [SPI groups in swift-testing](https://github.com/apple/swift-testing/blob/main/Documentation/SPI.md)
-  describes wheh and how the testing library uses Swift SPI.
+  describes when and how the testing library uses Swift SPI.
 
 ## Project maintenance
 


### PR DESCRIPTION
Fix a typo in `Documentation/README.md`

### Motivation:

We don't like typos?

### Modifications:

Fix a typo "wheh" -> "when" in `Documentation/README.md`

### Result:

No typos.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
