### PR TITLE
Do not assume `UnsafeRawBufferPointer` provides contiguous storage.

### DIFF
--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -243,6 +243,23 @@ extension FileHandle {
     }
   }
 
+  /// Write a sequence of bytes to this file handle.
+  ///
+  /// - Parameters:
+  ///   - bytes: The bytes to write. This untyped buffer is interpreted as a
+  ///     sequence of `UInt8` values.
+  ///   - flushAfterward: Whether or not to flush the file (with `fflush()`)
+  ///     after writing. If `true`, `fflush()` is called even if an error
+  ///     occurred while writing.
+  ///
+  /// - Throws: Any error that occurred while writing `bytes`. If an error
+  ///   occurs while flushing the file, it is not thrown.
+  func write(_ bytes: UnsafeRawBufferPointer, flushAfterward: Bool = true) throws {
+    try bytes.withMemoryRebound(to: UInt8.self) { bytes in
+      try write(bytes)
+    }
+  }
+
   /// Write a string to this file handle.
   ///
   /// - Parameters:

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -71,11 +71,20 @@ struct FileHandleTests {
       remove(path)
     }
     let fileHandle = try FileHandle(forWritingAtPath: path)
+    try fileHandle.write([0, 1, 2, 3, 4, 5])
     try fileHandle.write("Hello world!")
   }
 
-  @Test("Cannot write to a read-only file")
-  func cannotWriteToReadOnlyFile() throws {
+  @Test("Cannot write bytes to a read-only file")
+  func cannotWriteBytesToReadOnlyFile() throws {
+    let fileHandle = try FileHandle.null(mode: "rb")
+    #expect(throws: CError.self) {
+      try fileHandle.write([0, 1, 2, 3, 4, 5])
+    }
+  }
+
+  @Test("Cannot write string to a read-only file")
+  func cannotWriteStringToReadOnlyFile() throws {
     let fileHandle = try FileHandle.null(mode: "rb")
     #expect(throws: CError.self) {
       try fileHandle.write("Impossible!")


### PR DESCRIPTION
`UnsafeRawBufferPointer` only gained an implementation of `withContiguousStorageIfAvailable(_:)` with [SE-0333](https://github.com/apple/swift-evolution/blob/main/proposals/0333-with-memory-rebound.md) and https://github.com/apple/swift/pull/41288. Because swift-testing can be used on older versions of Darwin that don't have this implementation, one of our unit tests now crashes there when calling
`FileHandle.write(_: some Sequence<UInt8>)`. This PR resolves the crash by providing a concretely-typed overload that takes an instance of `UnsafeRawBufferPointer`.

This code path is technically dead right now (it survives from an intermediate implementation of #286) but because "writing bytes to a file" remains a useful tool we'll probably need in the future, I'm not ripping it out just yet.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
