### PR TITLE
Add experimental exit test support.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -125,6 +125,7 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .define("SWT_TARGET_OS_APPLE", .when(platforms: [.macOS, .iOS, .macCatalyst, .watchOS, .tvOS, .visionOS])),
 
       .define("SWT_NO_FILE_IO", .when(platforms: [.wasi])),
+      .define("SWT_NO_EXIT_TESTS", .when(platforms: [.iOS, .watchOS, .tvOS, .visionOS, .wasi])),
     ]
   }
 

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -125,6 +125,7 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .define("SWT_TARGET_OS_APPLE", .when(platforms: [.macOS, .iOS, .macCatalyst, .watchOS, .tvOS, .visionOS])),
 
       .define("SWT_NO_FILE_IO", .when(platforms: [.wasi])),
+      .define("SWT_NO_EXIT_TESTS", .when(platforms: [.iOS, .watchOS, .tvOS, .visionOS, .wasi])),
     ]
   }
 

--- a/Sources/Testing/ExitTests/ExitCondition.swift
+++ b/Sources/Testing/ExitTests/ExitCondition.swift
@@ -1,0 +1,104 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+private import TestingInternals
+
+/// An enumeration describing possible conditions under which an exit test will
+/// succeed or fail.
+///
+/// Values of this type can be passed to
+/// ``expect(exitsWith:_:sourceLocation:performing:)`` or
+/// ``require(exitsWith:_:sourceLocation:performing:)`` to configure which exit
+/// statuses should be considered successful.
+@_spi(Experimental)
+#if SWT_NO_EXIT_TESTS
+@available(*, unavailable, message: "Exit tests are not available on this platform.")
+#endif
+public enum ExitCondition: Sendable {
+  /// The process terminated successfully with status `EXIT_SUCCESS`.
+  public static var success: Self { .exitCode(EXIT_SUCCESS) }
+
+  /// The process terminated abnormally with any status other than
+  /// `EXIT_SUCCESS` or with any signal.
+  case failure
+
+  /// The process terminated with the given exit code.
+  ///
+  /// - Parameters:
+  ///   - exitCode: The exit code yielded by the process.
+  ///
+  /// The C programming language defines two [standard exit codes](https://en.cppreference.com/w/c/program/EXIT_status),
+  /// `EXIT_SUCCESS` and `EXIT_FAILURE`. Platforms may additionally define their
+  /// own non-standard exit codes:
+  ///
+  /// | Platform | Header |
+  /// |-|-|
+  /// | macOS | [`<stdlib.h>`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/_Exit.3.html), [`<sysexits.h>`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/sysexits.3.html) |
+  /// | Linux | `<stdlib.h>`, `<sysexits.h>` |
+  /// | Windows | [`<stdlib.h>`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/exit-success-exit-failure) |
+  ///
+  /// On POSIX-like systems including macOS and Linux, only the low unsigned 8
+  /// bits (0&ndash;255) of the exit code are reliably preserved and reported to
+  /// a parent process.
+  case exitCode(_ exitCode: CInt)
+
+  /// The process terminated with the given signal.
+  ///
+  /// - Parameters:
+  ///   - signal: The signal that terminated the process.
+  ///
+  /// The C programming language defines a number of [standard signals](https://en.cppreference.com/w/c/program/SIG_types).
+  /// Platforms may additionally define their own non-standard signal codes:
+  ///
+  /// | Platform | Header |
+  /// |-|-|
+  /// | macOS | [`<signal.h>`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/signal.3.html) |
+  /// | Linux | `<signal.h>` |
+  /// | Windows | [`<signal.h>`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/signal-constants) |
+#if os(Windows)
+  @available(*, unavailable, message: "On Windows, use .failure instead.")
+#endif
+  case signal(_ signal: CInt)
+}
+
+// MARK: -
+
+#if SWT_NO_EXIT_TESTS
+@available(*, unavailable, message: "Exit tests are not available on this platform.")
+#endif
+extension ExitCondition {
+  /// Check whether this instance matches another.
+  ///
+  /// - Parameters:
+  ///   - other: The other instance to compare against.
+  ///
+  /// - Returns: Whether or not this instance is equal to, or at least covers,
+  ///   the other instance.
+  func matches(_ other: ExitCondition) -> Bool {
+    return switch (self, other) {
+    case (.failure, .failure):
+      true
+    case let (.failure, .exitCode(exitCode)), let (.exitCode(exitCode), .failure):
+      exitCode != EXIT_SUCCESS
+    case let (.exitCode(lhs), .exitCode(rhs)):
+      lhs == rhs
+#if !os(Windows)
+    case let (.signal(lhs), .signal(rhs)):
+      lhs == rhs
+    case (.signal, .failure), (.failure, .signal):
+      // All terminating signals are considered failures.
+      true
+    case (.signal, .exitCode), (.exitCode, .signal):
+      // Signals do not match exit codes.
+      false
+#endif
+    }
+  }
+}

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -96,7 +96,19 @@ extension ExitTest {
       }
     }
 
-    return context.result
+    if var result = context.result {
+      // Add some glue code that terminates the process with an exit condition
+      // that does not match the expected one. If the exit test's body doesn't
+      // terminate, we'll manually call exit() and cause the test to fail.
+      let expectingFailure = result.expectedExitCondition.matches(.failure)
+      result.body = { [body = result.body] in
+        await body()
+        exit(expectingFailure ? EXIT_SUCCESS : EXIT_FAILURE)
+      }
+      return result
+    }
+
+    return nil
   }
 }
 

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -221,7 +221,7 @@ extension ExitTest {
   /// are available or the child environment is otherwise terminated. The parent
   /// environment is then responsible for interpreting those results and
   /// recording any issues that occur.
-  public typealias Handler = @Sendable (_ exitTest: ExitTest) async throws -> ExitCondition?
+  public typealias Handler = @Sendable (_ exitTest: borrowing ExitTest) async throws -> ExitCondition?
 
 #if SWIFT_PM_SUPPORTS_SWIFT_TESTING
   /// Find the exit test function specified by the given command-line arguments,

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -102,13 +102,6 @@ extension ExitTest {
 
 // MARK: -
 
-/// A type that provides task-local context for exit tests.
-private enum _ExitTestContext {
-  /// Whether or not the current process and task are running an exit test.
-  @TaskLocal
-  static var isRunning = false
-}
-
 /// Check that an expression always exits (terminates the current process) with
 /// a given status.
 ///
@@ -135,9 +128,6 @@ func callExitTest(
   isRequired: Bool,
   sourceLocation: SourceLocation
 ) async -> Result<Void, any Error> {
-  // FIXME: use lexicalContext to capture this misuse at compile time.
-  precondition(!_ExitTestContext.isRunning, "Running an exit test within another exit test is unsupported.")
-
   // FIXME: use lexicalContext to capture these misuses at compile time.
   guard let configuration = Configuration.current, Test.current != nil else {
     preconditionFailure("A test must be running on the current task to use #expect(exitsWith:).")

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -1,0 +1,304 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+private import TestingInternals
+#if canImport(Foundation)
+private import Foundation
+#endif
+
+#if !SWT_NO_EXIT_TESTS
+/// A type describing an exit test.
+///
+/// Instances of this type describe an exit test defined by the test author and
+/// discovered or called at runtime.
+@_spi(Experimental) @_spi(ForToolsIntegrationOnly)
+public struct ExitTest: Sendable {
+  /// The expected exit condition of the exit test.
+  public var expectedExitCondition: ExitCondition
+
+  /// The body closure of the exit test.
+  fileprivate var body: @Sendable () async -> Void
+
+  /// The source location of the exit test.
+  ///
+  /// The source location is unique to each exit test and is consistent between
+  /// processes, so it can be used to uniquely identify an exit test at runtime.
+  public var sourceLocation: SourceLocation
+
+  /// Call the exit test in the current process.
+  public func callAsFunction() async -> Void {
+    await body()
+  }
+}
+
+// MARK: - Discovery
+
+/// A protocol describing a type that contains an exit test.
+///
+/// - Warning: This protocol is used to implement the `#expect(exitsWith:)`
+///   macro. Do not use it directly.
+@_alwaysEmitConformanceMetadata
+@_spi(Experimental)
+public protocol __ExitTestContainer {
+  /// The expected exit condition of the exit test.
+  static var __expectedExitCondition: ExitCondition { get }
+
+  /// The source location of the exit test.
+  static var __sourceLocation: SourceLocation { get }
+
+  /// The body function of the exit test.
+  static var __body: @Sendable () async -> Void { get }
+}
+
+extension ExitTest {
+  /// A string that appears within all auto-generated types conforming to the
+  /// `__ExitTestContainer` protocol.
+  private static let _exitTestContainerTypeNameMagic = "__🟠$exit_test_body__"
+
+  /// Find the exit test function at the given source location.
+  ///
+  /// - Parameters:
+  ///   - sourceLocation: The source location of the exit test to find.
+  ///
+  /// - Returns: The specified exit test function, or `nil` if no such exit test
+  ///   could be found.
+  public static func find(at sourceLocation: SourceLocation) -> Self? {
+    struct Context {
+      var sourceLocation: SourceLocation
+      var result: ExitTest?
+    }
+    var context = Context(sourceLocation: sourceLocation)
+    withUnsafeMutablePointer(to: &context) { context in
+      swt_enumerateTypes(context) { type, context in
+        let context = context!.assumingMemoryBound(to: (Context).self)
+        if let type = unsafeBitCast(type, to: Any.Type.self) as? any __ExitTestContainer.Type,
+           type.__sourceLocation == context.pointee.sourceLocation {
+          context.pointee.result = ExitTest(
+            expectedExitCondition: type.__expectedExitCondition,
+            body: type.__body,
+            sourceLocation: type.__sourceLocation
+          )
+          return false
+        }
+        return true
+      } withNamesMatching: { typeName, _ in
+        // strstr() lets us avoid copying either string before comparing.
+        Self._exitTestContainerTypeNameMagic.withCString { testContainerTypeNameMagic in
+          nil != strstr(typeName, testContainerTypeNameMagic)
+        }
+      }
+    }
+
+    return context.result
+  }
+}
+
+// MARK: -
+
+/// A type that provides task-local context for exit tests.
+private enum _ExitTestContext {
+  /// Whether or not the current process and task are running an exit test.
+  @TaskLocal
+  static var isRunning = false
+}
+
+/// Check that an expression always exits (terminates the current process) with
+/// a given status.
+///
+/// - Parameters:
+///   - expectedExitCondition: The expected exit condition.
+///   - body: The exit test body.
+///   - expression: The expression, corresponding to `condition`, that is being
+///     evaluated (if available at compile time.)
+///   - comments: An array of comments describing the expectation. This array
+///     may be empty.
+///   - isRequired: Whether or not the expectation is required. The value of
+///     this argument does not affect whether or not an error is thrown on
+///     failure.
+///   - sourceLocation: The source location of the expectation.
+///
+/// This function contains the common implementation for all
+/// `await #expect(exitsWith:) { }` invocations regardless of calling
+/// convention.
+func callExitTest(
+  exitsWith expectedExitCondition: ExitCondition,
+  performing body: @escaping @Sendable () async -> Void,
+  expression: Expression,
+  comments: @autoclosure () -> [Comment],
+  isRequired: Bool,
+  sourceLocation: SourceLocation
+) async -> Result<Void, any Error> {
+  // FIXME: use lexicalContext to capture this misuse at compile time.
+  precondition(!_ExitTestContext.isRunning, "Running an exit test within another exit test is unsupported.")
+
+  // FIXME: use lexicalContext to capture these misuses at compile time.
+  guard let configuration = Configuration.current, Test.current != nil else {
+    preconditionFailure("A test must be running on the current task to use #expect(exitsWith:).")
+  }
+
+  let actualExitCondition: ExitCondition
+  do {
+    let exitTest = ExitTest(expectedExitCondition: expectedExitCondition, body: body, sourceLocation: sourceLocation)
+    guard let exitCondition = try await configuration.exitTestHandler(exitTest) else {
+      // This exit test was not run by the handler. Return successfully (and
+      // move on to the next one.)
+      return __checkValue(
+        true,
+        expression: expression,
+        comments: comments(),
+        isRequired: isRequired,
+        sourceLocation: sourceLocation
+      )
+    }
+    actualExitCondition = exitCondition
+  } catch {
+    // An error here would indicate a problem in the exit test handler such as a
+    // failure to find the process' path, to construct arguments to the
+    // subprocess, or to spawn the subprocess. These are not expected to be
+    // common issues, however they would constitute a failure of the test
+    // infrastructure rather than the test itself and perhaps should not cause
+    // the test to terminate early.
+    Issue.record(.errorCaught(error), comments: comments(), backtrace: .current(), sourceLocation: sourceLocation, configuration: configuration)
+    return __checkValue(
+      false,
+      expression: expression,
+      comments: comments(),
+      isRequired: isRequired,
+      sourceLocation: sourceLocation
+    )
+  }
+
+  lazy var actualValue: CInt? = switch actualExitCondition {
+  case .failure:
+    nil
+  case let .exitCode(exitCode):
+    exitCode
+#if !os(Windows)
+  case let .signal(signal):
+    signal
+#endif
+  }
+
+  return __checkValue(
+    expectedExitCondition.matches(actualExitCondition),
+    expression: expression,
+    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(actualValue),
+    comments: comments(),
+    isRequired: isRequired,
+    sourceLocation: sourceLocation
+  )
+}
+
+// MARK: - SwiftPM/tools integration
+
+extension ExitTest {
+  /// A handler that is invoked when an exit test starts.
+  ///
+  /// - Parameters:
+  ///   - exitTest: The exit test that is starting.
+  ///
+  /// - Returns: The condition under which the exit test exited, or `nil` if the
+  ///   exit test was not invoked.
+  ///
+  /// - Throws: Any error that prevents the normal invocation or execution of
+  ///   the exit test.
+  ///
+  /// This handler is invoked when an exit test (i.e. a call to either
+  /// ``expect(exitsWith:_:sourceLocation:performing:)`` or
+  /// ``require(exitsWith:_:sourceLocation:performing:)``) is started. The
+  /// handler is responsible for initializing a new child environment (typically
+  /// a child process) and running the exit test identified by `sourceLocation`
+  /// there. The exit test's body can be found using ``ExitTest/find(at:)``.
+  ///
+  /// The parent environment should suspend until the results of the exit test
+  /// are available or the child environment is otherwise terminated. The parent
+  /// environment is then responsible for interpreting those results and
+  /// recording any issues that occur.
+  public typealias Handler = @Sendable (_ exitTest: ExitTest) async throws -> ExitCondition?
+
+#if SWIFT_PM_SUPPORTS_SWIFT_TESTING
+  /// Find the exit test function specified by the given command-line arguments,
+  /// if any.
+  ///
+  /// - Parameters:
+  ///   - args: The command-line arguments to this process.
+  ///
+  /// - Returns: The exit test this process should run, or `nil` if it is not
+  ///   expected to run any.
+  ///
+  /// This function should only be used when the process was started via the
+  /// `__swiftPMEntryPoint()` function. The effect of using it under other
+  /// configurations is undefined.
+  public static func find(withArguments args: [String]) -> Self? {
+    if let runArgIndex = args.firstIndex(of: "--experimental-run-exit-test-body-at"), runArgIndex < args.endIndex {
+      if let sourceLocationData = args[args.index(after: runArgIndex)].data(using: .utf8),
+         let sourceLocation = try? JSONDecoder().decode(SourceLocation.self, from: sourceLocationData) {
+        return find(at: sourceLocation)
+      }
+    }
+    return nil
+  }
+
+  /// The exit test handler used when integrating with Swift Package Manager via
+  /// the `__swiftPMEntryPoint()` function.
+  ///
+  /// For a description of the inputs and outputs of this function, see the
+  /// documentation for ``ExitTest/Handler``.
+  static let handlerForSwiftPM: Handler = { exitTest in
+    let actualExitCode: Int32
+    let wasSignalled: Bool
+    do {
+      let childProcessURL: URL = try URL(fileURLWithPath: CommandLine.executablePath, isDirectory: false)
+      let childArguments = [
+        "--experimental-run-exit-test-body-at",
+        try String(data: JSONEncoder().encode(exitTest.sourceLocation), encoding: .utf8)!,
+      ]
+      // By default, inherit the environment from the parent process.
+      var childEnvironment: [String: String]? = nil
+#if os(Linux)
+      if Environment.variable(named: "SWIFT_BACKTRACE") == nil {
+        // Disable interactive backtraces unless explicitly enabled to reduce
+        // the noise level during the exit test. Only needed on Linux.
+        childEnvironment = ProcessInfo.processInfo.environment
+        childEnvironment?["SWIFT_BACKTRACE"] = "enable=no"
+      }
+#endif
+
+      (actualExitCode, wasSignalled) = try await withCheckedThrowingContinuation { continuation in
+        do {
+          let process = Process()
+          process.executableURL = childProcessURL
+          process.arguments = childArguments
+          if let childEnvironment {
+            process.environment = childEnvironment
+          }
+          process.terminationHandler = { process in
+            continuation.resume(returning: (process.terminationStatus, process.terminationReason == .uncaughtSignal))
+          }
+          try process.run()
+        } catch {
+          continuation.resume(throwing: error)
+        }
+      }
+
+      if wasSignalled {
+#if os(Windows)
+        // Actually an uncaught SEH/VEH exception (which we don't model yet.)
+        return .failure
+#else
+        return .signal(actualExitCode)
+#endif
+      }
+      return .exitCode(actualExitCode)
+    }
+  }
+#endif
+}
+#endif

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -1072,6 +1072,72 @@ public func __checkClosureCall<R>(
   )
 }
 
+// MARK: - Exit tests
+
+#if !SWT_NO_EXIT_TESTS
+/// Check that an expression always exits (terminates the current process) with
+/// a given status.
+///
+/// This overload is used for `await #expect(exitsWith:) { }` invocations when
+/// the body of the exit test is a synchronous function. Because no arguments
+/// are passed into the exit test and no errors can be thrown, a C function
+/// (`@convention(c)`) can be used to prevent accidentally closing over state
+/// from the parent process.
+///
+/// - Warning: This function is used to implement the `#expect()` and
+///   `#require()` macros. Do not call it directly.
+@_spi(Experimental)
+public func __checkClosureCall(
+  exitsWith expectedExitCondition: ExitCondition,
+  performing body: @convention(c) () -> Void,
+  expression: Expression,
+  comments: @autoclosure () -> [Comment],
+  isRequired: Bool,
+  sourceLocation: SourceLocation
+) async -> Result<Void, any Error> {
+  await callExitTest(
+    exitsWith: expectedExitCondition,
+    performing: { body() },
+    expression: expression,
+    comments: comments(),
+    isRequired: isRequired,
+    sourceLocation: sourceLocation
+  )
+}
+
+/// Check that an expression always exits (terminates the current process) with
+/// a given status.
+///
+/// This overload is used for `await #expect(exitsWith:) { }` invocations when
+/// the body of the exit test is an `async` function. The body must be
+/// implemented using `@convention(thin)` to prevent accidentally closing over
+/// state from the parent process, but the diagnostics emitted for thin
+/// functions that close over state are less clear than those emitted for C
+/// functions.
+///
+/// - Warning: This function is used to implement the `#expect()` and
+///   `#require()` macros. Do not call it directly.
+@_spi(Experimental)
+@_disfavoredOverload
+public func __checkClosureCall(
+  exitsWith expectedExitCondition: ExitCondition,
+  performing body: @convention(thin) () async -> Void,
+  expression: Expression,
+  comments: @autoclosure () -> [Comment],
+  isRequired: Bool,
+  sourceLocation: SourceLocation
+) async -> Result<Void, any Error> {
+  await callExitTest(
+    exitsWith: expectedExitCondition,
+    performing: { await body() },
+    expression: expression,
+    comments: comments(),
+    isRequired: isRequired,
+    sourceLocation: sourceLocation
+  )
+}
+#endif
+
 // MARK: -
 
 /// Generate a description of an error that includes its type name if not

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -32,7 +32,7 @@ extension Issue {
   ///
   /// - Returns: The issue that was recorded.
   @discardableResult
-  static func record(_ kind: Kind, comments: [Comment], backtrace: Backtrace?, sourceLocation: SourceLocation, configuration: Configuration? = nil) -> Issue {
+  static func record(_ kind: Kind, comments: [Comment], backtrace: Backtrace?, sourceLocation: SourceLocation, configuration: Configuration? = nil) -> Self {
     let sourceContext = SourceContext(backtrace: backtrace, sourceLocation: sourceLocation)
     return record(kind, comments: comments, sourceContext: sourceContext, configuration: configuration)
   }
@@ -49,10 +49,9 @@ extension Issue {
   ///
   /// - Returns: The issue that was recorded.
   @discardableResult
-  static func record(_ kind: Kind, comments: [Comment], sourceContext: SourceContext, configuration: Configuration? = nil) -> Issue {
+  static func record(_ kind: Kind, comments: [Comment], sourceContext: SourceContext, configuration: Configuration? = nil) -> Self {
     let issue = Issue(kind: kind, comments: comments, sourceContext: sourceContext)
-    issue.record(configuration: configuration)
-    return issue
+    return issue.record(configuration: configuration)
   }
 
   /// Record this issue by wrapping it in an ``Event`` and passing it to the
@@ -61,7 +60,19 @@ extension Issue {
   /// - Parameters:
   ///   - configuration: The test configuration to use when recording the issue.
   ///     The default value is ``Configuration/current``.
-  func record(configuration: Configuration? = nil) {
+  ///
+  /// - Returns: The issue that was recorded (`self` or a modified copy of it.)
+  @discardableResult
+  func record(configuration: Configuration? = nil) -> Self {
+    // If this issue is a caught error of kind SystemError, reinterpret it as a
+    // testing system issue instead (per the documentation for SystemError.)
+    if case let .errorCaught(error) = kind, let error = error as? SystemError {
+      var selfCopy = self
+      selfCopy.kind = .system
+      selfCopy.comments.append(Comment(rawValue: String(describing: error)))
+      return selfCopy.record(configuration: configuration)
+    }
+
     // If this issue matches via the known issue matcher, set a copy of it to be
     // known and record the copy instead.
     if !isKnown, let issueMatcher = Self.currentKnownIssueMatcher, issueMatcher(self) {
@@ -80,6 +91,8 @@ extension Issue {
       // can help explain the failure.
       failureBreakpoint()
     }
+
+    return self
   }
 
   /// Record an issue when a running test fails unexpectedly.
@@ -102,8 +115,7 @@ extension Issue {
     let sourceLocation = SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column)
     let sourceContext = SourceContext(backtrace: .current(), sourceLocation: sourceLocation)
     let issue = Issue(kind: .unconditional, comments: Array(comment), sourceContext: sourceContext)
-    issue.record()
-    return issue
+    return issue.record()
   }
 
   /// Record a new issue when a running test unexpectedly catches an error.
@@ -130,8 +142,7 @@ extension Issue {
     let backtrace = Backtrace(forFirstThrowOf: error) ?? Backtrace.current()
     let sourceContext = SourceContext(backtrace: backtrace, sourceLocation: sourceLocation)
     let issue = Issue(kind: .errorCaught(error), comments: Array(comment), sourceContext: sourceContext)
-    issue.record()
-    return issue
+    return issue.record()
   }
 }
 

--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -176,12 +176,24 @@ public struct Configuration: Sendable {
   /// By default, events of this kind are not delivered to event handlers
   /// because they occur frequently in a typical test run and can generate
   /// significant backpressure on the event handler.
-  @_spi(ForToolsIntegrationOnly)
   public var deliverExpectationCheckedEvents = false
 
   /// The event handler to which events should be passed when they occur.
-  @_spi(ForToolsIntegrationOnly)
   public var eventHandler: Event.Handler = { _, _ in }
+
+#if !SWT_NO_EXIT_TESTS
+  /// A handler that is invoked when an exit test starts.
+  ///
+  /// For an explanation of how this property is used, see ``ExitTest/Handler``.
+  ///
+  /// When using the `swift test` command from Swift Package Manager, this
+  /// property is pre-configured. Otherwise, the default value of this property
+  /// records an issue indicating that it has not been configured.
+  @_spi(Experimental)
+  public var exitTestHandler: ExitTest.Handler = { _ in
+    throw SystemError(description: "Exit test support has not been implemented by the current testing infrastructure.")
+  }
+#endif
 
   // MARK: - Test selection
 

--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -54,6 +54,13 @@ private import Foundation
 #endif
       options.isVerbose = args.contains("--verbose")
 
+#if !SWT_NO_EXIT_TESTS && SWIFT_PM_SUPPORTS_SWIFT_TESTING
+      if let exitTest = ExitTest.find(withArguments: args) {
+        await exitTest()
+        return exitCode.rawValue
+      }
+#endif
+
       await runTests(options: options, configuration: configuration)
     }
   } catch {
@@ -230,6 +237,11 @@ func configurationForSwiftPMEntryPoint(withArguments args: [String]) throws -> C
   }
   configuration.repetitionPolicy = repetitionPolicy
 
+#if !SWT_NO_EXIT_TESTS && SWIFT_PM_SUPPORTS_SWIFT_TESTING
+  // Enable exit test handling via __swiftPMEntryPoint().
+  configuration.exitTestHandler = ExitTest.handlerForSwiftPM
+#endif
+
   return configuration
 }
 
@@ -240,13 +252,13 @@ func configurationForSwiftPMEntryPoint(withArguments args: [String]) throws -> C
 ///   - options: Options to pass when configuring the console output recorder.
 ///   - configuration: The configuration to use for running.
 func runTests(options: Event.ConsoleOutputRecorder.Options, configuration: Configuration) async {
+  var configuration = configuration
   let eventRecorder = Event.ConsoleOutputRecorder(options: options) { string in
 #if !SWT_NO_FILE_IO
     try? FileHandle.stderr.write(string)
 #endif
   }
 
-  var configuration = configuration
   let oldEventHandler = configuration.eventHandler
   configuration.eventHandler = { event, context in
     eventRecorder.record(event, in: context)

--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -54,7 +54,7 @@ private import Foundation
 #endif
       options.isVerbose = args.contains("--verbose")
 
-#if !SWT_NO_EXIT_TESTS && SWIFT_PM_SUPPORTS_SWIFT_TESTING
+#if !SWT_NO_EXIT_TESTS
       if let exitTest = ExitTest.find(withArguments: args) {
         await exitTest()
         return exitCode.rawValue
@@ -237,16 +237,16 @@ func configurationForSwiftPMEntryPoint(withArguments args: [String]) throws -> C
   }
   configuration.repetitionPolicy = repetitionPolicy
 
-#if !SWT_NO_EXIT_TESTS && SWIFT_PM_SUPPORTS_SWIFT_TESTING
+#if !SWT_NO_EXIT_TESTS
   // Enable exit test handling via __swiftPMEntryPoint().
-  configuration.exitTestHandler = ExitTest.handlerForSwiftPM
+  configuration.exitTestHandler = ExitTest.handlerForSwiftPM()
 #endif
 
   return configuration
 }
 
 /// The common implementation of ``swiftPMEntryPoint()`` and
-/// ``XCTestScaffold/runAllTests(hostedBy:)``.
+/// ``XCTestScaffold/runAllTests(hostedBy:_:)``.
 ///
 /// - Parameters:
 ///   - options: Options to pass when configuring the console output recorder.

--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -165,27 +165,14 @@ public enum XCTestScaffold: Sendable {
       await exitTest()
       exit(EXIT_SUCCESS)
     }
-    var exitTestHandler: ExitTest.Handler?
-#if SWT_TARGET_OS_APPLE
-    if isProcessLaunchedByXcode {
-      exitTestHandler = { _ in
-        throw SystemError(description: "Exit tests are not supported within Xcode. Run 'swift test' instead.")
-      }
+    let typeName = String(reflecting: type(of: testCase.rawValue as Any))
+    let functionName = if let parenIndex = functionName.lastIndex(of: "(") {
+      functionName[..<parenIndex]
+    } else {
+      functionName[...]
     }
-#endif
-    if exitTestHandler == nil {
-      let typeName = String(reflecting: type(of: testCase.rawValue as Any))
-      let functionName = if let parenIndex = functionName.lastIndex(of: "(") {
-        functionName[..<parenIndex]
-      } else {
-        functionName[...]
-      }
-      let testIdentifier = "\(typeName)/\(functionName)"
-      exitTestHandler = ExitTest.handlerForSwiftPM(forXCTestCaseIdentifiedBy: testIdentifier)
-    }
-    if let exitTestHandler {
-      configuration.exitTestHandler = exitTestHandler
-    }
+    let testIdentifier = "\(typeName)/\(functionName)"
+    configuration.exitTestHandler = ExitTest.handlerForSwiftPM(forXCTestCaseIdentifiedBy: testIdentifier)
 #endif
 
     var options = Event.ConsoleOutputRecorder.Options()

--- a/Sources/Testing/Support/SystemError.swift
+++ b/Sources/Testing/Support/SystemError.swift
@@ -1,0 +1,23 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+/// A type representing an error in the testing library or its underlying
+/// infrastructure.
+///
+/// When an error of this type is thrown and caught by the testing library, it
+/// is recorded as an issue of kind ``Issue/Kind/system`` rather than
+/// ``Issue/Kind/errorCaught(_:)``.
+///
+/// This type is not part of the public interface of the testing library.
+/// External callers should generally record issues by throwing their own errors
+/// or by calling ``Issue/record(_:fileID:filePath:line:column:)``.
+struct SystemError: Error, CustomStringConvertible {
+  var description: String
+}

--- a/Sources/Testing/Test+Discovery.swift
+++ b/Sources/Testing/Test+Discovery.swift
@@ -55,6 +55,7 @@ extension Test {
               await type.__tests
             }
           }
+          return true
         } withNamesMatching: { typeName, _ in
           // strstr() lets us avoid copying either string before comparing.
           Self._testContainerTypeNameMagic.withCString { testContainerTypeNameMagic in

--- a/Sources/TestingInternals/Discovery.cpp
+++ b/Sources/TestingInternals/Discovery.cpp
@@ -324,7 +324,8 @@ void swt_enumerateTypes(void *context, SWTTypeEnumerator body, SWTTypeNameFilter
     auto records = reinterpret_cast<const SWTTypeMetadataRecord *>(section);
     size_t recordCount = size / sizeof(SWTTypeMetadataRecord);
 
-    for (size_t i = 0; i < recordCount; i++) {
+    bool keepGoing = true;
+    for (size_t i = 0; i < recordCount && keepGoing; i++) {
       const auto& record = records[i];
 
       auto contextDescriptor = record.getContextDescriptor();
@@ -350,7 +351,7 @@ void swt_enumerateTypes(void *context, SWTTypeEnumerator body, SWTTypeNameFilter
       }
 
       if (void *typeMetadata = contextDescriptor->getMetadata()) {
-        body(typeMetadata, context);
+        keepGoing = body(typeMetadata, context);
       }
     }
   });

--- a/Sources/TestingInternals/include/Discovery.h
+++ b/Sources/TestingInternals/include/Discovery.h
@@ -23,7 +23,9 @@ SWT_ASSUME_NONNULL_BEGIN
 ///   - typeMetadata: A type metadata pointer that can be bitcast to `Any.Type`.
 ///   - context: An arbitrary pointer passed by the caller to
 ///     `swt_enumerateTypes()`.
-typedef void (* SWTTypeEnumerator)(void *typeMetadata, void *_Null_unspecified context);
+///
+/// - Returns: Whether or not to continue enumeration.
+typedef bool (* SWTTypeEnumerator)(void *typeMetadata, void *_Null_unspecified context);
 
 /// The type name filter that is called by `swt_enumerateTypes()`.
 ///

--- a/Sources/TestingInternals/include/Includes.h
+++ b/Sources/TestingInternals/include/Includes.h
@@ -27,6 +27,9 @@
 /// - Note: Avoid including headers that aren't actually used.
 
 #include <errno.h>
+#if __has_include(<signal.h>)
+#include <signal.h>
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -58,6 +61,10 @@
 
 #if __has_include(<pty.h>)
 #include <pty.h>
+#endif
+
+#if __has_include(<limits.h>)
+#include <limits.h>
 #endif
 
 #if defined(_WIN32)

--- a/Sources/TestingMacros/TestingMacrosMain.swift
+++ b/Sources/TestingMacros/TestingMacrosMain.swift
@@ -27,6 +27,8 @@ struct TestingMacrosMain: CompilerPlugin {
       ExpectMacro.self,
       RequireMacro.self,
       AmbiguousRequireMacro.self,
+      ExitTestExpectMacro.self,
+      ExitTestRequireMacro.self,
       TagMacro.self,
     ]
   }

--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -374,6 +374,20 @@ struct ConditionMacroTests {
     #expect(diagnostics.isEmpty)
   }
 
+  @Test("Expectation inside an exit test diagnoses",
+    arguments: [
+      "#expectExitTest(exitsWith: .failure) { #expect(1 > 2) }",
+      "#requireExitTest(exitsWith: .success) { #expect(1 > 2) }",
+    ]
+  )
+  func expectationInExitTest(input: String) throws {
+    let (_, diagnostics) = try parse(input)
+    let diagnostic = try #require(diagnostics.first)
+    #expect(diagnostic.diagMessage.severity == .error)
+    #expect(diagnostic.message.contains("record an issue"))
+    #expect(diagnostic.message.contains("(exitsWith:"))
+  }
+
   @Test("Macro expansion is performed within a test function")
   func macroExpansionInTestFunction() throws {
     let input = ##"""

--- a/Tests/TestingMacrosTests/TestSupport/Parse.swift
+++ b/Tests/TestingMacrosTests/TestSupport/Parse.swift
@@ -22,6 +22,8 @@ fileprivate let allMacros: [String: any Macro.Type] = [
   "expect": ExpectMacro.self,
   "require": RequireMacro.self,
   "requireAmbiguous": AmbiguousRequireMacro.self, // different name needed only for unit testing
+  "expectExitTest": ExitTestRequireMacro.self, // different name needed only for unit testing
+  "requireExitTest": ExitTestRequireMacro.self, // different name needed only for unit testing
   "Suite": SuiteDeclarationMacro.self,
   "Test": TestDeclarationMacro.self,
   "Tag": TagMacro.self,

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -12,8 +12,11 @@
 private import TestingInternals
 
 #if !SWT_NO_EXIT_TESTS
-@Suite("Exit test tests") struct ExitTestTests {
-#if SWIFT_PM_SUPPORTS_SWIFT_TESTING
+var isLaunchedByXcode: Bool {
+  Environment.variable(named: "XCTestSessionIdentifier") != nil
+}
+
+@Suite("Exit test tests", .disabled(if: isLaunchedByXcode)) struct ExitTestTests {
   @Test("Exit tests (passing)") func passing() async {
     await #expect(exitsWith: .failure) {
       exit(EXIT_FAILURE)
@@ -48,6 +51,7 @@ private import TestingInternals
   @TaskLocal
   static var isTestingFailingExitTests = false
 
+#if SWIFT_PM_SUPPORTS_SWIFT_TESTING
   @Test("Exit tests (failing)") func failing() async {
     let expectedCount: Int
 #if os(Windows)
@@ -62,7 +66,7 @@ private import TestingInternals
           failed()
         }
       }
-      configuration.exitTestHandler = ExitTest.handlerForSwiftPM
+      configuration.exitTestHandler = ExitTest.handlerForSwiftPM()
 
       await Self.$isTestingFailingExitTests.withValue(true) {
         await Runner(selecting: "failingExitTests()", configuration: configuration).run()
@@ -202,7 +206,6 @@ private import TestingInternals
 
 // MARK: - Fixtures
 
-#if SWIFT_PM_SUPPORTS_SWIFT_TESTING
 var inFailingExitTestChild: Bool {
   ExitTestTests.isTestingFailingExitTests || ExitTest.find(withArguments: CommandLine.arguments()) != nil
 }
@@ -240,6 +243,5 @@ func sellIceCreamCones(count: Int) async throws {
     precondition(count < 10, "Too many ice cream cones")
   }
 }
-#endif
 #endif
 #endif

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -13,7 +13,11 @@ private import TestingInternals
 
 #if !SWT_NO_EXIT_TESTS
 var isLaunchedByXcode: Bool {
+#if SWT_TARGET_OS_APPLE
   Environment.variable(named: "XCTestSessionIdentifier") != nil
+#else
+  false
+#endif
 }
 
 @Suite("Exit test tests", .disabled(if: isLaunchedByXcode)) struct ExitTestTests {

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -12,16 +12,8 @@
 private import TestingInternals
 
 #if !SWT_NO_EXIT_TESTS
-let isLaunchedByXcode: Bool = {
-#if SWT_TARGET_OS_APPLE
-  Environment.variable(named: "XCTestSessionIdentifier") != nil
-#else
-  false
-#endif
-}()
-
 @Suite("Exit test tests") struct ExitTestTests {
-  @Test("Exit tests (passing)", .disabled(if: isLaunchedByXcode)) func passing() async {
+  @Test("Exit tests (passing)") func passing() async {
     await #expect(exitsWith: .failure) {
       exit(EXIT_FAILURE)
     }
@@ -53,7 +45,7 @@ let isLaunchedByXcode: Bool = {
   }
 
 #if SWIFT_PM_SUPPORTS_SWIFT_TESTING
-  @Test("Exit tests (failing)", .disabled(if: isLaunchedByXcode)) func failing() async {
+  @Test("Exit tests (failing)") func failing() async {
     let expectedCount: Int
 #if os(Windows)
     expectedCount = 7

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -48,7 +48,7 @@ private import TestingInternals
   @Test("Exit tests (failing)") func failing() async {
     let expectedCount: Int
 #if os(Windows)
-    expectedCount = 7
+    expectedCount = 6
 #else
     expectedCount = 10
 #endif
@@ -211,11 +211,13 @@ private import TestingInternals
     await #expect(exitsWith: .exitCode(123)) {
       exit(0)
     }
-    await #expect(exitsWith: .exitCode(SIGABRT)) {
-      abort()
-    }
 
 #if !os(Windows)
+    await #expect(exitsWith: .exitCode(SIGABRT)) {
+      // abort() raises on Windows, but we don't handle that yet and it is
+      // reported as .failure (which will fuzzy-match with SIGABRT.)
+      abort()
+    }
     await #expect(exitsWith: .signal(123)) {}
     await #expect(exitsWith: .signal(123)) {
       exit(123)

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -12,16 +12,16 @@
 private import TestingInternals
 
 #if !SWT_NO_EXIT_TESTS
-var isLaunchedByXcode: Bool {
+let isLaunchedByXcode: Bool = {
 #if SWT_TARGET_OS_APPLE
   Environment.variable(named: "XCTestSessionIdentifier") != nil
 #else
   false
 #endif
-}
+}()
 
-@Suite("Exit test tests", .disabled(if: isLaunchedByXcode)) struct ExitTestTests {
-  @Test("Exit tests (passing)") func passing() async {
+@Suite("Exit test tests") struct ExitTestTests {
+  @Test("Exit tests (passing)", .disabled(if: isLaunchedByXcode)) func passing() async {
     await #expect(exitsWith: .failure) {
       exit(EXIT_FAILURE)
     }
@@ -56,7 +56,7 @@ var isLaunchedByXcode: Bool {
   static var isTestingFailingExitTests = false
 
 #if SWIFT_PM_SUPPORTS_SWIFT_TESTING
-  @Test("Exit tests (failing)") func failing() async {
+  @Test("Exit tests (failing)", .disabled(if: isLaunchedByXcode)) func failing() async {
     let expectedCount: Int
 #if os(Windows)
     expectedCount = 4

--- a/Tests/TestingTests/Traits/TagListTests.swift
+++ b/Tests/TestingTests/Traits/TagListTests.swift
@@ -221,6 +221,15 @@ struct TagListTests {
     // By value
     #expect(Tag.Color.rgb(0, 0, 0) < .rgb(100, 100, 100))
   }
+
+#if !SWT_NO_EXIT_TESTS && SWIFT_PM_SUPPORTS_SWIFT_TESTING
+  @Test("Invalid symbolic tag declaration")
+  func invalidSymbolicTag() async {
+    await #expect(exitsWith: .failure) {
+      _ = Tag.__fromStaticMember(of: String.self, "invalid")
+    }
+  }
+#endif
 }
 
 // MARK: - Fixtures


### PR DESCRIPTION
This PR adds a new kind of expectation called an "exit test", "death test", "expected crasher", etc. It can be invoked by writing:

```swift
#expect(exitsWith: .failure) {
  fatalError("How dare you!")
}
```

It works by spinning up a second process that re-runs the same test function. The parent process awaits the return of the child process, while the child process executes the closure passed to `#expect()`.

This is similar to calling `fork()`, however that function is fundamentally unusable on Darwin and unavailable on Windows, so I've pursued a different implementation here that works across macOS, Linux, and Windows.

There are some constraints to using exit tests that are documented, but which are not enforced at compile time. swift-syntax's `lexicalContext` should allow us to do general checks for (some of) these constraints at compile time.

Resolves #157.
(Sort of.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
