### PR TITLE
Prevent adding tests to extensions to generic types.

### DIFF
--- a/Sources/TestingMacros/SuiteDeclarationMacro.swift
+++ b/Sources/TestingMacros/SuiteDeclarationMacro.swift
@@ -113,6 +113,10 @@ public struct SuiteDeclarationMacro: MemberMacro, PeerMacro, Sendable {
       return []
     }
 
+    if let genericGuardDecl = makeGenericGuardDecl(guardingAgainst: declaration, in: context) {
+      result.append(genericGuardDecl)
+    }
+
     // Parse the @Suite attribute.
     let attributeInfo = AttributeInfo(byParsing: suiteAttribute, on: declaration, in: context)
 

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -426,6 +426,10 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
     }
 #endif
 
+    if typeName != nil, let genericGuardDecl = makeGenericGuardDecl(guardingAgainst: functionDecl, in: context) {
+      result.append(genericGuardDecl)
+    }
+
     // Parse the @Test attribute.
     let attributeInfo = AttributeInfo(byParsing: testAttribute, on: functionDecl, in: context)
     if attributeInfo.hasFunctionArguments != !functionDecl.signature.parameterClause.parameters.isEmpty {


### PR DESCRIPTION
When a test is added to a type extension, we can't see any information about the type being extended, so we cannot report invalid lexical contexts such as protocols or non-final classes.

One of the invalid cases is a generic type, because swift-testing does not know how to realize the type—what generic arguments is it supposed to pass?

This PR causes the compiler to emit a diagnostic when a generic type contains a test or suite. **How does it work?**, you ask? Generic types do not support static stored properties, while non-static types _do_ support them. So we just add a static stored property (of type `Void`, because the value is unimportant.) In a non-generic type, it will "just work." In a generic type, a diagnostic is emitted:

> 🛑 Static stored properties not supported in generic types

The diagnostic is non-optimal (it's not fine-tuned for swift-testing) but it prevents building an invalid test that can't be resolved at runtime, so it's better than nothing.

This change works with swift-syntax-600 _and_ swift-syntax-510.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
