### PR TITLE
Use `#if compiler` instead of `#if swift` with access levels on import.

### DIFF
--- a/Sources/TestingMacros/Support/Additions/DeclGroupSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/DeclGroupSyntaxAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if swift(>=5.11)
+#if compiler(>=5.11)
 import SwiftSyntax
 #else
 public import SwiftSyntax

--- a/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if swift(>=5.11)
+#if compiler(>=5.11)
 import SwiftSyntax
 import SwiftSyntaxMacros
 #else

--- a/Sources/TestingMacros/Support/Additions/TokenSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/TokenSyntaxAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if swift(>=5.11)
+#if compiler(>=5.11)
 import SwiftSyntax
 #else
 public import SwiftSyntax

--- a/Sources/TestingMacros/Support/Additions/TriviaPieceAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/TriviaPieceAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if swift(>=5.11)
+#if compiler(>=5.11)
 import SwiftSyntax
 #else
 public import SwiftSyntax

--- a/Sources/TestingMacros/Support/Additions/TypeSyntaxProtocolAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/TypeSyntaxProtocolAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if swift(>=5.11)
+#if compiler(>=5.11)
 import SwiftSyntax
 #else
 public import SwiftSyntax

--- a/Sources/TestingMacros/Support/Additions/VersionTupleSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/VersionTupleSyntaxAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if swift(>=5.11)
+#if compiler(>=5.11)
 import SwiftSyntax
 #else
 public import SwiftSyntax

--- a/Sources/TestingMacros/Support/Additions/WithAttributesSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/WithAttributesSyntaxAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if swift(>=5.11)
+#if compiler(>=5.11)
 import SwiftSyntax
 import SwiftSyntaxMacros
 #else

--- a/Sources/TestingMacros/Support/Argument.swift
+++ b/Sources/TestingMacros/Support/Argument.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if swift(>=5.11)
+#if compiler(>=5.11)
 import SwiftSyntax
 #else
 public import SwiftSyntax

--- a/Sources/TestingMacros/Support/AttributeDiscovery.swift
+++ b/Sources/TestingMacros/Support/AttributeDiscovery.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if swift(>=5.11)
+#if compiler(>=5.11)
 import SwiftSyntax
 import SwiftSyntaxMacros
 #else

--- a/Sources/TestingMacros/Support/AvailabilityGuards.swift
+++ b/Sources/TestingMacros/Support/AvailabilityGuards.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if swift(>=5.11)
+#if compiler(>=5.11)
 import SwiftSyntax
 import SwiftSyntaxMacros
 #else

--- a/Sources/TestingMacros/Support/CommentParsing.swift
+++ b/Sources/TestingMacros/Support/CommentParsing.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if swift(>=5.11)
+#if compiler(>=5.11)
 import SwiftSyntax
 #else
 public import SwiftSyntax

--- a/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
+++ b/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if swift(>=5.11)
+#if compiler(>=5.11)
 import SwiftSyntax
 import SwiftSyntaxMacros
 #else

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -9,7 +9,7 @@
 //
 
 import SwiftDiagnostics
-#if swift(>=5.11)
+#if compiler(>=5.11)
 import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftSyntaxMacroExpansion

--- a/Sources/TestingMacros/Support/SourceCodeCapturing.swift
+++ b/Sources/TestingMacros/Support/SourceCodeCapturing.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if swift(>=5.11)
+#if compiler(>=5.11)
 import SwiftSyntax
 #else
 public import SwiftSyntax

--- a/Sources/TestingMacros/Support/SourceLocationGeneration.swift
+++ b/Sources/TestingMacros/Support/SourceLocationGeneration.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if swift(>=5.11)
+#if compiler(>=5.11)
 import SwiftSyntax
 import SwiftSyntaxMacros
 #else

--- a/Sources/TestingMacros/Support/TagConstraints.swift
+++ b/Sources/TestingMacros/Support/TagConstraints.swift
@@ -9,7 +9,7 @@
 //
 
 import SwiftDiagnostics
-#if swift(>=5.11)
+#if compiler(>=5.11)
 import SwiftSyntax
 import SwiftSyntaxMacros
 #else

--- a/Sources/TestingMacros/TestingMacrosMain.swift
+++ b/Sources/TestingMacros/TestingMacrosMain.swift
@@ -10,7 +10,7 @@
 
 #if canImport(SwiftCompilerPlugin)
 import SwiftCompilerPlugin
-#if swift(>=5.11)
+#if compiler(>=5.11)
 import SwiftSyntaxMacros
 #else
 public import SwiftSyntaxMacros

--- a/Sources/_Testing_Foundation/ReexportTesting.swift
+++ b/Sources/_Testing_Foundation/ReexportTesting.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if swift(>=5.11)
+#if compiler(>=5.11)
 @_exported import Testing
 #else
 @_exported public import Testing


### PR DESCRIPTION
`#if swift` checks the language version, not the compiler version, but the changes in behaviour around the access-levels-on-import feature are bound to the compiler version, not the language version. This PR resolves a number of spurious warnings seen when building with a Swift 6 compiler, for instance:

```
/swift/swift-testing/Sources/TestingMacros/Support/TagConstraints.swift:17:8: warning: public import of 'SwiftSyntaxMacros' was not used in public declarations or inlinable code
15 │ #else
16 │ public import SwiftSyntax
17 │ public import SwiftSyntaxMacros
   │        ╰─ warning: public import of 'SwiftSyntaxMacros' was not used in public declarations or inlinable code
18 │ #endif
19 │ 
```

Resolves rdar://124272587.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
