### PR TITLE
Disallow test/suite declarations in protocols.

### DIFF
--- a/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
@@ -114,6 +114,8 @@ func diagnoseIssuesWithLexicalContext(
       if !classDecl.modifiers.lazy.map(\.name.tokenKind).contains(.keyword(.final)) {
         diagnostics.append(.containingNodeUnsupported(classDecl, whenUsing: attribute, on: decl))
       }
+    } else if let protocolDecl = lexicalContext.as(ProtocolDeclSyntax.self) {
+      diagnostics.append(.containingNodeUnsupported(protocolDecl, whenUsing: attribute, on: decl))
     }
   }
 

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -119,14 +119,22 @@ struct TestDeclarationMacroTests {
 #if canImport(SwiftSyntax600)
   @Test("Error diagnostics emitted for invalid lexical contexts",
     arguments: [
-      "struct S { func f() { @Test func f() {} } }":
-        "Attribute 'Test' cannot be applied to a function within a function",
-      "struct S { func f() { @Suite struct S { } } }":
-        "Attribute 'Suite' cannot be applied to a structure within a function",
+      "struct S { func f() { @Test func g() {} } }":
+        "Attribute 'Test' cannot be applied to a function within function 'f()'",
+      "struct S { func f(x: Int) { @Suite struct S { } } }":
+        "Attribute 'Suite' cannot be applied to a structure within function 'f(x:)'",
       "class C { @Test func f() {} }":
-        "Attribute 'Test' cannot be applied to a function within a non-final class",
+        "Attribute 'Test' cannot be applied to a function within non-final class 'C'",
       "class C { @Suite struct S {} }":
-        "Attribute 'Suite' cannot be applied to a structure within a non-final class",
+        "Attribute 'Suite' cannot be applied to a structure within non-final class 'C'",
+      "protocol P { @Test func f() {} }":
+        "Attribute 'Test' cannot be applied to a function within protocol 'P'",
+      "protocol P { @Suite struct S {} }":
+        "Attribute 'Suite' cannot be applied to a structure within protocol 'P'",
+      "{ _ in @Test func f() {} }":
+        "Attribute 'Test' cannot be applied to a function within a closure",
+      "{ _ in @Suite struct S {} }":
+        "Attribute 'Suite' cannot be applied to a structure within a closure",
     ]
   )
   func invalidLexicalContext(input: String, expectedMessage: String) throws {


### PR DESCRIPTION
This change is similar to #332 except that the diagnostic is applied when a test or suite is declared inside a protocol rather than inside a non-final class.

Without this change, the compiler will fail to build a test target with such a test _anyway_, but the diagnostics produced will refer to the emitted macro expansion and are opaque. For example, given the declaration:

```swift
protocol P {
  @Test func f()
}
```

The compiler produces these diagnostics which don't really explain the problem very well:

> 🛑 'private' modifier cannot be used in protocols
> 🛑 Protocol methods must not have bodies
> 🛑 Type '$s12TestingTests1PP1f4TestfMp_37__🟠$test_container__function__funcf__fMu_' cannot be nested in protocol 'P'
> 🛑 Use of protocol 'P' as a type must be written 'any P'
> 🛑 Cannot find '$s12TestingTests1PP1f4TestfMp_7funcf__fMu0_' in scope

This is because the swift-testing macro target is unaware that the enclosing lexical context is a protocol, so it tries to emit code that would only make sense inside a concrete type. With this change, you instead get:

> 🛑 Attribute 'Test' cannot be applied to a function within protocol 'P'

I also took the liberty of improving the diagnostic emitted if a test/suite is declared inside a closure.

> [!NOTE]
> As with #332, this change only takes effect when swift-syntax-600 is used.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
