### PR TITLE
Include test names in verbose output.

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -210,7 +210,7 @@ extension Event.HumanReadableOutputRecorder {
     let testName = if let test {
       if let displayName = test.displayName {
         if verbose {
-          "\"\(displayName)\" → \(test.name)"
+          "\"\(displayName)\" (aka '\(test.name)')"
         } else {
           "\"\(displayName)\""
         }

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -207,13 +207,18 @@ extension Event.HumanReadableOutputRecorder {
     verbosely verbose: Bool = false
   ) -> [Message] {
     let test = eventContext.test
-    var testName: String
-    if let displayName = test?.displayName {
-      testName = "\"\(displayName)\""
-    } else if let test {
-      testName = test.name
+    let testName = if let test {
+      if let displayName = test.displayName {
+        if verbose {
+          "\"\(displayName)\" → \(test.name)"
+        } else {
+          "\"\(displayName)\""
+        }
+      } else {
+        test.name
+      }
     } else {
-      testName = "«unknown»"
+      "«unknown»"
     }
     let instant = event.instant
 

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -108,6 +108,7 @@ struct EventRecorderTests {
     let buffer = stream.buffer.rawValue
     #expect(buffer.contains(#"\#(Event.Symbol.details.unicodeCharacter) "abc": Swift.String"#))
     #expect(buffer.contains(#"\#(Event.Symbol.details.unicodeCharacter) lhs: Swift.String → "987""#))
+    #expect(buffer.contains(#""Not A Lobster" → actuallyCrab()"#))
 
     if testsWithSignificantIOAreEnabled {
       print(buffer, terminator: "")

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -108,7 +108,8 @@ struct EventRecorderTests {
     let buffer = stream.buffer.rawValue
     #expect(buffer.contains(#"\#(Event.Symbol.details.unicodeCharacter) "abc": Swift.String"#))
     #expect(buffer.contains(#"\#(Event.Symbol.details.unicodeCharacter) lhs: Swift.String → "987""#))
-    #expect(buffer.contains(#""Not A Lobster" → actuallyCrab()"#))
+    #expect(buffer.contains(#""Animal Crackers" (aka 'WrittenTests')"#))
+    #expect(buffer.contains(#""Not A Lobster" (aka 'actuallyCrab()')"#))
 
     if testsWithSignificantIOAreEnabled {
       print(buffer, terminator: "")
@@ -333,7 +334,7 @@ struct EventRecorderTests {
 
 // MARK: - Fixtures
 
-@Suite(.hidden) struct WrittenTests {
+@Suite("Animal Crackers", .hidden) struct WrittenTests {
   @Test(.hidden) func failWhale() async {
     Issue.record("Whales fail.")
     await { () async in


### PR DESCRIPTION
This PR inserts test names (as opposed to test _display_ names) into verbose output. Without this change, a test with a display name is identified solely by its display name. With this change, when the developer passes `--verbose` to `swift test`, the test function or suite type name is included after the display name. For tests/suites without display names, there is no change in behavior.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
