### PR TITLE
Specialize `FileHandle.write(_:)` when the input is `UnsafeBufferPointer<UInt8>`.

### DIFF
--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -271,7 +271,7 @@ extension FileHandle {
   ///   occurs while flushing the file, it is not thrown.
   func write(_ bytes: UnsafeRawBufferPointer, flushAfterward: Bool = true) throws {
     try bytes.withMemoryRebound(to: UInt8.self) { bytes in
-      try write(bytes)
+      try write(bytes, flushAfterward: flushAfterward)
     }
   }
 

--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -214,6 +214,32 @@ extension FileHandle {
   /// Write a sequence of bytes to this file handle.
   ///
   /// - Parameters:
+  ///   - bytes: The bytes to write. This untyped buffer is interpreted as a
+  ///     sequence of `UInt8` values.
+  ///   - flushAfterward: Whether or not to flush the file (with `fflush()`)
+  ///     after writing. If `true`, `fflush()` is called even if an error
+  ///     occurred while writing.
+  ///
+  /// - Throws: Any error that occurred while writing `bytes`. If an error
+  ///   occurs while flushing the file, it is not thrown.
+  func write(_ bytes: UnsafeBufferPointer<UInt8>, flushAfterward: Bool = true) throws {
+    try withUnsafeCFILEHandle { file in
+      defer {
+        if flushAfterward {
+          _ = fflush(file)
+        }
+      }
+
+      let countWritten = fwrite(bytes.baseAddress, MemoryLayout<UInt8>.stride, bytes.count, file)
+      if countWritten < bytes.count {
+        throw CError(rawValue: swt_errno())
+      }
+    }
+  }
+
+  /// Write a sequence of bytes to this file handle.
+  ///
+  /// - Parameters:
   ///   - bytes: The bytes to write.
   ///   - flushAfterward: Whether or not to flush the file (with `fflush()`)
   ///     after writing. If `true`, `fflush()` is called even if an error
@@ -224,22 +250,11 @@ extension FileHandle {
   ///
   /// - Precondition: `bytes` must provide contiguous storage.
   func write(_ bytes: some Sequence<UInt8>, flushAfterward: Bool = true) throws {
-    try withUnsafeCFILEHandle { file in
-      defer {
-        if flushAfterward {
-          _ = fflush(file)
-        }
-      }
-
-      let hasContiguousStorage: Void? = try bytes.withContiguousStorageIfAvailable { bytes in
-        let countWritten = fwrite(bytes.baseAddress, MemoryLayout<UInt8>.stride, bytes.count, file)
-        if countWritten < bytes.count {
-          throw CError(rawValue: swt_errno())
-        }
-      }
-      if hasContiguousStorage == nil {
-        preconditionFailure("byte sequence must provide contiguous storage: \(bytes)")
-      }
+    let hasContiguousStorage: Void? = try bytes.withContiguousStorageIfAvailable { bytes in
+      try write(bytes, flushAfterward: flushAfterward)
+    }
+    if hasContiguousStorage == nil {
+      preconditionFailure("byte sequence must provide contiguous storage: \(bytes)")
     }
   }
 


### PR DESCRIPTION
This PR adds a specialization of `FileHandle.write(_:)` for `UnsafeBufferPointer<UInt8>`. By splitting up the specialization that takes `some Sequence<UInt8>`, we avoid needing to call
`withContiguousStorageIfAvailable(_:)` on the buffer (which just yields `self`) and avoid the overhead of a generic call. The other overloads of `write(_:)` are also refactored to call the new overload too, so there's still one true way to call `fwrite()`.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
