### PR TITLE
Fix a dead store in `configurationForSwiftPMEntryPoint(withArguments:)`.

### DIFF
--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -136,7 +136,6 @@ func listTestsForSwiftPM(_ tests: some Sequence<Test>) -> [String] {
 /// validated the passed arguments.
 func configurationForSwiftPMEntryPoint(withArguments args: [String]) throws -> Configuration {
   var configuration = Configuration()
-  configuration.isParallelizationEnabled = false
 
   // Do not consider the executable path AKA argv[0].
   let args = args.dropFirst()


### PR DESCRIPTION
This PR fixes a (harmless) dead store to `configuration.isParallelizationEnabled` in the aforementioned function.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
