### PR TITLE
Mention the need for a dev toolchain in the package readme.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,8 +59,8 @@ and install a toolchain.
 
 #### Installing a toolchain
 
-1. Download a toolchain. A recent **development snapshot** toolchain is required
-   to build the testing library. Visit
+1. Download a toolchain. A recent **trunk development snapshot** toolchain is
+   required to build the testing library. Visit
    [swift.org](https://www.swift.org/download/#trunk-development-main) and
    download the most recent toolchain from the section titled
    **Snapshots — Trunk Development (main)**.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ and expressive capabilities. It gives developers more confidence with less code:
 ```
 
 > [!IMPORTANT]
-> This package is under active, ongoing development. Its contents, including all
+> This package is under active, ongoing development and requires a recent
+> **trunk development snapshot** toolchain. Its contents, including all
 > interfaces and implementation details, are experimental and are subject to
 > change or removal without notice.
 >

--- a/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
+++ b/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
@@ -27,7 +27,7 @@ To learn how to contribute to the testing library itself, see
 
 ### Downloading a development toolchain
 
-A recent **development snapshot** toolchain is required to use all of the
+A recent **trunk development snapshot** toolchain is required to use all of the
 features of the testing library. Visit [swift.org](https://www.swift.org/download/#trunk-development-main)
 to download and install a toolchain from the section titled
 **Snapshots — Trunk Development (main)**.


### PR DESCRIPTION
This PR modifies the package readme file to explicitly state that a development toolchain is required. Getting Started continues to describe the limited Swift 5.10 support offered by swift-testing.

I've also updated references to "development toolchain" in other files to explicitly say "_trunk_ development toolchain".

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
