### PR TITLE
Fix spelling of a new swift-syntax-600-only diagnostic.

### DIFF
--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -245,7 +245,7 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
     // not have reliable location information.
     Self(
       syntax: Syntax(attribute),
-      message: "The @\(attribute.attributeNameText) attribute cannot be applied within \(_kindString(for: node, includeA: true)).",
+      message: "Attribute \(_macroName(attribute)) cannot be applied within \(_kindString(for: node, includeA: true)).",
       severity: .error
     )
   }


### PR DESCRIPTION
Follow-up to #279 and #302.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
