### PR TITLE
Adopt swift-syntax-600.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
   ],
 
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax.git", from: Version(stringLiteral: Context.environment["SWT_SWIFT_SYNTAX_VERSION"] ?? "510.0.1")),
+    .package(url: "https://github.com/apple/swift-syntax.git", from: Version(stringLiteral: Context.environment["SWT_SWIFT_SYNTAX_VERSION"] ?? "600.0.0-latest")),
   ],
 
   targets: [

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -33,7 +33,7 @@ let package = Package(
   ],
 
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax.git", from: Version(stringLiteral: Context.environment["SWT_SWIFT_SYNTAX_VERSION"] ?? "510.0.1")),
+    .package(url: "https://github.com/apple/swift-syntax.git", from: Version(stringLiteral: Context.environment["SWT_SWIFT_SYNTAX_VERSION"] ?? "600.0.0-latest")),
   ],
 
   targets: [

--- a/Sources/Testing/Test+Discovery.swift
+++ b/Sources/Testing/Test+Discovery.swift
@@ -89,10 +89,6 @@ extension Test {
   ///   - tests: A dictionary of tests to amend.
   ///
   /// - Returns: The number of key-value pairs added to `tests`.
-  ///
-  /// - Bug: This function is necessary because containing type information is
-  ///   not available during expansion of the `@Test` macro.
-  ///   ([105470382](rdar://105470382))
   @discardableResult private static func _synthesizeSuiteTypes(into tests: inout [ID: Self]) -> Int {
     let originalCount = tests.count
 

--- a/Sources/Testing/Testing.docc/OrganizingTests.md
+++ b/Sources/Testing/Testing.docc/OrganizingTests.md
@@ -147,10 +147,6 @@ _not_ be annotated with the `@available` attribute:
 The compiler will emit an error when presented with a test suite that does not
 meet this requirement.
 
-- Bug: Inherited availability is not always visible to the compiler during
-  expansion of the ``Suite(_:_:)`` macro. A test function may crash when run on
-  an unsupported system. ([110974351](rdar://110974351))
-
 ### Classes must be final
 
 The testing library does not currently support inheritance between test suite

--- a/Sources/Testing/Traits/Tags/Tag+Macro.swift
+++ b/Sources/Testing/Traits/Tags/Tag+Macro.swift
@@ -27,18 +27,9 @@ extension Tag {
     // described static member.
     var fullyQualifiedMemberNameComponents = TypeInfo(describing: type).fullyQualifiedNameComponents
 
-#if canImport(SwiftSyntax600)
     // Strip off the "Testing" and "Tag" components of the fully-qualified name
     // since they're redundant. Macro expansion will have already checked that
     // the type is nested inside `Tag`.
-#else
-    // Ensure that the tag is nested somewhere inside Testing.Tag, then strip
-    // off those elements of the fully-qualified type name. These preconditions
-    // are necessary because we do not currently have access, during macro
-    // expansion, to the lexical context in which a tag is declared.
-    precondition(fullyQualifiedMemberNameComponents.count >= 2, "Tags must be specified as members of the Tag type or a nested type in Tag.")
-    precondition(fullyQualifiedMemberNameComponents[0 ..< 2] == ["Testing", "Tag"], "Tags must be specified as members of the Tag type or a nested type in Tag.")
-#endif
     fullyQualifiedMemberNameComponents = Array(fullyQualifiedMemberNameComponents.dropFirst(2))
 
     // Add the specified tag name to the fully-qualified name and reconstruct

--- a/Sources/TestingMacros/SuiteDeclarationMacro.swift
+++ b/Sources/TestingMacros/SuiteDeclarationMacro.swift
@@ -59,10 +59,8 @@ public struct SuiteDeclarationMacro: MemberMacro, PeerMacro, Sendable {
       context.diagnose(diagnostics)
     }
 
-#if canImport(SwiftSyntax600)
     // Check if the lexical context is appropriate for a suite or test.
     diagnostics += diagnoseIssuesWithLexicalContext(context.lexicalContext, containing: declaration, attribute: suiteAttribute)
-#endif
     diagnostics += diagnoseIssuesWithLexicalContext(declaration, containing: declaration, attribute: suiteAttribute)
 
     // Suites inheriting from XCTestCase are not supported.

--- a/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
@@ -96,11 +96,7 @@ extension FunctionDeclSyntax {
         colonToken = .colonToken()
       } else {
         let hasThrowsSpecifier: Bool
-#if canImport(SwiftSyntax600)
         hasThrowsSpecifier = signature.effectSpecifiers?.throwsClause != nil
-#else
-        hasThrowsSpecifier = signature.effectSpecifiers?.throwsSpecifier != nil
-#endif
         if hasThrowsSpecifier {
           selector += "AndReturnError"
           colonToken = .colonToken()

--- a/Sources/TestingMacros/Support/Additions/MacroExpansionContextAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/MacroExpansionContextAdditions.swift
@@ -28,11 +28,7 @@ extension MacroExpansionContext {
   ///
   /// If the lexical context includes functions, closures, or some other
   /// non-type scope, the value of this property is `nil`.
-  ///
-  /// If swift-syntax-600 or newer is available, `node` is ignored. The argument
-  /// will be removed once the testing library's swift-syntax dependency is
-  /// updated to swift-syntax-600 or later.
-  func typeOfLexicalContext(containing node: some WithAttributesSyntax) -> TypeSyntax? {
+  var typeOfLexicalContext: TypeSyntax? {
     var typeNames = [String]()
     for lexicalContext in lexicalContext.reversed() {
       guard let decl = lexicalContext.asProtocol((any DeclGroupSyntax).self) else {

--- a/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
@@ -276,13 +276,12 @@ func makeGenericGuardDecl(
   guardingAgainst decl: some DeclSyntaxProtocol,
   in context: some MacroExpansionContext
 ) -> DeclSyntax? {
-#if canImport(SwiftSyntax600)
   guard context.lexicalContext.lazy.map(\.kind).contains(.extensionDecl) else {
     // Don't bother emitting a member if the declaration is not in an extension
     // because we'll already be able to emit a better error.
     return nil
   }
-#endif
+
   let genericGuardName = if let functionDecl = decl.as(FunctionDeclSyntax.self) {
     context.makeUniqueName(thunking: functionDecl)
   } else {

--- a/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
@@ -237,7 +237,6 @@ func diagnoseIssuesWithLexicalContext(
   return diagnostics
 }
 
-#if canImport(SwiftSyntax600)
 /// Diagnose issues with the lexical context containing a declaration.
 ///
 /// - Parameters:
@@ -256,7 +255,6 @@ func diagnoseIssuesWithLexicalContext(
     .map { diagnoseIssuesWithLexicalContext($0, containing: decl, attribute: attribute) }
     .reduce(into: [], +=)
 }
-#endif
 
 /// Create a declaration that prevents compilation if it is generic.
 ///

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -118,13 +118,8 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
       result = ("subscript", "a")
     case .enumCaseDecl:
       result = ("enumeration case", "an")
-#if canImport(SwiftSyntax600)
     case .typeAliasDecl:
       result = ("typealias", "a")
-#else
-    case .typealiasDecl:
-      result = ("typealias", "a")
-#endif
     case .macroDecl:
       result = ("macro", "a")
     case .protocolDecl:
@@ -400,7 +395,6 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
     }
   }
 
-#if canImport(SwiftSyntax600)
   /// Create a diagnostic message stating that the given attribute cannot be
   /// applied to the given declaration outside the scope of an extension to
   /// `Tag`.
@@ -417,7 +411,6 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
       severity: .error
     )
   }
-#endif
 
   /// Create a diagnostic message stating that the given attribute has no effect
   /// when applied to the given extension declaration.

--- a/Sources/TestingMacros/TagMacro.swift
+++ b/Sources/TestingMacros/TagMacro.swift
@@ -40,7 +40,7 @@ public struct TagMacro: PeerMacro, AccessorMacro, Sendable {
 
     // Figure out what type the tag is declared on. It must be declared on Tag
     // or a type nested in Tag.
-    guard let type = context.typeOfLexicalContext(containing: variableDecl) else {
+    guard let type = context.typeOfLexicalContext else {
       context.diagnose(.nonMemberTagDeclarationNotSupported(variableDecl, whenUsing: node))
       return _fallbackAccessorDecls
     }

--- a/Sources/TestingMacros/TagMacro.swift
+++ b/Sources/TestingMacros/TagMacro.swift
@@ -45,7 +45,6 @@ public struct TagMacro: PeerMacro, AccessorMacro, Sendable {
       return _fallbackAccessorDecls
     }
 
-#if canImport(SwiftSyntax600)
     // Check that the tag is declared within Tag's namespace.
     let typeNameTokens: [String] = type.tokens(viewMode: .fixedUp).lazy
       .filter { $0.tokenKind != .period }
@@ -75,7 +74,6 @@ public struct TagMacro: PeerMacro, AccessorMacro, Sendable {
         return _fallbackAccessorDecls
       }
     }
-#endif
 
     // We know the tag is nested in Tag. Now check that it is a static member.
     guard variableDecl.modifiers.map(\.name.tokenKind).contains(.keyword(.static)) else {

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -56,10 +56,8 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
       return false
     }
 
-#if canImport(SwiftSyntax600)
     // Check if the lexical context is appropriate for a suite or test.
     diagnostics += diagnoseIssuesWithLexicalContext(context.lexicalContext, containing: declaration, attribute: testAttribute)
-#endif
 
     // Only one @Test attribute is supported.
     let suiteAttributes = function.attributes(named: "Test")
@@ -73,7 +71,6 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
     for parameter in parameterList {
       let invalidSpecifierKeywords: [TokenKind] = [.keyword(.inout), .keyword(.isolated), .keyword(._const),]
       if let parameterType = parameter.type.as(AttributedTypeSyntax.self) {
-#if canImport(SwiftSyntax600)
         for specifier in parameterType.specifiers {
           guard case let .simpleTypeSpecifier(specifier) = specifier else {
             continue
@@ -82,11 +79,6 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
             diagnostics.append(.specifierNotSupported(specifier.specifier, on: parameter, whenUsing: testAttribute))
           }
         }
-#else
-        if let specifier = parameterType.specifier, invalidSpecifierKeywords.contains(specifier.tokenKind) {
-          diagnostics.append(.specifierNotSupported(specifier, on: parameter, whenUsing: testAttribute))
-        }
-#endif
       }
     }
 
@@ -193,18 +185,12 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
     let closureCaptures = parametersWithLabels.lazy.map { label, parameter in
       var needsCopy = false
       if let parameterType = parameter.type.as(AttributedTypeSyntax.self) {
-#if canImport(SwiftSyntax600)
         needsCopy = parameterType.specifiers.contains { specifier in
           guard case let .simpleTypeSpecifier(specifier) = specifier else {
             return false
           }
           return specifierKeywordsNeedingCopy.contains(specifier.specifier.tokenKind)
         }
-#else
-        if let specifier = parameterType.specifier {
-          needsCopy = specifierKeywordsNeedingCopy.contains(specifier.tokenKind)
-        }
-#endif
       }
 
       if needsCopy {
@@ -395,36 +381,9 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
   ) -> [DeclSyntax] {
     var result = [DeclSyntax]()
 
-#if canImport(SwiftSyntax600)
     // Get the name of the type containing the function for passing to the test
     // factory function later.
     let typealiasExpr: ExprSyntax = typeName.map { "\($0).self" } ?? "nil"
-#else
-    // We cannot directly refer to Self here because it will end up being
-    // resolved as the __TestContainer type we generate. Create a uniquely-named
-    // reference to Self outside the context of the generated type, and use it
-    // when the generated type needs to refer to the containing type.
-    //
-    // To support covariant Self on classes, we embed the reference to Self
-    // inside a static computed property instead of a typealias (where covariant
-    // Self is disallowed.)
-    //
-    // This "typealias" is not necessary when swift-syntax-6.0.0 is available.
-    var typealiasExpr: ExprSyntax = "nil"
-    if let typeName {
-      let typealiasName = context.makeUniqueName(thunking: functionDecl)
-      result.append(
-        """
-        @available(*, deprecated, message: "This property is an implementation detail of the testing library. Do not use it directly.")
-        private static nonisolated var \(typealiasName): Any.Type {
-          \(typeName).self
-        }
-        """
-      )
-
-      typealiasExpr = "\(typealiasName)"
-    }
-#endif
 
     if typeName != nil, let genericGuardDecl = makeGenericGuardDecl(guardingAgainst: functionDecl, in: context) {
       result.append(genericGuardDecl)

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -26,7 +26,7 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
     }
 
     let functionDecl = declaration.cast(FunctionDeclSyntax.self)
-    let typeName = context.typeOfLexicalContext(containing: functionDecl)
+    let typeName = context.typeOfLexicalContext
 
     return _createTestContainerDecls(for: functionDecl, on: typeName, testAttribute: node, in: context)
   }

--- a/Tests/TestingMacrosTests/TagMacroTests.swift
+++ b/Tests/TestingMacrosTests/TagMacroTests.swift
@@ -31,25 +31,14 @@ struct TagMacroTests {
     ]
   )
   func tagMacro(input: String, typeName: String) throws {
-#if !canImport(SwiftSyntax600)
-    // The whitespace hack we perform for swift-syntax-510 cannot "see" the
-    // leading whitespace when the entire syntax tree of interest is on a single
-    // line. Run the input through formatting before applying macros so that it
-    // is expanded out into a multi-line string.
-    let input = Parser.parse(source: input).formatted().trimmedDescription
-#endif
     let (output, diagnostics) = try parse(input)
     #expect(diagnostics.count == 0)
-#if canImport(SwiftSyntax600)
     #expect(output.contains("__fromStaticMember(of: \(typeName).self,"))
-#else
-    #expect(output.contains("__fromStaticMember(of: Self.self,"))
-#endif
     #expect(output.contains(#""x")"#))
   }
 
-  static var apiMisuseErrors: [String: String] {
-    var result = [
+  @Test("Error diagnostics emitted on API misuse",
+    arguments: [
       "@Tag struct S {}":
         "Attribute 'Tag' cannot be applied to a structure",
       "@Tag var x: Tag":
@@ -58,10 +47,7 @@ struct TagMacroTests {
         "Attribute 'Tag' cannot be applied to a global variable",
       "@Tag static var x: Tag":
         "Attribute 'Tag' cannot be applied to a global variable",
-    ]
 
-#if canImport(SwiftSyntax600)
-    let swiftSyntax600Misuses = [
       "extension Tag { @Tag var x: Tag }":
         "Attribute 'Tag' cannot be applied to an instance property",
       "extension Tag { @Tag nonisolated var x: Tag }":
@@ -73,29 +59,8 @@ struct TagMacroTests {
       "extension Tag.A.B { @Tag static var x: Self }":
         "Attribute 'Tag' cannot be applied to a property of type 'Tag.A.B'",
     ]
-    result.merge(swiftSyntax600Misuses, uniquingKeysWith: { lhs, _ in lhs })
-#else
-    let swiftSyntax510Misuses = [
-      "{ @Tag var x: Tag }":
-        "Attribute 'Tag' cannot be applied to an instance property",
-      "{ @Tag nonisolated var x: Tag }":
-        "Attribute 'Tag' cannot be applied to an instance property",
-    ]
-    result.merge(swiftSyntax510Misuses, uniquingKeysWith: { lhs, _ in lhs })
-#endif
-
-    return result
-  }
-
-  @Test("Error diagnostics emitted on API misuse", arguments: apiMisuseErrors)
+  )
   func apiMisuseErrors(input: String, expectedMessage: String) throws {
-#if !canImport(SwiftSyntax600)
-    // The whitespace hack we perform for swift-syntax-510 cannot "see" the
-    // leading whitespace when the entire syntax tree of interest is on a single
-    // line. Run the input through formatting before applying macros so that it
-    // is expanded out into a multi-line string.
-    let input = Parser.parse(source: input).formatted().trimmedDescription
-#endif
     let (_, diagnostics) = try parse(input)
 
     #expect(diagnostics.count > 0)

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -104,21 +104,8 @@ struct TestDeclarationMacroTests {
         "Attribute 'Test' must specify 2 arguments when used with 'f(i:j:)'",
       "@Test(arguments: []) func f() {}":
         "Attribute 'Test' cannot specify arguments when used with 'f()' because it does not take any",
-    ]
-  )
-  func apiMisuseErrors(input: String, expectedMessage: String) throws {
-    let (_, diagnostics) = try parse(input)
 
-    #expect(diagnostics.count > 0)
-    for diagnostic in diagnostics {
-      #expect(diagnostic.diagMessage.severity == .error)
-      #expect(diagnostic.message == expectedMessage)
-    }
-  }
-
-#if canImport(SwiftSyntax600)
-  @Test("Error diagnostics emitted for invalid lexical contexts",
-    arguments: [
+      // Invalid lexical contexts
       "struct S { func f() { @Test func g() {} } }":
         "Attribute 'Test' cannot be applied to a function within function 'f()'",
       "struct S { func f(x: Int) { @Suite struct S { } } }":
@@ -161,7 +148,7 @@ struct TestDeclarationMacroTests {
         "Attribute 'Suite' cannot be applied to a structure within a generic extension to type 'T!'",
     ]
   )
-  func invalidLexicalContext(input: String, expectedMessage: String) throws {
+  func apiMisuseErrors(input: String, expectedMessage: String) throws {
     let (_, diagnostics) = try parse(input)
 
     #expect(diagnostics.count > 0)
@@ -170,7 +157,6 @@ struct TestDeclarationMacroTests {
       #expect(diagnostic.message == expectedMessage)
     }
   }
-#endif
 
   @Test("Warning diagnostics emitted on API misuse",
     arguments: [
@@ -273,21 +259,12 @@ struct TestDeclarationMacroTests {
       ),
     ]
 
-#if canImport(SwiftSyntax600)
     result += [
       ("struct S_NAME {\n\t@Test func f() {} }", "S_NAME", "let"),
       ("struct S_NAME {\n\t@Test mutating func f() {} }", "S_NAME", "var"),
       ("struct S_NAME {\n\t@Test static func f() {} }", "S_NAME", nil),
       ("final class C_NAME {\n\t@Test class func f() {} }", "C_NAME", nil),
     ]
-#else
-    result += [
-      ("struct S {\n\t@Test func f() {} }", "Self", "let"),
-      ("struct S {\n\t@Test mutating func f() {} }", "Self", "var"),
-      ("struct S {\n\t@Test static func f() {} }", "Self", nil),
-      ("final class C {\n\t@Test class func f() {} }", "Self", nil),
-    ]
-#endif
 
     return result
   }

--- a/Tests/TestingMacrosTests/TestSupport/Parse.swift
+++ b/Tests/TestingMacrosTests/TestSupport/Parse.swift
@@ -38,17 +38,12 @@ func parse(_ sourceCode: String, activeMacros activeMacroNames: [String] = [], r
   }
   let operatorTable = OperatorTable.standardOperators
   let originalSyntax = try operatorTable.foldAll(Parser.parse(source: sourceCode))
-#if canImport(SwiftSyntax600)
   let context = BasicMacroExpansionContext(lexicalContext: [], expansionDiscriminator: "", sourceFiles: [:])
   let syntax = try operatorTable.foldAll(
     originalSyntax.expand(macros: activeMacros) { syntax in
       BasicMacroExpansionContext(sharingWith: context, lexicalContext: syntax.allMacroLexicalContexts())
     }
   )
-#else
-  let context = BasicMacroExpansionContext(expansionDiscriminator: "", sourceFiles: [:])
-  let syntax = try operatorTable.foldAll(originalSyntax.expand(macros: activeMacros, in: context))
-#endif
   var sourceCode = String(describing: syntax.formatted().trimmed)
   if removeWhitespace {
     sourceCode = sourceCode.filter { !$0.isWhitespace }

--- a/Tests/TestingTests/Traits/TagListTests.swift
+++ b/Tests/TestingTests/Traits/TagListTests.swift
@@ -221,15 +221,6 @@ struct TagListTests {
     // By value
     #expect(Tag.Color.rgb(0, 0, 0) < .rgb(100, 100, 100))
   }
-
-#if !SWT_NO_EXIT_TESTS && SWIFT_PM_SUPPORTS_SWIFT_TESTING && !canImport(SwiftSyntax600)
-  @Test("Invalid symbolic tag declaration")
-  func invalidSymbolicTag() async {
-    await #expect(exitsWith: .failure) {
-      _ = Tag.__fromStaticMember(of: String.self, "invalid")
-    }
-  }
-#endif
 }
 
 // MARK: - Fixtures


### PR DESCRIPTION
This PR changes our swift-syntax dependency from swift-syntax-510 to swift-syntax-600.

We rely on several upcoming Swift 6 features, including swift-syntax's `lexicalContext` property, in order to correctly build and run tests. This PR migrates us to the latest prerelease swift-syntax-600 package so that we can take advantage of said feature.

swift-testing clients that have an explicit or inherited dependency on swift-syntax-510 or earlier may fail to build as a result of this change. As a reminder, swift-testing is an experimental package and we do not guarantee compatibility with older versions of the toolchain or related packages.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
