### PR TITLE
Make `Event.ConsoleOutputRecorder.Option[s]` a struct instead of an enum.

### DIFF
--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -159,14 +159,12 @@ public enum XCTestScaffold: Sendable {
 #endif
     }
 
-    var options = [Event.ConsoleOutputRecorder.Option]()
+    var options = Event.ConsoleOutputRecorder.Options()
 #if !SWT_NO_FILE_IO
-    options += .for(.stderr)
+    options = .for(.stderr)
 #endif
-    if Environment.flag(named: "SWT_VERBOSE_OUTPUT") == true {
-      options.append(.useVerboseOutput)
-    }
-    
+    options.isVerbose = (Environment.flag(named: "SWT_VERBOSE_OUTPUT") == true)
+
     await runTests(options: options, configuration: configuration)
 #endif
   }

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -33,29 +33,30 @@ struct EventRecorderTests {
     }
   }
 
-  private static var optionCombinations: [[Event.ConsoleOutputRecorder.Option]] {
-    var result: [[Event.ConsoleOutputRecorder.Option]] = [
-      [],
-      [.useANSIEscapeCodes(colorBitDepth: 1)],
-      [.useANSIEscapeCodes(colorBitDepth: 4)],
-      [.useANSIEscapeCodes(colorBitDepth: 8)],
-      [.useANSIEscapeCodes(colorBitDepth: 24)],
+  private static var optionCombinations: [(useSFSymbols: Bool, ansiColorBitDepth: Int8?)] {
+    var result: [(useSFSymbols: Bool, ansiColorBitDepth: Int8?)] = [
+      (false, nil), (false, 1), (false, 4), (false, 8), (false, 24),
     ]
 #if os(macOS)
     result += [
-      [.useSFSymbols],
-      [.useSFSymbols, .useANSIEscapeCodes(colorBitDepth: 1)],
-      [.useSFSymbols, .useANSIEscapeCodes(colorBitDepth: 4)],
-      [.useSFSymbols, .useANSIEscapeCodes(colorBitDepth: 8)],
-      [.useSFSymbols, .useANSIEscapeCodes(colorBitDepth: 24)],
+      (true, nil), (true, 1), (true, 4), (true, 8), (true, 24),
     ]
 #endif
     return result
   }
 
   @Test("Writing events", arguments: optionCombinations)
-  func writingToStream(options: [Event.ConsoleOutputRecorder.Option]) async throws {
+  func writingToStream(useSFSymbols: Bool, ansiColorBitDepth: Int8?) async throws {
     let stream = Stream()
+
+    var options = Event.ConsoleOutputRecorder.Options()
+#if os(macOS)
+    options.useSFSymbols = useSFSymbols
+#endif
+    if let ansiColorBitDepth {
+      options.useANSIEscapeCodes = true
+      options.ansiColorBitDepth = ansiColorBitDepth
+    }
 
     var configuration = Configuration()
     configuration.deliverExpectationCheckedEvents = true
@@ -77,7 +78,7 @@ struct EventRecorderTests {
     #expect(buffer.contains("i → 5"))
     #expect(buffer.contains("Ocelots don't like the number 3."))
 
-    if let colorBitDepth = options.colorBitDepth, colorBitDepth > 1 {
+    if let ansiColorBitDepth, ansiColorBitDepth > 1 {
       #expect(buffer.contains("\u{001B}["))
       #expect(buffer.contains("●"))
     } else {
@@ -96,9 +97,12 @@ struct EventRecorderTests {
   func verboseOutput() async throws {
     let stream = Stream()
 
+    var options = Event.ConsoleOutputRecorder.Options()
+    options.isVerbose = true
+
     var configuration = Configuration()
     configuration.deliverExpectationCheckedEvents = true
-    let eventRecorder = Event.ConsoleOutputRecorder(options: [.useVerboseOutput], writingUsing: stream.write)
+    let eventRecorder = Event.ConsoleOutputRecorder(options: options, writingUsing: stream.write)
     configuration.eventHandler = { event, context in
       eventRecorder.record(event, in: context)
     }


### PR DESCRIPTION
When I'd originally assembled the `Event.ConsoleOutputRecorder.Option` enum, I assumed that it would behave much like a set of flags (_à la_ C bitmask enums.) As it has evolved, it has taken on associated values and ceased to behave like an option set, so it really should be a struct. This PR changes it to a struct, renames it from `Option` to `Options`, and of course updates call sites.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
