### PR TITLE
Drop remaining 5.9 support.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 5.10
 
 //
 // This source file is part of the Swift.org open source project

--- a/Sources/Testing/Testing.docc/DefiningTests.md
+++ b/Sources/Testing/Testing.docc/DefiningTests.md
@@ -87,7 +87,7 @@ a test is unable to run due to limited availability:
 
 ```swift
 @available(macOS 11.0, *)
-@available(swift, introduced: 5.9, message: "Requires Swift 5.9 features to run")
+@available(swift, introduced: 8.0, message: "Requires Swift 8.0 features to run")
 @Test func foodTruckExists() { ... }
 ```
 

--- a/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
+++ b/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
@@ -27,8 +27,8 @@ To learn how to contribute to the testing library itself, see
 
 ### Downloading a development toolchain
 
-A recent **development snapshot** toolchain is required to use the testing
-library. Visit [swift.org](https://www.swift.org/download/#trunk-development-main)
+A recent **development snapshot** toolchain is required to use all of the
+features of the testing library. Visit [swift.org](https://www.swift.org/download/#trunk-development-main)
 to download and install a toolchain from the section titled
 **Snapshots — Trunk Development (main)**.
 


### PR DESCRIPTION
This PR updates the package manifest to require Swift 5.10 or newer. We previously had a tools version of 5.9 so that content from the package would be indexed by Swift Package Index, but they have updated their systems to use 5.10 so this is no longer required.

As a reminder, Swift 5.10 support is temporary for the benefit of developers who cannot rely on a nightly main-branch toolchain. **Swift 5.10 support will be removed in a future update.**

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
