### PR TITLE
Add a dedicated `Win32Error` type for errors in the Windows domain.

### DIFF
--- a/Sources/Testing/Support/Environment.swift
+++ b/Sources/Testing/Support/Environment.swift
@@ -45,15 +45,16 @@ enum Environment {
           SetLastError(DWORD(ERROR_SUCCESS))
           let count = GetEnvironmentVariableW(name, buffer.baseAddress!, DWORD(buffer.count))
           if count == 0 {
-            return switch GetLastError() {
+            switch GetLastError() {
             case DWORD(ERROR_SUCCESS):
               // Empty String
-              ""
+              return ""
             case DWORD(ERROR_ENVVAR_NOT_FOUND):
               // The environment variable wasn't set.
-              nil
+              return nil
             case let errorCode:
-              fatalError("unexpected error code: \(errorCode) when getting environment variable '\(name)'")
+              let error = Win32Error(rawValue: errorCode)
+              fatalError("unexpected error when getting environment variable '\(name)': \(error) (\(errorCode))")
             }
           } else if count > buffer.count {
             // Try again with the larger count.

--- a/Sources/TestingInternals/include/Stubs.h
+++ b/Sources/TestingInternals/include/Stubs.h
@@ -64,6 +64,16 @@ static bool swt_S_ISFIFO(mode_t mode) {
 #endif
 #endif
 
+#if defined(_WIN32)
+/// Make a Win32 language ID.
+///
+/// This function is provided because `MAKELANGID()` is a complex macro and
+/// cannot be imported directly into Swift.
+static LANGID swt_MAKELANGID(int p, int s) {
+  return MAKELANGID(p, s);
+}
+#endif
+
 SWT_ASSUME_NONNULL_END
 
 #endif

--- a/Tests/TestingTests/Support/CErrorTests.swift
+++ b/Tests/TestingTests/Support/CErrorTests.swift
@@ -20,3 +20,22 @@ struct CErrorTests {
     #expect(strerror(errorCode) == description)
   }
 }
+
+#if os(Windows)
+@Suite("Win32Error Tests")
+struct Win32ErrorTests {
+  @Test("Win32Error.description property",
+    arguments: [
+      (ERROR_OUTOFMEMORY, "Not enough memory resources are available to complete this operation."),
+      (ERROR_INVALID_ACCESS, "The access code is invalid."),
+      (ERROR_ARITHMETIC_OVERFLOW, "Arithmetic result exceeded 32 bits."),
+      (999_999_999, "An unknown error occurred (999999999)."),
+    ]
+  )
+  fileprivate func errorDescription(errorCode: CInt, expectedMessage: String) {
+    let description = String(describing: Win32Error(rawValue: DWORD(errorCode)))
+    #expect(!description.isEmpty)
+    #expect(expectedMessage == description)
+  }
+}
+#endif


### PR DESCRIPTION
On Windows, errors produced by Win32 functions (`GetLastError()`) are in a separate domain from errors produced by C standard library functions (`errno`).

Although we're not currently making _much_ use of Win32 API that produces errors in this domain, we do use it in `Environment` and #307 uses it, so I've factored out the part of that PR that adds a dedicated error type.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
