### PR TITLE
Apply suite diagnostics to the entire lexical context.

### DIFF
--- a/Sources/TestingMacros/Support/Additions/WithAttributesSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/WithAttributesSyntaxAdditions.swift
@@ -121,11 +121,10 @@ extension WithAttributesSyntax {
   ///   - name: The name of the attribute to look for.
   ///   - moduleName: The name of the module that declares the attribute named
   ///     `name`.
-  ///   - context: The macro context in which the expression is being parsed.
   ///
   /// - Returns: An array of `AttributeSyntax` corresponding to the attached
   ///   `@Test` attributes, or the empty array if none is attached.
-  func attributes(named name: String, inModuleNamed moduleName: String = "Testing", in context: some MacroExpansionContext) -> [AttributeSyntax] {
+  func attributes(named name: String, inModuleNamed moduleName: String = "Testing") -> [AttributeSyntax] {
     attributes.lazy.compactMap { attribute in
       if case let .attribute(attribute) = attribute {
         return attribute

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -188,8 +188,11 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
   ///
   /// - Returns: A diagnostic message.
   static func genericDeclarationNotSupported(_ decl: some SyntaxProtocol, whenUsing attribute: AttributeSyntax, becauseOf genericClause: some SyntaxProtocol) -> Self {
-    Self(
-      syntax: (genericClause.root != decl.root) ? Syntax(decl) : Syntax(genericClause),
+    // Avoid using a syntax node from a lexical context (it won't have source
+    // location information.)
+    let syntax = (genericClause.root != decl.root) ? Syntax(decl) : Syntax(genericClause)
+    return Self(
+      syntax: syntax,
       message: "Attribute \(_macroName(attribute)) cannot be applied to a generic \(_kindString(for: decl))",
       severity: .error
     )
@@ -209,8 +212,11 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
   ///   semantic availability and fully-qualified names for types at macro
   ///   expansion time. ([104081994](rdar://104081994))
   static func availabilityAttributeNotSupported(_ availabilityAttribute: AttributeSyntax, on decl: some SyntaxProtocol, whenUsing attribute: AttributeSyntax) -> Self {
-    Self(
-      syntax: Syntax(availabilityAttribute),
+    // Avoid using a syntax node from a lexical context (it won't have source
+    // location information.)
+    let syntax = (availabilityAttribute.root != decl.root) ? Syntax(decl) : Syntax(availabilityAttribute)
+    return Self(
+      syntax: syntax,
       message: "Attribute \(_macroName(attribute)) cannot be applied to this \(_kindString(for: decl)) because it has been marked '\(availabilityAttribute.trimmed)'",
       severity: .error
     )

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -189,7 +189,7 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
   /// - Returns: A diagnostic message.
   static func genericDeclarationNotSupported(_ decl: some SyntaxProtocol, whenUsing attribute: AttributeSyntax, becauseOf genericClause: some SyntaxProtocol) -> Self {
     Self(
-      syntax: Syntax(genericClause),
+      syntax: (genericClause.root != decl.root) ? Syntax(decl) : Syntax(genericClause),
       message: "Attribute \(_macroName(attribute)) cannot be applied to a generic \(_kindString(for: decl))",
       severity: .error
     )

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -331,7 +331,6 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
     )
   }
 
-#if canImport(SwiftSyntax600)
   /// Create a diagnostic message stating that the given attribute cannot be
   /// used within a lexical context.
   ///
@@ -375,6 +374,7 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
     }
   }
 
+#if canImport(SwiftSyntax600)
   /// Create a diagnostic message stating that the given attribute cannot be
   /// applied to the given declaration outside the scope of an extension to
   /// `Tag`.

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -58,11 +58,11 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
 
 #if canImport(SwiftSyntax600)
     // Check if the lexical context is appropriate for a suite or test.
-    diagnostics += diagnoseIssuesWithLexicalContext(containing: declaration, attribute: testAttribute, in: context)
+    diagnostics += diagnoseIssuesWithLexicalContext(context.lexicalContext, containing: declaration, attribute: testAttribute)
 #endif
 
     // Only one @Test attribute is supported.
-    let suiteAttributes = function.attributes(named: "Test", in: context)
+    let suiteAttributes = function.attributes(named: "Test")
     if suiteAttributes.count > 1 {
       diagnostics.append(.multipleAttributesNotSupported(suiteAttributes, on: declaration))
     }
@@ -290,7 +290,7 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
     // If the function is noasync *and* main-actor-isolated, we'll call through
     // MainActor.run to invoke it. We do not have a general mechanism for
     // detecting isolation to other global actors.
-    lazy var isMainActorIsolated = !functionDecl.attributes(named: "MainActor", inModuleNamed: "Swift", in: context).isEmpty
+    lazy var isMainActorIsolated = !functionDecl.attributes(named: "MainActor", inModuleNamed: "Swift").isEmpty
     var forwardCall: (ExprSyntax) -> ExprSyntax = {
       "try await (\($0), Testing.__requiringTry, Testing.__requiringAwait).0"
     }

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -135,6 +135,10 @@ struct TestDeclarationMacroTests {
         "Attribute 'Test' cannot be applied to a function within a closure",
       "{ _ in @Suite struct S {} }":
         "Attribute 'Suite' cannot be applied to a structure within a closure",
+      "@available(*, noasync) struct S { @Test func f() {} }":
+        "Attribute 'Test' cannot be applied to this function because it has been marked '@available(*, noasync)'",
+      "@available(*, noasync) struct S { @Suite struct S {} }":
+        "Attribute 'Suite' cannot be applied to this structure because it has been marked '@available(*, noasync)'",
     ]
   )
   func invalidLexicalContext(input: String, expectedMessage: String) throws {

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -123,6 +123,10 @@ struct TestDeclarationMacroTests {
         "Attribute 'Test' cannot be applied to a function within function 'f()'",
       "struct S { func f(x: Int) { @Suite struct S { } } }":
         "Attribute 'Suite' cannot be applied to a structure within function 'f(x:)'",
+      "struct S<T> { @Test func f() {} }":
+        "Attribute 'Test' cannot be applied to a generic function",
+      "struct S<T> { @Suite struct S {} }":
+        "Attribute 'Suite' cannot be applied to a generic structure",
       "class C { @Test func f() {} }":
         "Attribute 'Test' cannot be applied to a function within non-final class 'C'",
       "class C { @Suite struct S {} }":


### PR DESCRIPTION
This PR applies all suite diagnostics\* to every decl group (declaring type or extension) in the lexical context during `@Suite` and `@Test` expansion. For example:

```swift
struct S1<T> {
  @Suite struct S2 { // 🛑 Attribute 'Suite' cannot be applied to a generic structure
    @Test func f() {} // 🛑 Attribute 'Test' cannot be applied to a generic function
  }
}
```

This PR is follow-up to #332 and #333.

\* Except for diagnostics specific to the `@Suite` attribute itself.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
