### PR TITLE
Only load tag colors from disk if color output is enabled.

### DIFF
--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -286,9 +286,12 @@ extension [Event.ConsoleOutputRecorder.Option] {
     }
 #endif
 
-    // Load tag colors from user/package preferences on disk.
-    if let tagColors = try? loadTagColors() {
-      result.append(.useTagColors(tagColors))
+    // If color output is enabled, load tag colors from user/package preferences
+    // on disk.
+    if let colorBitDepth = result.colorBitDepth, colorBitDepth > 1 {
+      if let tagColors = try? loadTagColors() {
+        result.append(.useTagColors(tagColors))
+      }
     }
 
     return result


### PR DESCRIPTION
If color output is disabled (`NO_COLOR`, no ANSI escape code support, or writing to a regular file), don't bother reading tag colors from disk.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
