### PR TITLE
Use `String(reflecting:)` instead of `_typeName(_:qualified:)` to get the fully-qualified names of types.

### DIFF
--- a/Sources/Testing/Parameterization/TypeInfo.swift
+++ b/Sources/Testing/Parameterization/TypeInfo.swift
@@ -92,13 +92,13 @@ extension TypeInfo {
   public var fullyQualifiedNameComponents: [String] {
     switch _kind {
     case let .type(type):
-      var result = _typeName(type, qualified: true)
+      var result = String(reflecting: type)
         .split(separator: ".")
         .map(String.init)
 
       // If a type is extended in another module and then referenced by name,
-      // its name according to the _typeName(_:qualified:) SPI will be prefixed
-      // with "(extension in MODULE_NAME):". For our purposes, we never want to
+      // its name according to the String(reflecting:) API will be prefixed with
+      // "(extension in MODULE_NAME):". For our purposes, we never want to
       // preserve that prefix.
       if let firstComponent = result.first, firstComponent.starts(with: "(extension in ") {
         result[0] = String(firstComponent.split(separator: ":", maxSplits: 1).last!)

--- a/Tests/TestingTests/TypeInfoTests.swift
+++ b/Tests/TestingTests/TypeInfoTests.swift
@@ -41,7 +41,7 @@ struct TypeInfoTests {
   }
 
   @Test func typeNameInExtensionIsMungedCorrectly() {
-    #expect(_typeName(String.NestedType.self, qualified: true) == "(extension in TestingTests):Swift.String.NestedType")
+    #expect(String(reflecting: String.NestedType.self) == "(extension in TestingTests):Swift.String.NestedType")
     #expect(TypeInfo(describing: String.NestedType.self).fullyQualifiedName == "Swift.String.NestedType")
   }
 


### PR DESCRIPTION
We were directly using the Swift standard library function `_typeName(_:qualified:)` to get the fully-qualified names of types, but `String(reflecting:)` does this for us and is supported API. This PR switches us over to the API.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
