### PR TITLE
Fix some variable names in #310.

### DIFF
--- a/Sources/Testing/Parameterization/TypeInfo.swift
+++ b/Sources/Testing/Parameterization/TypeInfo.swift
@@ -51,8 +51,8 @@ public struct TypeInfo: Sendable {
     switch _kind {
     case let .type(type):
       nameComponents(of: type)
-    case let .nameOnly(fqn, _):
-      fqn.split(separator: ".").map(String.init)
+    case let .nameOnly(fullyQualifiedName, _):
+      fullyQualifiedName.split(separator: ".").map(String.init)
     }
   }
 
@@ -74,8 +74,8 @@ public struct TypeInfo: Sendable {
     switch _kind {
     case let .type(type):
       Testing.fullyQualifiedName(of: type)
-    case let .nameOnly(fqn, _):
-      fqn
+    case let .nameOnly(fullyQualifiedName, _):
+      fullyQualifiedName
     }
   }
 
@@ -154,17 +154,12 @@ extension TypeInfo: Hashable {
     case let (.type(lhs), .type(rhs)):
       return lhs == rhs
     default:
-      return lhs.fullyQualifiedNameComponents == rhs.fullyQualifiedNameComponents
+      return lhs.fullyQualifiedName == rhs.fullyQualifiedName
     }
   }
 
   public func hash(into hasher: inout Hasher) {
-    switch _kind {
-    case let .type(type):
-      hasher.combine(ObjectIdentifier(type))
-    case let .nameOnly(fqnComponents, _):
-      hasher.combine(fqnComponents)
-    }
+    hasher.combine(fullyQualifiedName)
   }
 }
 


### PR DESCRIPTION
This PR fixes some poor variable names I picked in #310. It also optimizes the `==` operator a bit by using the stored FQN instead of computed FQN components. Finally, it fixes `hash(into:)` producing different hashes depending on the kind case (oops.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
