### PR TITLE
Enable `pthread_mutex_t` use on WASI with a multithreaded runtime.

### DIFF
--- a/Sources/Testing/Support/Locked.swift
+++ b/Sources/Testing/Support/Locked.swift
@@ -36,12 +36,12 @@ struct Locked<T>: RawRepresentable, Sendable where T: Sendable {
   /// To keep the implementation of this type as simple as possible,
   /// `pthread_mutex_t` is used on Apple platforms instead of `os_unfair_lock`
   /// or `OSAllocatedUnfairLock`.
-#if SWT_TARGET_OS_APPLE || os(Linux)
+#if SWT_TARGET_OS_APPLE || os(Linux) || (os(WASI) && compiler(>=6.0) && _runtime(_multithreaded))
   private typealias _Lock = pthread_mutex_t
 #elseif os(Windows)
   private typealias _Lock = SRWLOCK
 #elseif os(WASI)
-  // No locks on WASI.
+	// No locks on WASI without multithreaded runtime.
 #else
 #warning("Platform-specific implementation missing: locking unavailable")
   private typealias _Lock = Void
@@ -51,12 +51,12 @@ struct Locked<T>: RawRepresentable, Sendable where T: Sendable {
   private final class _Storage: ManagedBuffer<T, _Lock> {
     deinit {
       withUnsafeMutablePointerToElements { lock in
-#if SWT_TARGET_OS_APPLE || os(Linux)
+#if SWT_TARGET_OS_APPLE || os(Linux) || (os(WASI) && compiler(>=6.0) && _runtime(_multithreaded))
         _ = pthread_mutex_destroy(lock)
 #elseif os(Windows)
         // No deinitialization needed.
 #elseif os(WASI)
-        // No locks on WASI.
+        // No locks on WASI without multithreaded runtime.
 #else
 #warning("Platform-specific implementation missing: locking unavailable")
 #endif
@@ -70,12 +70,12 @@ struct Locked<T>: RawRepresentable, Sendable where T: Sendable {
   init(rawValue: T) {
     let storage = _Storage.create(minimumCapacity: 1, makingHeaderWith: { _ in rawValue })
     storage.withUnsafeMutablePointerToElements { lock in
-#if SWT_TARGET_OS_APPLE || os(Linux)
+#if SWT_TARGET_OS_APPLE || os(Linux) || (os(WASI) && compiler(>=6.0) && _runtime(_multithreaded))
       _ = pthread_mutex_init(lock, nil)
 #elseif os(Windows)
       InitializeSRWLock(lock)
 #elseif os(WASI)
-      // No locks on WASI.
+      // No locks on WASI without multithreaded runtime.
 #else
 #warning("Platform-specific implementation missing: locking unavailable")
 #endif
@@ -101,7 +101,7 @@ struct Locked<T>: RawRepresentable, Sendable where T: Sendable {
   /// concurrency tools.
   nonmutating func withLock<R>(_ body: (inout T) throws -> R) rethrows -> R {
     try _storage.rawValue.withUnsafeMutablePointers { rawValue, lock in
-#if SWT_TARGET_OS_APPLE || os(Linux)
+#if SWT_TARGET_OS_APPLE || os(Linux) || (os(WASI) && compiler(>=6.0) && _runtime(_multithreaded))
       _ = pthread_mutex_lock(lock)
       defer {
         _ = pthread_mutex_unlock(lock)
@@ -112,7 +112,7 @@ struct Locked<T>: RawRepresentable, Sendable where T: Sendable {
         ReleaseSRWLockExclusive(lock)
       }
 #elseif os(WASI)
-      // No locks on WASI.
+      // No locks on WASI without multithreaded runtime.
 #else
 #warning("Platform-specific implementation missing: locking unavailable")
 #endif
@@ -150,11 +150,6 @@ extension Locked where T: Numeric {
 }
 
 extension Locked {
-  /// Initialize an instance of this type with a raw value of `0`.
-  init() where T: AdditiveArithmetic {
-    self.init(rawValue: .zero)
-  }
-
   /// Initialize an instance of this type with a raw value of `nil`.
   init<V>() where T == V? {
     self.init(rawValue: nil)

--- a/Sources/Testing/Support/Locked.swift
+++ b/Sources/Testing/Support/Locked.swift
@@ -41,7 +41,7 @@ struct Locked<T>: RawRepresentable, Sendable where T: Sendable {
 #elseif os(Windows)
   private typealias _Lock = SRWLOCK
 #elseif os(WASI)
-	// No locks on WASI without multithreaded runtime.
+  // No locks on WASI without multithreaded runtime.
 #else
 #warning("Platform-specific implementation missing: locking unavailable")
   private typealias _Lock = Void

--- a/Sources/Testing/Support/Locked.swift
+++ b/Sources/Testing/Support/Locked.swift
@@ -36,7 +36,7 @@ struct Locked<T>: RawRepresentable, Sendable where T: Sendable {
   /// To keep the implementation of this type as simple as possible,
   /// `pthread_mutex_t` is used on Apple platforms instead of `os_unfair_lock`
   /// or `OSAllocatedUnfairLock`.
-#if SWT_TARGET_OS_APPLE || os(Linux) || (os(WASI) && compiler(>=6.0) && _runtime(_multithreaded))
+#if SWT_TARGET_OS_APPLE || os(Linux) || (os(WASI) && compiler(>=6.1) && _runtime(_multithreaded))
   private typealias _Lock = pthread_mutex_t
 #elseif os(Windows)
   private typealias _Lock = SRWLOCK
@@ -51,7 +51,7 @@ struct Locked<T>: RawRepresentable, Sendable where T: Sendable {
   private final class _Storage: ManagedBuffer<T, _Lock> {
     deinit {
       withUnsafeMutablePointerToElements { lock in
-#if SWT_TARGET_OS_APPLE || os(Linux) || (os(WASI) && compiler(>=6.0) && _runtime(_multithreaded))
+#if SWT_TARGET_OS_APPLE || os(Linux) || (os(WASI) && compiler(>=6.1) && _runtime(_multithreaded))
         _ = pthread_mutex_destroy(lock)
 #elseif os(Windows)
         // No deinitialization needed.
@@ -70,7 +70,7 @@ struct Locked<T>: RawRepresentable, Sendable where T: Sendable {
   init(rawValue: T) {
     let storage = _Storage.create(minimumCapacity: 1, makingHeaderWith: { _ in rawValue })
     storage.withUnsafeMutablePointerToElements { lock in
-#if SWT_TARGET_OS_APPLE || os(Linux) || (os(WASI) && compiler(>=6.0) && _runtime(_multithreaded))
+#if SWT_TARGET_OS_APPLE || os(Linux) || (os(WASI) && compiler(>=6.1) && _runtime(_multithreaded))
       _ = pthread_mutex_init(lock, nil)
 #elseif os(Windows)
       InitializeSRWLock(lock)
@@ -101,7 +101,7 @@ struct Locked<T>: RawRepresentable, Sendable where T: Sendable {
   /// concurrency tools.
   nonmutating func withLock<R>(_ body: (inout T) throws -> R) rethrows -> R {
     try _storage.rawValue.withUnsafeMutablePointers { rawValue, lock in
-#if SWT_TARGET_OS_APPLE || os(Linux) || (os(WASI) && compiler(>=6.0) && _runtime(_multithreaded))
+#if SWT_TARGET_OS_APPLE || os(Linux) || (os(WASI) && compiler(>=6.1) && _runtime(_multithreaded))
       _ = pthread_mutex_lock(lock)
       defer {
         _ = pthread_mutex_unlock(lock)


### PR DESCRIPTION
This PR opts WASI builds into using `pthread_mutex_t` in `Locked` when the WASI environment supports threading.

`_runtime(_multithreaded)` was added very recently with https://github.com/apple/swift/pull/72649, so we need an additional compiler version check before testing the runtime flag. That change has not been cherry-picked to Swift 6.0, so assume 6.1 or later is needed.

WASI with Swift 5.10, as well as WASI without threading, will continue to stub out `Locked`.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
