### PR TITLE
Add a `comment` property to the `.bug()` trait.

### DIFF
--- a/Sources/Testing/Testing.docc/AssociatingBugs.md
+++ b/Sources/Testing/Testing.docc/AssociatingBugs.md
@@ -25,8 +25,8 @@ specific bugs with tests that reproduce them or verify they are fixed.
 
 ## Associating a bug with a test
 
-To associate a bug with a test, use the ``Trait/bug(_:relationship:)-duvt``
-or ``Trait/bug(_:relationship:)-40riy`` function. The first argument to this
+To associate a bug with a test, use the ``Trait/bug(_:relationship:_:)-86mmm``
+or ``Trait/bug(_:relationship:_:)-3hsi5`` function. The first argument to this
 function is the bug's _identifier_ in its bug-tracking system:
 
 ```swift
@@ -55,9 +55,10 @@ expected to fail, or that a failure indicates a regression that requires
 attention from a developer.
 
 To specify how a bug is related to a test, use the `relationship` parameter of
-the ``Trait/bug(_:relationship:)-duvt`` or ``Trait/bug(_:relationship:)-40riy``
-function. For example, to indicate that a test was written to verify a
-previously-fixed bug, one would specify `.verifiesFix`:
+the ``Trait/bug(_:relationship:_:)-86mmm`` or
+``Trait/bug(_:relationship:_:)-3hsi5`` function. For example, to indicate that a
+test was written to verify a previously-fixed bug, one would specify
+`.verifiesFix`:
 
 ```swift
 @Test("Food truck engine works", .bug("12345", relationship: .verifiesFix))
@@ -83,9 +84,27 @@ The testing library defines several kinds of common bug/test relationship:
 <!-- Keep `.unspecified` as the last row above in order to imply it is a
 fallback. -->
 
+## Adding comments to associated bugs
+
+A bug identifier may be insufficient to uniquely and clearly identify a bug
+associated with a test. Bug trackers universally provide a "title" field for
+bugs that is not visible to the testing library. To add a bug's title to a test,
+include it after the bug's identifier and (optionally) its relationship to the
+test:
+
+```swift
+@Test(
+  "Food truck has napkins",
+  .bug("12345", "Forgot to buy more napkins")
+)
+func hasNapkins() async {
+  ...
+}
+```
+
 ## Topics
 
 - <doc:BugIdentifiers>
-- ``Trait/bug(_:relationship:)-duvt``
-- ``Trait/bug(_:relationship:)-40riy``
+- ``Trait/bug(_:relationship:_:)-86mmm``
+- ``Trait/bug(_:relationship:_:)-3hsi5``
 - ``Bug``

--- a/Sources/Testing/Testing.docc/EnablingAndDisabling.md
+++ b/Sources/Testing/Testing.docc/EnablingAndDisabling.md
@@ -83,8 +83,8 @@ func isCold() async throws { ... }
 ```
 
 If a test is disabled because of a problem for which there is a corresponding
-bug report, you can use the ``Trait/bug(_:relationship:)-duvt`` or
-``Trait/bug(_:relationship:)-40riy`` function with the relationship
+bug report, you can use the ``Trait/bug(_:relationship:_:)-86mmm`` or
+``Trait/bug(_:relationship:_:)-3hsi5`` function with the relationship
 ``Bug/Relationship-swift.enum/failingBecauseOfBug``:
 
 ```swift

--- a/Sources/Testing/Traits/Bug.swift
+++ b/Sources/Testing/Traits/Bug.swift
@@ -12,8 +12,8 @@
 ///
 /// To add this trait to a test, use one of the following functions:
 ///
-/// - ``Trait/bug(_:relationship:)-duvt``
-/// - ``Trait/bug(_:relationship:)-40riy``
+/// - ``Trait/bug(_:relationship:_:)-86mmm``
+/// - ``Trait/bug(_:relationship:_:)-3hsi5``
 public struct Bug {
   /// The identifier of this bug in the associated bug-tracking system.
   ///
@@ -25,7 +25,7 @@ public struct Bug {
   ///
   /// For more information on how the testing library uses bug relationships,
   /// see <doc:AssociatingBugs>.
-  public enum Relationship: Sendable, Equatable, Hashable {
+  public enum Relationship: Sendable {
     /// The relationship between the test and this bug is unspecified.
     ///
     /// Use this relationship to describe a bug that is related to a test, but
@@ -62,6 +62,9 @@ public struct Bug {
   /// For more information on how the testing library uses bug relationships,
   /// see <doc:AssociatingBugs>.
   public var relationship: Relationship
+
+  /// An optional, user-specified comment describing this trait.
+  public var comment: Comment?
 }
 
 // MARK: - Equatable, Hashable, Comparable
@@ -80,9 +83,20 @@ extension Bug: Equatable, Hashable, Comparable {
   }
 }
 
+extension Bug.Relationship: Equatable, Hashable {}
+
+// MARK: - Codable
+
+extension Bug: Codable {}
+extension Bug.Relationship: Codable {}
+
 // MARK: - Trait, TestTrait, SuiteTrait
 
-extension Bug: TestTrait, SuiteTrait {}
+extension Bug: TestTrait, SuiteTrait {
+  public var comments: [Comment] {
+    Array(comment)
+  }
+}
 
 extension Trait where Self == Bug {
   /// Construct a bug to track with a test.
@@ -94,10 +108,11 @@ extension Trait where Self == Bug {
   ///   - relationship: The relationship between the bug and the associated
   ///     test. The default value is
   ///     ``Bug/Relationship-swift.enum/unspecified``.
+  ///   - comment: An optional, user-specified comment describing this trait.
   ///
   /// - Returns: An instance of ``Bug`` representing the specified bug.
-  public static func bug(_ identifier: String, relationship: Bug.Relationship = .unspecified) -> Self {
-    Self(identifier: identifier, relationship: relationship)
+  public static func bug(_ identifier: String, relationship: Bug.Relationship = .unspecified, _ comment: Comment? = nil) -> Self {
+    Self(identifier: identifier, relationship: relationship, comment: comment)
   }
 
   /// Construct a bug to track with a test.
@@ -109,10 +124,11 @@ extension Trait where Self == Bug {
   ///   - relationship: The relationship between the bug and the associated
   ///     test. The default value is
   ///     ``Bug/Relationship-swift.enum/unspecified``.
+  ///   - comment: An optional, user-specified comment describing this trait.
   ///
   /// - Returns: An instance of ``Bug`` representing the specified bug.
-  public static func bug(_ identifier: some Numeric, relationship: Bug.Relationship = .unspecified) -> Self {
-    Self(identifier: String(describing: identifier), relationship: relationship)
+  public static func bug(_ identifier: some Numeric, relationship: Bug.Relationship = .unspecified, _ comment: Comment? = nil) -> Self {
+    Self(identifier: String(describing: identifier), relationship: relationship, comment: comment)
   }
 }
 

--- a/Sources/Testing/Traits/Comment.swift
+++ b/Sources/Testing/Traits/Comment.swift
@@ -18,8 +18,8 @@
 /// or `@Suite` attribute. See <doc:AddingComments> for more details.
 ///
 /// - Note: This type is not intended to reference bugs related to a test.
-///   Instead, use ``Trait/bug(_:relationship:)-duvt`` or
-///   ``Trait/bug(_:relationship:)-40riy``.
+///   Instead, use ``Trait/bug(_:relationship:_:)-86mmm`` or
+///   ``Trait/bug(_:relationship:_:)-3hsi5``.
 public struct Comment: RawRepresentable, Sendable {
   /// The single comment string contained in this instance.
   ///
@@ -122,8 +122,8 @@ extension Trait where Self == Comment {
   ///   comment.
   ///
   /// - Note: This function is not intended to reference bugs related to a test.
-  ///   Instead, use ``Trait/bug(_:relationship:)-duvt`` or
-  ///   ``Trait/bug(_:relationship:)-40riy``.
+  ///   Instead, use ``Trait/bug(_:relationship:_:)-86mmm`` or
+  ///   ``Trait/bug(_:relationship:_:)-3hsi5``.
   public static func comment(_ comment: String) -> Self {
     Self(rawValue: comment, kind: .trait)
   }

--- a/Tests/TestingTests/Traits/BugTests.swift
+++ b/Tests/TestingTests/Traits/BugTests.swift
@@ -9,14 +9,19 @@
 //
 
 @testable import Testing
+#if canImport(Foundation)
+import Foundation
+#endif
 
 @Suite("Bug Tests", .tags(.traitRelated))
 struct BugTests {
   @Test(".bug() with String")
   func bugFactoryMethodWithString() throws {
-    let trait = Bug.bug("12345")
+    let trait = Bug.bug("12345", "Lorem ipsum")
     #expect((trait as Any) is Bug)
     #expect(trait.identifier == "12345")
+    #expect(trait.comment == "Lorem ipsum")
+    #expect(trait.comments == ["Lorem ipsum"])
   }
 
   @Test(".bug() with SignedInteger")
@@ -24,13 +29,17 @@ struct BugTests {
     let trait = Bug.bug(12345)
     #expect((trait as Any) is Bug)
     #expect(trait.identifier == "12345")
+    #expect(trait.comment == nil)
+    #expect(trait.comments.isEmpty)
   }
 
   @Test(".bug() with UnsignedInteger")
   func bugFactoryMethodWithUnsignedInteger() throws {
-    let trait = Bug.bug(UInt32(12345))
+    let trait = Bug.bug(UInt32(12345), "Lorem ipsum")
     #expect((trait as Any) is Bug)
     #expect(trait.identifier == "12345")
+    #expect(trait.comment == "Lorem ipsum")
+    #expect(trait.comments == ["Lorem ipsum"])
   }
 
   @Test("Comparing Bug instances")
@@ -81,4 +90,14 @@ struct BugTests {
     let traits: Set<Bug> = [.bug(12345), .bug(12345), .bug(12345, relationship: .uncoveredBug), .bug("67890")]
     #expect(traits.count == 2)
   }
+
+#if canImport(Foundation)
+  @Test("Encoding/decoding")
+  func encodingAndDecoding() throws {
+    let original = Bug.bug(12345, relationship: .failingBecauseOfBug, "Lorem ipsum")
+    let data = try JSONEncoder().encode(original)
+    let copy = try JSONDecoder().decode(Bug.self, from: data)
+    #expect(original == copy)
+  }
+#endif
 }


### PR DESCRIPTION
This PR adds an optional `comment` property to the `.bug()` trait so that developers can associate additional notes that may not be obvious from just a bug's identifier. Since the testing library can't go off crawling arbitrary bug trackers looking for metadata, it makes sense to include basic metadata inline. For example, since this PR is resolving rdar://124101140 whose description in Apple's Radar system is "Add an optional Comment parameter to `.bug` trait", an associated test could have this trait added to it:

```swift
.bug("rdar://124101140", "Add an optional Comment parameter to `.bug` trait")
```

This PR also adds `Codable` conformance to `Bug` so that it can be encoded and decoded when needed.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
