### PR TITLE
Add a note about compile-time diagnostics to the style guide.

### DIFF
--- a/Documentation/StyleGuide.md
+++ b/Documentation/StyleGuide.md
@@ -101,6 +101,12 @@ Or, when writing the abstract for an enumeration `Flavor`, you could write:
 To organize symbols under types, place them in topic groups organized by usage.
 Begin topic group headings inside types with a noun or noun phrase.
 
+#### Writing compile-time diagnostics
+
+The macro target of this package produces a number of different compile-time
+diagnostics. These diagnostics should be written according to the Swift style
+guide for compiler diagnostics [here](https://github.com/apple/swift/blob/main/docs/Diagnostics.md).
+
 ### Documentation
 
 Documentation for the testing library should follow the


### PR DESCRIPTION
This PR adds a paragraph explaining that compile-time diagnostics in the macro target should follow Swift's style guide.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
