### PR TITLE
Improve handling of required expectation failures in error matcher closure of `#expect { } throws: { }`

### DIFF
--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -1002,14 +1002,13 @@ public func __checkClosureCall<R>(
     mismatchExplanationValue = explanation
   } catch {
     expression = expression.capturingRuntimeValues(error)
-    do {
+    let secondError = Issue.recordingErrors(at: sourceLocation) {
       errorMatches = try errorMatcher(error)
-      if !errorMatches {
-        mismatchExplanationValue = mismatchExplanation?(error) ?? "unexpected error \(_description(of: error)) was thrown"
-      }
-    } catch let secondError {
-      Issue.record(.errorCaught(secondError), comments: comments(), backtrace: .current(), sourceLocation: sourceLocation)
+    }
+    if let secondError {
       mismatchExplanationValue = "a second error \(_description(of: secondError)) was thrown when checking error \(_description(of: error))"
+    } else if !errorMatches {
+      mismatchExplanationValue = mismatchExplanation?(error) ?? "unexpected error \(_description(of: error)) was thrown"
     }
   }
 
@@ -1051,14 +1050,13 @@ public func __checkClosureCall<R>(
     mismatchExplanationValue = explanation
   } catch {
     expression = expression.capturingRuntimeValues(error)
-    do {
+    let secondError = await Issue.recordingErrors(at: sourceLocation) {
       errorMatches = try await errorMatcher(error)
-      if !errorMatches {
-        mismatchExplanationValue = mismatchExplanation?(error) ?? "unexpected error \(_description(of: error)) was thrown"
-      }
-    } catch let secondError {
-      Issue.record(.errorCaught(secondError), comments: comments(), backtrace: .current(), sourceLocation: sourceLocation)
+    }
+    if let secondError {
       mismatchExplanationValue = "a second error \(_description(of: secondError)) was thrown when checking error \(_description(of: error))"
+    } else if !errorMatches {
+      mismatchExplanationValue = mismatchExplanation?(error) ?? "unexpected error \(_description(of: error)) was thrown"
     }
   }
 

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -1002,7 +1002,7 @@ public func __checkClosureCall<R>(
     mismatchExplanationValue = explanation
   } catch {
     expression = expression.capturingRuntimeValues(error)
-    let secondError = Issue.recordingErrors(at: sourceLocation) {
+    let secondError = Issue.withErrorRecording(at: sourceLocation) {
       errorMatches = try errorMatcher(error)
     }
     if let secondError {
@@ -1050,7 +1050,7 @@ public func __checkClosureCall<R>(
     mismatchExplanationValue = explanation
   } catch {
     expression = expression.capturingRuntimeValues(error)
-    let secondError = await Issue.recordingErrors(at: sourceLocation) {
+    let secondError = await Issue.withErrorRecording(at: sourceLocation) {
       errorMatches = try await errorMatcher(error)
     }
     if let secondError {

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -150,7 +150,7 @@ extension Issue {
   /// - Returns: The issue representing the caught error, if any error was
   ///   caught, otherwise `nil`.
   @discardableResult
-  static func recordingErrors(
+  static func withErrorRecording(
     at sourceLocation: SourceLocation,
     configuration: Configuration? = nil,
     _ body: () throws -> Void
@@ -194,7 +194,7 @@ extension Issue {
   /// - Returns: The issue representing the caught error, if any error was
   ///   caught, otherwise `nil`.
   @discardableResult
-  static func recordingErrors(
+  static func withErrorRecording(
     at sourceLocation: SourceLocation,
     configuration: Configuration? = nil,
     _ body: () async throws -> Void

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -203,7 +203,7 @@ extension Runner {
 
     if let step = stepGraph.value, case .run = step.action {
       await Test.withCurrent(step.test) {
-        _ = await Issue.recordingErrors(at: step.test.sourceLocation, configuration: configuration) {
+        _ = await Issue.withErrorRecording(at: step.test.sourceLocation, configuration: configuration) {
           try await _executeTraits(for: step, testCase: nil) {
             // Run the test function at this step (if one is present.)
             if let testCases = step.test.testCases {
@@ -272,7 +272,7 @@ extension Runner {
 
     await Test.Case.withCurrent(testCase) {
       let sourceLocation = step.test.sourceLocation
-      await Issue.recordingErrors(at: sourceLocation, configuration: configuration) {
+      await Issue.withErrorRecording(at: sourceLocation, configuration: configuration) {
         try await withTimeLimit(for: step.test, configuration: configuration) {
           try await _executeTraits(for: step, testCase: testCase) {
             try await testCase.body()

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -541,7 +541,7 @@ final class IssueTests: XCTestCase {
 
   func testErrorCheckingWithExpect_Mismatching() async throws {
     let expectationFailed = expectation(description: "Expectation failed")
-    expectationFailed.expectedFulfillmentCount = 11
+    expectationFailed.expectedFulfillmentCount = 13
 
     var configuration = Configuration()
     configuration.eventHandler = { event, _ in
@@ -599,6 +599,12 @@ final class IssueTests: XCTestCase {
       func nonVoidReturning() throws -> Int { 0 }
       #expect(throws: MyError.self) {
         try nonVoidReturning()
+      }
+      #expect {
+        throw MyError()
+      } throws: { error in
+        let parameterizedError = try #require(error as? MyParameterizedError)
+        return parameterizedError.index == 123
       }
     }.run(configuration: configuration)
 
@@ -702,7 +708,7 @@ final class IssueTests: XCTestCase {
 
   func testErrorCheckingWithExpectAsync_Mismatching() async throws {
     let expectationFailed = expectation(description: "Expectation failed")
-    expectationFailed.expectedFulfillmentCount = 11
+    expectationFailed.expectedFulfillmentCount = 13
 
     var configuration = Configuration()
     configuration.eventHandler = { event, _ in
@@ -752,6 +758,12 @@ final class IssueTests: XCTestCase {
       func nonVoidReturning() async throws -> Int { 0 }
       await #expect(throws: MyError.self) {
         try await nonVoidReturning()
+      }
+      await #expect { () async throws in
+        throw MyError()
+      } throws: { error in
+        let parameterizedError = try #require(error as? MyParameterizedError)
+        return parameterizedError.index == 123
       }
     }.run(configuration: configuration)
 


### PR DESCRIPTION
This improves the handling of `#require` failures in the `throws: { error in … }` error-matching closure of an `#expect { } throws: { }` expectation, by ensuring the resulting issues are relevant.

Take this example:

```swift
struct AnotherError: Error {}
struct MyError: Error { ... }

@Test func example() {
  #expect {
    throw AnotherError()
  } throws: { error in
    let myError = try #require(error as? MyError)
    return myError.someProperty
  }
}
```

Before this PR, the following issues were recorded:
1. ❌ Expectation failed: (error → AnotherError()) as? (MyError → AnotherError)
2. ❌ Caught error: ExpectationFailedError(expectation: Testing.Expectation(...))
3. ❌ Expectation failed: a second error "ExpectationFailedError(expectation: Testing.Expectation(...))" was thrown when checking error "AnotherError()"

Issue 1 is from the `#require`, and it's correct and appropriate. But issue 2 is unnecessary noise; it's revealing an implementation detail about the underlying error which all `#require` expectations throw when they fail (`ExpectationFailedError`), so this issue ought to be suppressed. Issue 3 is _meant_ to indicate the failure of the overall `#expect { } throws: { }`, but it's phrased in a misleading way which focuses on the internal error mentioned earlier, instead of describing the real problem: that the caught error did not match.

After this PR, the following issues are recorded instead:
- ❌ Expectation failed: (error → AnotherError()) as? (MyError → AnotherError)
- ❌ Expectation failed: unexpected error "AnotherError()" was thrown

Along the way, I consolidated some logic into a more widely-shared helper which invokes closures which may throw and translates caught errors into issues.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
