### PR TITLE
Improve Unicode characters used for CLI output on Windows.

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
@@ -327,7 +327,7 @@ extension Event.ConsoleOutputRecorder {
     for message in messages {
       let symbol = message.symbol?.stringValue(options: options) ?? " "
 
-      if case .details = message.symbol, options.colorBitDepth != nil {
+      if case .details = message.symbol, let colorBitDepth = options.colorBitDepth, colorBitDepth > 1 {
         // Special-case the detail symbol to apply grey to the entire line of
         // text instead of just the symbol.
         write("\(_ansiEscapeCodePrefix)90m\(symbol) \(message.stringValue)\(_resetANSIEscapeCode)\n")

--- a/Sources/Testing/Events/Recorder/Event.Symbol.swift
+++ b/Sources/Testing/Events/Recorder/Event.Symbol.swift
@@ -154,11 +154,11 @@ extension Event.Symbol {
       // Unicode: PLUS-MINUS SIGN
       return "\u{00B1}"
     case .warning:
-      // Unicode: EXCLAMATION MARK
-      return "\u{0021}"
+      // Unicode: BLACK UP-POINTING TRIANGLE
+      return "\u{25B2}"
     case .details:
-      // Unicode: GREATER-THAN SIGN
-      return "\u{003E}"
+      // Unicode: RIGHTWARDS ARROW
+      return "\u{2192}"
     }
 #else
 #warning("Platform-specific implementation missing: Unicode characters unavailable")

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -77,13 +77,9 @@ struct EventRecorderTests {
     #expect(buffer.contains("i → 5"))
     #expect(buffer.contains("Ocelots don't like the number 3."))
 
-    if let colorBitDepth = options.colorBitDepth, colorBitDepth >= 1 {
+    if let colorBitDepth = options.colorBitDepth, colorBitDepth > 1 {
       #expect(buffer.contains("\u{001B}["))
-      if colorBitDepth >= 4 {
-        #expect(buffer.contains("●"))
-      } else {
-        #expect(!buffer.contains("●"))
-      }
+      #expect(buffer.contains("●"))
     } else {
       #expect(!buffer.contains("\u{001B}["))
       #expect(!buffer.contains("●"))


### PR DESCRIPTION
This PR tweaks the set of Unicode characters used on Windows for CLI output. The new characters are, hopefully, visually closer to what we use on macOS and Linux. The Consolas font is assumed.

### Before

!["Before" screenshot of PowerShell showing the old symbols](https://github.com/apple/swift-testing/assets/4145863/694de011-3dec-4414-850d-a351beb4e5fc)

### After

!["After" screenshot of PowerShell showing the new symbols](https://github.com/apple/swift-testing/assets/4145863/8c330741-ddd6-44d0-9674-9bca0f9c4aa4)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
