### PR TITLE
Fix issues building when using Xcode Command Line Tools (no XCTest.)

### DIFF
--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if !SWT_NO_XCTEST_SCAFFOLDING
+#if !SWT_NO_XCTEST_SCAFFOLDING && canImport(XCTest)
 private import TestingInternals
 public import XCTest
 
@@ -25,19 +25,6 @@ extension XCTSourceCodeContext {
     self.init(callStackAddresses: addresses, location: sourceLocation)
   }
 }
-
-/// An error that is reported by ``XCTestScaffold`` when a test times out.
-///
-/// This type is not part of the public interface of the testing library.
-struct TimeoutError: Error, CustomStringConvertible {
-  /// The time limit exceeded by the test that timed out.
-  var timeLimit: TimeValue
-
-  var description: String {
-    "Timed out after \(timeLimit) seconds."
-  }
-}
-
 extension XCTIssue {
   init(_ issue: Issue, processLaunchedByXcode: Bool) {
     var error = issue.error

--- a/Sources/Testing/Traits/TimeLimitTrait.swift
+++ b/Sources/Testing/Traits/TimeLimitTrait.swift
@@ -108,6 +108,18 @@ extension Test {
 
 // MARK: -
 
+/// An error that is reported by ``XCTestScaffold`` when a test times out.
+///
+/// This type is not part of the public interface of the testing library.
+struct TimeoutError: Error, CustomStringConvertible {
+  /// The time limit exceeded by the test that timed out.
+  var timeLimit: TimeValue
+
+  var description: String {
+    "Timed out after \(timeLimit) seconds."
+  }
+}
+
 #if !SWT_NO_UNSTRUCTURED_TASKS
 /// Invoke a function with a timeout.
 ///

--- a/Tests/TestingMacrosTests/TestSupport/Scaffolding.swift
+++ b/Tests/TestingMacrosTests/TestSupport/Scaffolding.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if !SWT_NO_XCTEST_SCAFFOLDING && !SWIFT_PM_SUPPORTS_SWIFT_TESTING
+#if !SWT_NO_XCTEST_SCAFFOLDING && !SWIFT_PM_SUPPORTS_SWIFT_TESTING && canImport(XCTest)
 import XCTest
 import Testing
 

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -10,6 +10,7 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 private import TestingInternals
+import Foundation
 
 #if canImport(XCTest)
 import XCTest

--- a/Tests/TestingTests/ObjCInteropTests.swift
+++ b/Tests/TestingTests/ObjCInteropTests.swift
@@ -8,6 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+#if canImport(XCTest)
 import XCTest
 @testable @_spi(ForToolsIntegrationOnly) import Testing
 
@@ -106,3 +107,4 @@ struct ObjCAndXCTestInteropTests {
     }
   }
 }
+#endif

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -10,6 +10,7 @@
 
 #if canImport(XCTest)
 import XCTest
+#endif
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
 struct MyError: Error, Equatable {
@@ -35,6 +36,7 @@ private let randomNumber = Int.random(in: 0 ..< .max)
   throw MyParameterizedError(index: i)
 }
 
+#if canImport(XCTest)
 @Suite(.hidden, .disabled())
 struct NeverRunTests {
   private static var someCondition: Bool {

--- a/Tests/TestingTests/TestSupport/Scaffolding.swift
+++ b/Tests/TestingTests/TestSupport/Scaffolding.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if !SWT_NO_XCTEST_SCAFFOLDING && !SWIFT_PM_SUPPORTS_SWIFT_TESTING
+#if !SWT_NO_XCTEST_SCAFFOLDING && !SWIFT_PM_SUPPORTS_SWIFT_TESTING && canImport(XCTest)
 import XCTest
 import Testing
 

--- a/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
+++ b/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
@@ -214,13 +214,11 @@ struct TimeLimitTraitTests {
     }
   }
 
-#if !SWT_NO_XCTEST_SCAFFOLDING && SWT_TARGET_OS_APPLE
   @Test("TimeoutError.description property")
   func timeoutErrorDescription() async throws {
     let timeLimit = TimeValue((0, 0))
     #expect(String(describing: TimeoutError(timeLimit: timeLimit)).contains("0.000"))
   }
-#endif
 
   @Test("Issue.Kind.timeLimitExceeded.description property",
     arguments: [


### PR DESCRIPTION
This PR removes some stray dependencies on XCTest that prevent building the testing library and its test target when XCTest is not available on Darwin. This can occur if the Xcode Command Line Tools are installed instead of the full IDE.

Automated testing for this change is difficult because it relies on a build environment that is not supported in CI (namely the presence of the CL tools but not Xcode nor XCTest.framework.) I have manually tested the change against swift-testing's own test target.

For more information about this change, see https://github.com/apple/swift-package-manager/pull/7426. That PR affects the Swift main-branch toolchain (Swift 6), not Swift 5.10 or earlier.

Resolves rdar://125371899.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
