### PR TITLE
Warn (eventually error) when a test or suite is contained within an extension.

### DIFF
--- a/Sources/TestingMacros/SuiteDeclarationMacro.swift
+++ b/Sources/TestingMacros/SuiteDeclarationMacro.swift
@@ -71,12 +71,6 @@ public struct SuiteDeclarationMacro: MemberMacro, PeerMacro, Sendable {
       diagnostics.append(.xcTestCaseNotSupported(declaration, whenUsing: suiteAttribute))
     }
 
-    // @Suite cannot be applied to a type extension (although a type extension
-    // can still contain test functions and test suites.)
-    if let extensionDecl = declaration.as(ExtensionDeclSyntax.self) {
-      diagnostics.append(.attributeHasNoEffect(suiteAttribute, on: extensionDecl))
-    }
-
     // Check other attributes on the declaration. Note that it should be
     // impossible to reach this point if the declaration can't have attributes.
     if let attributedDecl = declaration.asProtocol((any WithAttributesSyntax).self) {

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -371,6 +371,12 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
         message: "Attribute \(_macroName(attribute)) cannot be applied to \(_kindString(for: decl, includeA: true)) within\(nonFinal) \(_kindString(for: node)) '\(declName)'",
         severity: .error
       )
+    } else if let extensionDecl = node.as(ExtensionDeclSyntax.self) {
+      return Self(
+        syntax: Syntax(attribute),
+        message: "Attribute \(_macroName(attribute)) cannot be applied to \(_kindString(for: decl, includeA: true)) within an extension to type '\(extensionDecl.type.trimmed)'; this will be an error in the future",
+        severity: .warning
+      )
     } else {
       return Self(
         syntax: Syntax(attribute),


### PR DESCRIPTION
This PR produces a warning diagnostic when a test or suite is contained _within_ an extension:

```swift
extension E {
  @Suite struct S {} // ⚠️ Attribute 'Suite' cannot be applied to a structure
                     // within an extension to type 'E'; this will be an error
                     // in the future
  @Test func f() {} // ⚠️ Attribute 'Test' cannot be applied to a function
                    // within an extension to type 'E'; this will be an error
                    // in the future
}
```

During macro expansion, if a test or suite is contained within an extension, only the extension declaration itself can be "seen" by the macros code (and then, only with swift-syntax-600.) The actual type declaration corresponding to the extension is not available. For most types, this is fine, but there are several scenarios that produce poor or fatal outcomes:

```swift
// Generic types cannot be realized, so tests contained in them cannot run, and
// there are no compile-time diagnostics indicating the cause of the problem:
struct S<T> {}
extension S {
  @Test func f() {}
}

// Protocols can be extended, but are not concrete types and the macro code
// fails to compile with confusing diagnostics:
protocol P {}
extension P {
  @Test func f() {} // 🛑 'any P' cannot be constructed because it has no
                    // accessible initializers
                    // 🛑 'any P' cannot be constructed because it has no
                    // accessible initializers (yes, twice!)
                    // 🛑 Type '$s12TestingTests1PPAAE1f4TestfMp_37__🟠$test_container__function__funcf__fMu_'
                    // cannot be nested in protocol extension of 'P'
                    // 🛑 Use of protocol 'P' as a type must be written 'any P'
}

// Suites with constrained availability are not (yet) supported because it is
// not possible to inspect their types at runtime on unsupported OS versions.
// Depending on platform and precise package or Xcode project configuration,
// a type with constrained availability may cause crashes at runtime:
@available(macOS 13, *)
struct S {}

extension S {
  @Test func f() {} // Will crash when run on macOS 12
}
```

It would be preferable to block the use of extensions with swift-testing until we can devise a solution to the above problems (e.g. having the macro expansion context provide stub type declarations for each extension in a lexical context.)

Because there are likely a number of packages that have adopted swift-testing already and are using extensions in this fashion, we've opted to introduce this diagnostic as a warning. We will, subject to community review, upgrade the warning to an error in a subsequent swift-testing tag.

As with previous PRs in this area, these diagnostics are only available when using **swift-syntax-600**.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
