### PR TITLE
Adopt `TypeInfo` in `Test`.

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -179,7 +179,7 @@ extension Test.Case {
 
         if includeTypeNames {
           let typeInfo = TypeInfo(describingTypeOf: argument.value)
-          return "\(labeledArgument) (\(typeInfo.qualifiedName))"
+          return "\(labeledArgument) (\(typeInfo.fullyQualifiedName))"
         } else {
           return labeledArgument
         }

--- a/Sources/Testing/Parameterization/TypeInfo.swift
+++ b/Sources/Testing/Parameterization/TypeInfo.swift
@@ -12,20 +12,108 @@
 /// parameter of a test function.
 @_spi(ForToolsIntegrationOnly)
 public struct TypeInfo: Sendable {
+  /// An enumeration defining backing storage for an instance of ``TypeInfo``.
+  private enum _Kind: Sendable {
+    /// The type info represents a concrete metatype.
+    ///
+    /// - Parameters:
+    ///   - type: The concrete metatype.
+    case type(_ type: Any.Type)
+
+    /// The type info represents a metatype, but a reference to that metatype is
+    /// not available at runtime.
+    ///
+    /// - Parameters:
+    ///   - fullyQualified: The fully-qualified name of the type.
+    ///   - unqualified: The unqualified name of the type.
+    case nameOnly(fullyQualified: String, unqualified: String)
+  }
+
+  /// The kind of type info.
+  private var _kind: _Kind
+
   /// The complete name of this type, with the names of all referenced types
   /// fully-qualified by their module names when possible.
-  public var qualifiedName: String
+  ///
+  /// The value of this property is equal to ``fullyQualifiedName``, but is
+  /// split into components. For instance, given the following declaration in
+  /// the `Example` module:
+  ///
+  /// ```swift
+  /// struct A {
+  ///   struct B {}
+  /// }
+  /// ```
+  ///
+  /// The value of this property for the type `A.B` would be
+  /// `["Example", "A", "B"]`.
+  public var fullyQualifiedNameComponents: [String] {
+    switch _kind {
+    case let .type(type):
+      nameComponents(of: type)
+    case let .nameOnly(fqn, _):
+      fqn.split(separator: ".").map(String.init)
+    }
+  }
+
+  /// The complete name of this type, with the names of all referenced types
+  /// fully-qualified by their module names when possible.
+  ///
+  /// The value of this property is equal to ``fullyQualifiedNameComponents``,
+  /// but is represented as a single string. For instance, given the following
+  /// declaration in the `Example` module:
+  ///
+  /// ```swift
+  /// struct A {
+  ///   struct B {}
+  /// }
+  /// ```
+  ///
+  /// The value of this property for the type `A.B` would be `"Example.A.B"`.
+  public var fullyQualifiedName: String {
+    switch _kind {
+    case let .type(type):
+      Testing.fullyQualifiedName(of: type)
+    case let .nameOnly(fqn, _):
+      fqn
+    }
+  }
 
   /// A simplified name of this type, by leaving the names of all referenced
   /// types unqualified, i.e. without module name prefixes.
-  public var unqualifiedName: String
+  ///
+  /// The value of this property is equal to the name of the type in isolation.
+  /// For instance, given the following declaration in the `Example` module:
+  ///
+  /// ```swift
+  /// struct A {
+  ///   struct B {}
+  /// }
+  /// ```
+  ///
+  /// The value of this property for the type `A.B` would simply be `"B"`.
+  public var unqualifiedName: String {
+    switch _kind {
+    case let .type(type):
+      String(describing: type)
+    case let .nameOnly(_, unqualifiedName):
+      unqualifiedName
+    }
+  }
 
-  init(
-    qualifiedName: String,
-    unqualifiedName: String
-  ) {
-    self.qualifiedName = qualifiedName
-    self.unqualifiedName = unqualifiedName
+  /// The described type, if available.
+  ///
+  /// If this instance was created from a type name, or if it was previously
+  /// encoded and decoded, the value of this property is `nil`.
+  public var type: Any.Type? {
+    if case let .type(type) = _kind {
+      return type
+    }
+    return nil
+  }
+
+  init(fullyQualifiedName: String, unqualifiedName: String) {
+    _kind = .nameOnly(fullyQualified: fullyQualifiedName, unqualified: unqualifiedName)
   }
 
   /// Initialize an instance of this type describing the specified type.
@@ -33,8 +121,7 @@ public struct TypeInfo: Sendable {
   /// - Parameters:
   ///   - type: The type which this instance should describe.
   init(describing type: Any.Type) {
-    qualifiedName = fullyQualifiedName(of: type)
-    unqualifiedName = String(describing: type)
+    _kind = .type(type)
   }
 
   /// Initialize an instance of this type describing the type of the specified
@@ -42,8 +129,8 @@ public struct TypeInfo: Sendable {
   ///
   /// - Parameters:
   ///   - value: The value whose type this instance should describe.
-  init(describingTypeOf value: some Any) {
-    self.init(describing: type(of: value as Any))
+  init(describingTypeOf value: Any) {
+    self.init(describing: Swift.type(of: value))
   }
 }
 
@@ -55,14 +142,55 @@ extension TypeInfo: CustomStringConvertible, CustomDebugStringConvertible {
   }
 
   public var debugDescription: String {
-    qualifiedName
+    fullyQualifiedName
   }
 }
 
 // MARK: - Equatable, Hashable
 
-extension TypeInfo: Hashable {}
+extension TypeInfo: Hashable {
+  public static func ==(lhs: Self, rhs: Self) -> Bool {
+    switch (lhs._kind, rhs._kind) {
+    case let (.type(lhs), .type(rhs)):
+      return lhs == rhs
+    default:
+      return lhs.fullyQualifiedNameComponents == rhs.fullyQualifiedNameComponents
+    }
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    switch _kind {
+    case let .type(type):
+      hasher.combine(ObjectIdentifier(type))
+    case let .nameOnly(fqnComponents, _):
+      hasher.combine(fqnComponents)
+    }
+  }
+}
 
 // MARK: - Codable
 
-extension TypeInfo: Codable {}
+extension TypeInfo: Codable {
+  /// A simplified version of ``TypeInfo`` suitable for encoding and decoding.
+  fileprivate struct EncodedForm {
+    /// The complete name of this type, with the names of all referenced types
+    /// fully-qualified by their module names when possible.
+    public var fullyQualifiedName: String
+
+    /// A simplified name of this type, by leaving the names of all referenced
+    /// types unqualified, i.e. without module name prefixes.
+    public var unqualifiedName: String
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    let encodedForm = EncodedForm(fullyQualifiedName: fullyQualifiedName, unqualifiedName: unqualifiedName)
+    try encodedForm.encode(to: encoder)
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let encodedForm = try EncodedForm(from: decoder)
+    self.init(fullyQualifiedName: encodedForm.fullyQualifiedName, unqualifiedName: encodedForm.unqualifiedName)
+  }
+}
+
+extension TypeInfo.EncodedForm: Codable {}

--- a/Sources/Testing/SourceAttribution/Expression.swift
+++ b/Sources/Testing/SourceAttribution/Expression.swift
@@ -258,7 +258,7 @@ public struct Expression: Sendable {
     var result = ""
     switch kind {
     case let .generic(sourceCode), let .stringLiteral(sourceCode, _):
-      result = if includingTypeNames, let qualifiedName = runtimeValue?.typeInfo.qualifiedName {
+      result = if includingTypeNames, let qualifiedName = runtimeValue?.typeInfo.fullyQualifiedName {
         "\(sourceCode): \(qualifiedName)"
       } else {
         sourceCode

--- a/Sources/Testing/Test+Discovery.swift
+++ b/Sources/Testing/Test+Discovery.swift
@@ -28,7 +28,7 @@ extension Test {
   /// All available ``Test`` instances in the process, according to the runtime.
   ///
   /// The order of values in this sequence is unspecified.
-  static var all: some Sequence<Test> {
+  static var all: some Collection<Test> {
     get async {
       // Convert the raw sequence of tests to a dictionary keyed by ID.
       var result = await testsByID(_all)
@@ -45,7 +45,7 @@ extension Test {
   ///
   /// The order of values in this sequence is unspecified. This sequence may
   /// contain duplicates; callers should use ``all`` instead.
-  private static var _all: some Sequence<Self> {
+  private static var _all: some Collection<Self> {
     get async {
       await withTaskGroup(of: [Self].self) { taskGroup in
         swt_enumerateTypes(&taskGroup) { type, context in
@@ -98,16 +98,16 @@ extension Test {
     // Find any instances of Test in the input that are *not* suites. We'll be
     // checking the containing types of each one.
     for test in tests.values where !test.isSuite {
-      guard let suiteType = test.containingType else {
+      guard let suiteTypeInfo = test.containingTypeInfo else {
         continue
       }
-      let suiteID = ID(type: suiteType)
+      let suiteID = ID(typeInfo: suiteTypeInfo)
       if tests[suiteID] == nil {
         // If the real test is hidden, so shall the synthesized test be hidden.
         // Copy the exact traits from the real test in case they someday carry
         // any interesting metadata.
         let traits = test.traits.compactMap { $0 as? HiddenTrait }
-        tests[suiteID] = .__type(suiteType, displayName: nil, traits: traits, sourceLocation: test.sourceLocation)
+        tests[suiteID] = Test(traits: traits, sourceLocation: test.sourceLocation, containingTypeInfo: suiteTypeInfo)
       }
     }
 

--- a/Sources/Testing/Test+Discovery.swift
+++ b/Sources/Testing/Test+Discovery.swift
@@ -28,7 +28,7 @@ extension Test {
   /// All available ``Test`` instances in the process, according to the runtime.
   ///
   /// The order of values in this sequence is unspecified.
-  static var all: some Collection<Test> {
+  static var all: some Sequence<Test> {
     get async {
       // Convert the raw sequence of tests to a dictionary keyed by ID.
       var result = await testsByID(_all)
@@ -45,7 +45,7 @@ extension Test {
   ///
   /// The order of values in this sequence is unspecified. This sequence may
   /// contain duplicates; callers should use ``all`` instead.
-  private static var _all: some Collection<Self> {
+  private static var _all: some Sequence<Self> {
     get async {
       await withTaskGroup(of: [Self].self) { taskGroup in
         swt_enumerateTypes(&taskGroup) { type, context in

--- a/Sources/Testing/Test+Macro.swift
+++ b/Sources/Testing/Test+Macro.swift
@@ -110,8 +110,8 @@ extension Test {
     traits: [any SuiteTrait],
     sourceLocation: SourceLocation
   ) -> Self {
-    let typeName = String(describing: containingType)
-    return Self(name: typeName, displayName: displayName, traits: traits, sourceLocation: sourceLocation, containingType: containingType)
+    let containingTypeInfo = TypeInfo(describing: containingType)
+    return Self(displayName: displayName, traits: traits, sourceLocation: sourceLocation, containingTypeInfo: containingTypeInfo)
   }
 }
 
@@ -165,8 +165,9 @@ extension Test {
     parameters: [__Parameter] = [],
     testFunction: @escaping @Sendable () async throws -> Void
   ) -> Self {
+    let containingTypeInfo = containingType.map(TypeInfo.init(describing:))
     let caseGenerator = Case.Generator(testFunction: testFunction)
-    return Self(name: testFunctionName, displayName: displayName, traits: traits, sourceLocation: sourceLocation, containingType: containingType, xcTestCompatibleSelector: xcTestCompatibleSelector, testCases: caseGenerator, parameters: [])
+    return Self(name: testFunctionName, displayName: displayName, traits: traits, sourceLocation: sourceLocation, containingTypeInfo: containingTypeInfo, xcTestCompatibleSelector: xcTestCompatibleSelector, testCases: caseGenerator, parameters: [])
   }
 }
 
@@ -240,9 +241,10 @@ extension Test {
     parameters paramTuples: [__Parameter],
     testFunction: @escaping @Sendable (C.Element) async throws -> Void
   ) -> Self where C: Collection & Sendable, C.Element: Sendable {
+    let containingTypeInfo = containingType.map(TypeInfo.init(describing:))
     let parameters = paramTuples.parameters
     let caseGenerator = Case.Generator(arguments: collection, parameters: parameters, testFunction: testFunction)
-    return Self(name: testFunctionName, displayName: displayName, traits: traits, sourceLocation: sourceLocation, containingType: containingType, xcTestCompatibleSelector: xcTestCompatibleSelector, testCases: caseGenerator, parameters: parameters)
+    return Self(name: testFunctionName, displayName: displayName, traits: traits, sourceLocation: sourceLocation, containingTypeInfo: containingTypeInfo, xcTestCompatibleSelector: xcTestCompatibleSelector, testCases: caseGenerator, parameters: parameters)
   }
 }
 
@@ -368,9 +370,10 @@ extension Test {
     parameters paramTuples: [__Parameter],
     testFunction: @escaping @Sendable (C1.Element, C2.Element) async throws -> Void
   ) -> Self where C1: Collection & Sendable, C1.Element: Sendable, C2: Collection & Sendable, C2.Element: Sendable {
+    let containingTypeInfo = containingType.map(TypeInfo.init(describing:))
     let parameters = paramTuples.parameters
     let caseGenerator = Case.Generator(arguments: collection1, collection2, parameters: parameters, testFunction: testFunction)
-    return Self(name: testFunctionName, displayName: displayName, traits: traits, sourceLocation: sourceLocation, containingType: containingType, xcTestCompatibleSelector: xcTestCompatibleSelector, testCases: caseGenerator, parameters: parameters)
+    return Self(name: testFunctionName, displayName: displayName, traits: traits, sourceLocation: sourceLocation, containingTypeInfo: containingTypeInfo, xcTestCompatibleSelector: xcTestCompatibleSelector, testCases: caseGenerator, parameters: parameters)
   }
 
   /// Create an instance of ``Test`` for a parameterized function.
@@ -391,9 +394,10 @@ extension Test {
     parameters paramTuples: [__Parameter],
     testFunction: @escaping @Sendable ((E1, E2)) async throws -> Void
   ) -> Self where C: Collection & Sendable, C.Element == (E1, E2), E1: Sendable, E2: Sendable {
+    let containingTypeInfo = containingType.map(TypeInfo.init(describing:))
     let parameters = paramTuples.parameters
     let caseGenerator = Case.Generator(arguments: collection, parameters: parameters, testFunction: testFunction)
-    return Self(name: testFunctionName, displayName: displayName, traits: traits, sourceLocation: sourceLocation, containingType: containingType, xcTestCompatibleSelector: xcTestCompatibleSelector, testCases: caseGenerator, parameters: parameters)
+    return Self(name: testFunctionName, displayName: displayName, traits: traits, sourceLocation: sourceLocation, containingTypeInfo: containingTypeInfo, xcTestCompatibleSelector: xcTestCompatibleSelector, testCases: caseGenerator, parameters: parameters)
   }
 
   /// Create an instance of ``Test`` for a parameterized function.
@@ -417,9 +421,10 @@ extension Test {
     parameters paramTuples: [__Parameter],
     testFunction: @escaping @Sendable ((Key, Value)) async throws -> Void
   ) -> Self where Key: Sendable, Value: Sendable {
+    let containingTypeInfo = containingType.map(TypeInfo.init(describing:))
     let parameters = paramTuples.parameters
     let caseGenerator = Case.Generator(arguments: dictionary, parameters: parameters, testFunction: testFunction)
-    return Self(name: testFunctionName, displayName: displayName, traits: traits, sourceLocation: sourceLocation, containingType: containingType, xcTestCompatibleSelector: xcTestCompatibleSelector, testCases: caseGenerator, parameters: parameters)
+    return Self(name: testFunctionName, displayName: displayName, traits: traits, sourceLocation: sourceLocation, containingTypeInfo: containingTypeInfo, xcTestCompatibleSelector: xcTestCompatibleSelector, testCases: caseGenerator, parameters: parameters)
   }
 
   /// Create an instance of ``Test`` for a parameterized function.
@@ -437,11 +442,12 @@ extension Test {
     parameters paramTuples: [__Parameter],
     testFunction: @escaping @Sendable (C1.Element, C2.Element) async throws -> Void
   ) -> Self where C1: Collection & Sendable, C1.Element: Sendable, C2: Collection & Sendable, C2.Element: Sendable {
+    let containingTypeInfo = containingType.map(TypeInfo.init(describing:))
     let parameters = paramTuples.parameters
     let caseGenerator = Case.Generator(arguments: zippedCollections, parameters: parameters) {
       try await testFunction($0, $1)
     }
-    return Self(name: testFunctionName, displayName: displayName, traits: traits, sourceLocation: sourceLocation, containingType: containingType, xcTestCompatibleSelector: xcTestCompatibleSelector, testCases: caseGenerator, parameters: parameters)
+    return Self(name: testFunctionName, displayName: displayName, traits: traits, sourceLocation: sourceLocation, containingTypeInfo: containingTypeInfo, xcTestCompatibleSelector: xcTestCompatibleSelector, testCases: caseGenerator, parameters: parameters)
   }
 }
 

--- a/Sources/Testing/Test.ID.swift
+++ b/Sources/Testing/Test.ID.swift
@@ -71,7 +71,19 @@ extension Test: Identifiable {
     /// This initializer produces a test ID corresponding to the given type.
     @_spi(ForToolsIntegrationOnly)
     public init(type: Any.Type) {
-      self.init(Testing.nameComponents(of: type))
+      self.init(typeInfo: TypeInfo(describing: type))
+    }
+
+    /// Initialize an instance of this type representing the specified test
+    /// suite type.
+    ///
+    /// - Parameters:
+    ///   - type: The test suite type.
+    ///
+    /// This initializer produces a test ID corresponding to the given type.
+    @_spi(ForToolsIntegrationOnly)
+    public init(typeInfo: TypeInfo) {
+      self.init(typeInfo.fullyQualifiedNameComponents)
     }
 
     /// A representation of this instance suitable for use as a key path in a
@@ -104,7 +116,7 @@ extension Test: Identifiable {
   }
 
   public var id: ID {
-    var result = containingType.map(ID.init)
+    var result = containingTypeInfo.map(ID.init)
       ?? ID(moduleName: sourceLocation.moduleName, nameComponents: [], sourceLocation: nil)
 
     if !isSuite {

--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -53,12 +53,12 @@ public struct Test: Sendable {
   /// The source location of this test.
   public var sourceLocation: SourceLocation
 
-  /// The type containing this test, if any.
+  /// Information about the type containing this test, if any.
   ///
   /// If a test is associated with a free function or static function, the value
   /// of this property is `nil`. To determine if a specific instance of ``Test``
   /// refers to this type itself, check the ``isSuite`` property.
-  var containingType: Any.Type?
+  var containingTypeInfo: TypeInfo?
 
   /// The XCTest-compatible Objective-C selector corresponding to this
   /// instance's underlying test function.
@@ -109,22 +109,21 @@ public struct Test: Sendable {
   ///
   /// A test suite can be declared using the ``Suite(_:_:)`` macro.
   public var isSuite: Bool {
-    containingType != nil && testCases == nil
+    containingTypeInfo != nil && testCases == nil
   }
 
   /// Initialize an instance of this type representing a test suite type.
   init(
-    name: String,
     displayName: String? = nil,
     traits: [any Trait],
     sourceLocation: SourceLocation,
-    containingType: Any.Type
+    containingTypeInfo: TypeInfo
   ) {
-    self.name = name
+    self.name = containingTypeInfo.unqualifiedName
     self.displayName = displayName
     self.traits = traits
     self.sourceLocation = sourceLocation
-    self.containingType = containingType
+    self.containingTypeInfo = containingTypeInfo
   }
 
   /// Initialize an instance of this type representing a test function.
@@ -133,7 +132,7 @@ public struct Test: Sendable {
     displayName: String? = nil,
     traits: [any Trait],
     sourceLocation: SourceLocation,
-    containingType: Any.Type? = nil,
+    containingTypeInfo: TypeInfo? = nil,
     xcTestCompatibleSelector: __XCTestCompatibleSelector? = nil,
     testCases: Test.Case.Generator<S>,
     parameters: [Parameter]
@@ -142,7 +141,7 @@ public struct Test: Sendable {
     self.displayName = displayName
     self.traits = traits
     self.sourceLocation = sourceLocation
-    self.containingType = containingType
+    self.containingTypeInfo = containingTypeInfo
     self.xcTestCompatibleSelector = xcTestCompatibleSelector
     self._testCases = .init(rawValue: .init(testCases))
     self.parameters = parameters

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -362,7 +362,7 @@ final class IssueTests: XCTestCase {
       XCTAssertEqual(expression.sourceCode, "abc123")
       let runtimeValue = try XCTUnwrap(expression.runtimeValue)
       XCTAssertEqual(String(describing: runtimeValue), "987")
-      XCTAssertEqual(runtimeValue.typeInfo.qualifiedName, "Swift.Int")
+      XCTAssertEqual(runtimeValue.typeInfo.fullyQualifiedName, "Swift.Int")
       XCTAssertFalse(runtimeValue.isCollection)
     }
 
@@ -371,7 +371,7 @@ final class IssueTests: XCTestCase {
       XCTAssertEqual(expression.sourceCode, "abc123")
       let runtimeValue = try XCTUnwrap(expression.runtimeValue)
       XCTAssertEqual(String(describing: runtimeValue), "ExpressionRuntimeValueCapture_Value()")
-      XCTAssertEqual(runtimeValue.typeInfo.qualifiedName, "TestingTests.IssueTests.ExpressionRuntimeValueCapture_Value")
+      XCTAssertEqual(runtimeValue.typeInfo.fullyQualifiedName, "TestingTests.IssueTests.ExpressionRuntimeValueCapture_Value")
       XCTAssertFalse(runtimeValue.isCollection)
     }
 
@@ -380,7 +380,7 @@ final class IssueTests: XCTestCase {
       XCTAssertEqual(expression.sourceCode, "abc123")
       let runtimeValue = try XCTUnwrap(expression.runtimeValue)
       XCTAssertEqual(String(describing: runtimeValue), #"(123, "abc")"#)
-      XCTAssertEqual(runtimeValue.typeInfo.qualifiedName, "(Swift.Int, Swift.String)")
+      XCTAssertEqual(runtimeValue.typeInfo.fullyQualifiedName, "(Swift.Int, Swift.String)")
       XCTAssertFalse(runtimeValue.isCollection)
     }
   }
@@ -398,7 +398,7 @@ final class IssueTests: XCTestCase {
       expression = expression.capturingRuntimeValues(ExpressionRuntimeValueCapture_Value())
       let runtimeValue = try XCTUnwrap(expression.runtimeValue)
       XCTAssertEqual(String(describing: runtimeValue), "ExpressionRuntimeValueCapture_Value()")
-      XCTAssertEqual(runtimeValue.typeInfo.qualifiedName, "TestingTests.IssueTests.ExpressionRuntimeValueCapture_Value")
+      XCTAssertEqual(runtimeValue.typeInfo.fullyQualifiedName, "TestingTests.IssueTests.ExpressionRuntimeValueCapture_Value")
       XCTAssertFalse(runtimeValue.isCollection)
       XCTAssertNil(runtimeValue.children)
       XCTAssertNil(runtimeValue.label)
@@ -408,7 +408,7 @@ final class IssueTests: XCTestCase {
       expression = expression.capturingRuntimeValues(ExpressionRuntimeValueCapture_ValueWithChildren(contents: [123, "abc"]))
       let runtimeValue = try XCTUnwrap(expression.runtimeValue)
       XCTAssertEqual(String(describing: runtimeValue), #"ExpressionRuntimeValueCapture_ValueWithChildren(contents: [123, "abc"])"#)
-      XCTAssertEqual(runtimeValue.typeInfo.qualifiedName, "TestingTests.IssueTests.ExpressionRuntimeValueCapture_ValueWithChildren")
+      XCTAssertEqual(runtimeValue.typeInfo.fullyQualifiedName, "TestingTests.IssueTests.ExpressionRuntimeValueCapture_ValueWithChildren")
       XCTAssertFalse(runtimeValue.isCollection)
       XCTAssertNil(runtimeValue.label)
 
@@ -431,7 +431,7 @@ final class IssueTests: XCTestCase {
       expression = expression.capturingRuntimeValues([])
       let runtimeValue = try XCTUnwrap(expression.runtimeValue)
       XCTAssertEqual(String(describing: runtimeValue), "[]")
-      XCTAssertEqual(runtimeValue.typeInfo.qualifiedName, "Swift.Array<Any>")
+      XCTAssertEqual(runtimeValue.typeInfo.fullyQualifiedName, "Swift.Array<Any>")
       XCTAssertTrue(runtimeValue.isCollection)
       XCTAssertNil(runtimeValue.label)
 

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -208,7 +208,7 @@ struct MiscellaneousTests {
   @Test("Free function has custom display name")
   func namedFreeFunctionTest() async throws {
     let tests = await Test.all
-    #expect(tests.first { $0.displayName == "Named Free Sync Function" && !$0.isSuite && $0.containingType == nil } != nil)
+    #expect(tests.first { $0.displayName == "Named Free Sync Function" && !$0.isSuite && $0.containingTypeInfo == nil } != nil)
   }
 
   @Test("Member function has custom display name")
@@ -340,7 +340,7 @@ struct MiscellaneousTests {
       #expect(firstParameter.firstName == "i")
       #expect(firstParameter.secondName == nil)
       let firstParameterTypeInfo = try #require(firstParameter.typeInfo)
-      #expect(firstParameterTypeInfo.qualifiedName == "Swift.Int")
+      #expect(firstParameterTypeInfo.fullyQualifiedName == "Swift.Int")
       #expect(firstParameterTypeInfo.unqualifiedName == "Int")
     } catch {}
 
@@ -357,7 +357,7 @@ struct MiscellaneousTests {
       #expect(secondParameter.firstName == "j")
       #expect(secondParameter.secondName == "k")
       let secondParameterTypeInfo = try #require(secondParameter.typeInfo)
-      #expect(secondParameterTypeInfo.qualifiedName == "Swift.String")
+      #expect(secondParameterTypeInfo.fullyQualifiedName == "Swift.String")
       #expect(secondParameterTypeInfo.unqualifiedName == "String")
     } catch {}
   }

--- a/Tests/TestingTests/ObjCInteropTests.swift
+++ b/Tests/TestingTests/ObjCInteropTests.swift
@@ -77,7 +77,7 @@ struct ObjCAndXCTestInteropTests {
     #expect(steps.count > 0)
     for step in steps {
       let selector = try #require(step.test.xcTestCompatibleSelector)
-      let testCaseClass = try #require(step.test.containingType as? NSObject.Type)
+      let testCaseClass = try #require(step.test.containingTypeInfo?.type as? NSObject.Type)
       #expect(testCaseClass.instancesRespond(to: selector))
     }
   }

--- a/Tests/TestingTests/Test.Case.ArgumentTests.swift
+++ b/Tests/TestingTests/Test.Case.ArgumentTests.swift
@@ -141,7 +141,7 @@ struct Test_Case_ArgumentTests {
       #expect(value.1 == 123)
       #expect(argument.parameter.index == 0)
       #expect(argument.parameter.firstName == "x")
-      #expect(argument.parameter.typeInfo.qualifiedName == "(key: Swift.String, value: Swift.Int)")
+      #expect(argument.parameter.typeInfo.fullyQualifiedName == "(key: Swift.String, value: Swift.Int)")
       #expect(argument.parameter.typeInfo.unqualifiedName == "(key: String, value: Int)")
     }
 

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -35,8 +35,9 @@ extension Tag {
 /// - Returns: The test instance representing the specified type, or `nil` if
 ///   none is found.
 func test(for containingType: Any.Type) async -> Test? {
-  await Test.all.first {
-    $0.isSuite && $0.containingType == containingType
+  let containingTypeInfo = TypeInfo(describing: containingType)
+  return await Test.all.first {
+    $0.isSuite && $0.containingTypeInfo == containingTypeInfo
   }
 }
 
@@ -49,8 +50,9 @@ func test(for containingType: Any.Type) async -> Test? {
 /// - Returns: The test instance representing the specified test function, or
 ///   `nil` if none is found.
 func testFunction(named name: String, in containingType: Any.Type) async -> Test? {
-  await Test.all.first {
-    $0.name == name && !$0.isSuite && $0.containingType == containingType
+  let containingTypeInfo = TypeInfo(describing: containingType)
+  return await Test.all.first {
+    $0.name == name && !$0.isSuite && $0.containingTypeInfo == containingTypeInfo
   }
 }
 
@@ -146,7 +148,7 @@ extension Test {
   ) {
     let sourceLocation = SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column)
     let caseGenerator = Case.Generator(testFunction: testFunction)
-    self.init(name: name, displayName: name, traits: traits, sourceLocation: sourceLocation, containingType: nil, testCases: caseGenerator, parameters: [])
+    self.init(name: name, displayName: name, traits: traits, sourceLocation: sourceLocation, containingTypeInfo: nil, testCases: caseGenerator, parameters: [])
   }
 
   /// Initialize an instance of this type with a function or closure to call,
@@ -177,7 +179,7 @@ extension Test {
   ) where C: Collection & Sendable, C.Element: Sendable {
     let sourceLocation = SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column)
     let caseGenerator = Case.Generator(arguments: collection, parameters: parameters, testFunction: testFunction)
-    self.init(name: name, displayName: name, traits: traits, sourceLocation: sourceLocation, containingType: nil, testCases: caseGenerator, parameters: parameters)
+    self.init(name: name, displayName: name, traits: traits, sourceLocation: sourceLocation, containingTypeInfo: nil, testCases: caseGenerator, parameters: parameters)
   }
 
   /// Initialize an instance of this type with a function or closure to call,
@@ -209,7 +211,7 @@ extension Test {
   ) where C1: Collection & Sendable, C1.Element: Sendable, C2: Collection & Sendable, C2.Element: Sendable {
     let sourceLocation = SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column)
     let caseGenerator = Case.Generator(arguments: collection1, collection2, parameters: parameters, testFunction: testFunction)
-    self.init(name: name, displayName: name, traits: traits, sourceLocation: sourceLocation, containingType: nil, testCases: caseGenerator, parameters: parameters)
+    self.init(name: name, displayName: name, traits: traits, sourceLocation: sourceLocation, containingTypeInfo: nil, testCases: caseGenerator, parameters: parameters)
   }
 
   /// Initialize an instance of this type with a function or closure to call,
@@ -236,7 +238,7 @@ extension Test {
   ) where C1: Collection & Sendable, C1.Element: Sendable, C2: Collection & Sendable, C2.Element: Sendable {
     let sourceLocation = SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column)
     let caseGenerator = Case.Generator(arguments: zippedCollections, parameters: parameters, testFunction: testFunction)
-    self.init(name: name, displayName: name, traits: traits, sourceLocation: sourceLocation, containingType: nil, testCases: caseGenerator, parameters: parameters)
+    self.init(name: name, displayName: name, traits: traits, sourceLocation: sourceLocation, containingTypeInfo: nil, testCases: caseGenerator, parameters: parameters)
   }
 }
 

--- a/Tests/TestingTests/TypeInfoTests.swift
+++ b/Tests/TestingTests/TypeInfoTests.swift
@@ -15,23 +15,23 @@ struct TypeInfoTests {
   @Test(arguments: [
     (
       String.self,
-      TypeInfo(qualifiedName: "Swift.String", unqualifiedName: "String")
+      TypeInfo(fullyQualifiedName: "Swift.String", unqualifiedName: "String")
     ),
     (
       [String].self,
-      TypeInfo(qualifiedName: "Swift.Array<Swift.String>", unqualifiedName: "Array<String>")
+      TypeInfo(fullyQualifiedName: "Swift.Array<Swift.String>", unqualifiedName: "Array<String>")
     ),
     (
       [Test].self,
-      TypeInfo(qualifiedName: "Swift.Array<Testing.Test>", unqualifiedName: "Array<Test>")
+      TypeInfo(fullyQualifiedName: "Swift.Array<Testing.Test>", unqualifiedName: "Array<Test>")
     ),
     (
       (key: String, value: Int).self,
-      TypeInfo(qualifiedName: "(key: Swift.String, value: Swift.Int)", unqualifiedName: "(key: String, value: Int)")
+      TypeInfo(fullyQualifiedName: "(key: Swift.String, value: Swift.Int)", unqualifiedName: "(key: String, value: Int)")
     ),
     (
       (() -> String).self,
-      TypeInfo(qualifiedName: "() -> Swift.String", unqualifiedName: "() -> String")
+      TypeInfo(fullyQualifiedName: "() -> Swift.String", unqualifiedName: "() -> String")
     ),
   ] as [(Any.Type, TypeInfo)])
   func initWithType(type: Any.Type, expectedTypeInfo: TypeInfo) {


### PR DESCRIPTION
This PR adopts `TypeInfo` in `Test` so that we're not carrying around a direct type reference. This will allow us to synthesize instances of `Test` at runtime that describe types for which we don't have the metatype pointer. It may also enable future Embedded Swift work (where `Any.Type` is unavailable.)

This change updates `TypeInfo` to track either a metatype (where available) _or_ a qualified/unqualified name pair. If you start with a metatype, you keep it around until you need to encode the instance, at which point we encode strings, and subsequent decoding gives you back a `TypeInfo` that's string-backed. This should improve memory usage and storage requirements because otherwise every instance of `Test` in memory will need to keep strings around and they are unlikely to be interned/uniqued in the process.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
