### PR TITLE
Synthesize `Test` instances for all suite types.

### DIFF
--- a/Sources/Testing/Parameterization/TypeInfo.swift
+++ b/Sources/Testing/Parameterization/TypeInfo.swift
@@ -154,9 +154,11 @@ extension TypeInfo {
     let fqnComponents = fullyQualifiedNameComponents
     if fqnComponents.count > 2 { // the module is not a type
       let fqn = fqnComponents.dropLast().joined(separator: ".")
+#if false // currently non-functional
       if let type = _typeByName(fqn) {
         return Self(describing: type)
       }
+#endif
       let name = fqnComponents[fqnComponents.count - 2]
       return Self(fullyQualifiedName: fqn, unqualifiedName: name)
     }

--- a/Sources/Testing/Test+Discovery.swift
+++ b/Sources/Testing/Test+Discovery.swift
@@ -103,11 +103,15 @@ extension Test {
       }
       let suiteID = ID(typeInfo: suiteTypeInfo)
       if tests[suiteID] == nil {
-        // If the real test is hidden, so shall the synthesized test be hidden.
-        // Copy the exact traits from the real test in case they someday carry
-        // any interesting metadata.
-        let traits = test.traits.compactMap { $0 as? HiddenTrait }
-        tests[suiteID] = Test(traits: traits, sourceLocation: test.sourceLocation, containingTypeInfo: suiteTypeInfo)
+        tests[suiteID] = Test(traits: [], sourceLocation: test.sourceLocation, containingTypeInfo: suiteTypeInfo, isSynthesized: true)
+
+        // Also synthesize any ancestral suites that don't have tests.
+        for ancestralSuiteTypeInfo in suiteTypeInfo.allContainingTypeInfo {
+          let ancestralSuiteID = ID(typeInfo: ancestralSuiteTypeInfo)
+          if tests[ancestralSuiteID] == nil {
+            tests[ancestralSuiteID] = Test(traits: [], sourceLocation: test.sourceLocation, containingTypeInfo: ancestralSuiteTypeInfo, isSynthesized: true)
+          }
+        }
       }
     }
 

--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -112,18 +112,29 @@ public struct Test: Sendable {
     containingTypeInfo != nil && testCases == nil
   }
 
+  /// Whether or not this instance was synthesized at runtime.
+  ///
+  /// During test planning, suites that are not explicitly marked with the
+  /// `@Suite` attribute are synthesized from available type information before
+  /// being added to the plan. For such suites, the value of this property is
+  /// `true`.
+  @_spi(ForToolsIntegrationOnly)
+  public var isSynthesized = false
+
   /// Initialize an instance of this type representing a test suite type.
   init(
     displayName: String? = nil,
     traits: [any Trait],
     sourceLocation: SourceLocation,
-    containingTypeInfo: TypeInfo
+    containingTypeInfo: TypeInfo,
+    isSynthesized: Bool = false
   ) {
     self.name = containingTypeInfo.unqualifiedName
     self.displayName = displayName
     self.traits = traits
     self.sourceLocation = sourceLocation
     self.containingTypeInfo = containingTypeInfo
+    self.isSynthesized = isSynthesized
   }
 
   /// Initialize an instance of this type representing a test function.

--- a/Tests/TestingTests/PlanTests.swift
+++ b/Tests/TestingTests/PlanTests.swift
@@ -423,7 +423,9 @@ struct PlanTests {
   @Test("Runner.Plan.independentlyRunnableSteps property")
   func independentlyRunnableTests() async throws {
     let plan = await Runner.Plan(selecting: IndependentlyRunnableTests.self)
-    #expect(plan.independentlyRunnableSteps.count == 2)
+    withKnownIssue("This algorithm is no longer correct with all suites synthesized") {
+      #expect(plan.independentlyRunnableSteps.count == 2)
+    }
   }
 }
 

--- a/Tests/TestingTests/PlanTests.swift
+++ b/Tests/TestingTests/PlanTests.swift
@@ -420,11 +420,11 @@ struct PlanTests {
     #expect(plan.stepGraph.subgraph(at: nameComponents(of: SendableTests.self) + CollectionOfOne("reserved1(reserved2:)")) != nil)
   }
 
-  @Test("Runner.Plan.independentlyRunnableSteps property")
+  @Test("Runner.Plan.independentlyRunnableSteps property (all tests top-level)")
   func independentlyRunnableTests() async throws {
-    let plan = await Runner.Plan(selecting: IndependentlyRunnableTests.self)
-    withKnownIssue("This algorithm is no longer correct with all suites synthesized") {
-      #expect(plan.independentlyRunnableSteps.count == 2)
+    let plan = await Runner.Plan(configuration: .init())
+    for step in plan.independentlyRunnableSteps {
+      #expect(step.test.id.nameComponents.count == 1, "Test is not top-level: \(step.test)")
     }
   }
 }


### PR DESCRIPTION
This PR extends test discovery to synthesize `Test` instances for all suite types (that is, types containing other suites or test functions but which do not have the `@Suite` attribute explicitly applied to them.)

This ensures that deep type hierarchies like the following are fully represented in test plans:

```swift
struct AllTests {
  struct FoodTruckTests {
    @Suite struct MechanicalTests {
      struct BatteryTests {
      	@Test func isCharged() { ... }
      }
    }
  }
}
```

Resolves rdar://125241067.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
