### PR TITLE
Diagnose when a test or suite is embedded in a non-final class.

### DIFF
--- a/Sources/Testing/Testing.docc/OrganizingTests.md
+++ b/Sources/Testing/Testing.docc/OrganizingTests.md
@@ -163,10 +163,6 @@ actor CashRegisterTests: NSObject { ... } // ✅ OK: actors are implicitly final
 class MenuItemTests { ... } // ❌ ERROR: this class is not final
 ```
 
-- Bug: Violations of this requirement are not consistently diagnosed at compile
-  time, and the diagnostic produced when an issue is detected may be confusing
-  to developers. ([105470382](rdar://105470382))
-
 ## Topics
 
 - ``Suite(_:_:)``

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -120,9 +120,13 @@ struct TestDeclarationMacroTests {
   @Test("Error diagnostics emitted for invalid lexical contexts",
     arguments: [
       "struct S { func f() { @Test func f() {} } }":
-        "The @Test attribute cannot be applied within a function.",
+        "Attribute 'Test' cannot be applied to a function within a function",
       "struct S { func f() { @Suite struct S { } } }":
-        "The @Suite attribute cannot be applied within a function.",
+        "Attribute 'Suite' cannot be applied to a structure within a function",
+      "class C { @Test func f() {} }":
+        "Attribute 'Test' cannot be applied to a function within a non-final class",
+      "class C { @Suite struct S {} }":
+        "Attribute 'Suite' cannot be applied to a structure within a non-final class",
     ]
   )
   func invalidLexicalContext(input: String, expectedMessage: String) throws {


### PR DESCRIPTION
The testing library does not support using non-final classes as test suites. Prior to swift-syntax-600, we don't have a way to detect the name of the class, so we cannot correctly construct the thunk for a test function (we can only say `Self`, not `TheClassName`, and that's not valid for non-final classes.)

As of swift-syntax-600, that constraint is lifted, but because test content isn't inherited by subclasses (which may be confusing), we're keeping the constraint in place for now.

This PR diagnoses when a test or suite is declared inside a non-final class when swift-syntax-600 is available:

<img width="639" alt="Screenshot 2024-04-05 at 3 58 13 PM" src="https://github.com/apple/swift-testing/assets/4145863/8e1e1af0-33b5-417a-849d-191161c3d4fc">

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
