### PR TITLE
Avoid reassigning task-local runtime state in a Runner's event handler unless it's nested

### DIFF
--- a/Tests/TestingTests/Runner.RuntimeStateTests.swift
+++ b/Tests/TestingTests/Runner.RuntimeStateTests.swift
@@ -25,4 +25,21 @@ struct Runner_RuntimeStateTests {
 
     await Test(name: "foo") {}.run(configuration: configuration)
   }
+
+  // This confirms that an event posted within the closure of `withTaskGroup`
+  // (and similar APIs) in regular tests (those which are not testing the
+  // testing library itself) are handled appropriately and do not crash.
+  @Test func eventPostingInTaskGroup() async {
+    // Enable delivery of "expectation checked" events, merely as a way to allow
+    // an event to be posted during the test below without causing any real
+    // issues to be recorded or otherwise confuse the testing harness.
+    var configuration = Configuration.current ?? .init()
+    configuration.deliverExpectationCheckedEvents = true
+
+    await Configuration.withCurrent(configuration) {
+      await withTaskGroup(of: Void.self) { group in
+        #expect(Bool(true))
+      }
+    }
+  }
 }

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -49,6 +49,13 @@ struct NeverRunTests {
 }
 
 final class RunnerTests: XCTestCase {
+  func testInitialTaskLocalState() {
+    // These are expected to be `nil` since this is an XCTest.
+    XCTAssertNil(Test.current)
+    XCTAssertNil(Test.Case.current)
+    XCTAssertNil(Configuration.current)
+  }
+
   func testDefaultInit() async throws {
     let runner = await Runner()
     XCTAssertFalse(runner.tests.contains(where: \.isHidden))


### PR DESCRIPTION
This is a mitigation for a bug in which an expectation inside a `withTaskGroup` closure can cause a crash if it fails.

### Motivation:

It can sometimes be useful to perform expectations (e.g. `#expect`) within the body of the closure passed to `withTaskGroup` or similar APIs. However, doing so currently causes a crash if the expectation fails, illustrated by this small example:

```swift
@Test func example() async {
  await withTaskGroup(of: Void.self) { _ in
    #expect("abc" == "123") // 💥
  }
}
```

### Modifications:

This change avoids wrapping the event handler of a runner's configuration with one that reassigns a TaskLocal (potentially triggering the crash) unless that runner is running during the run operation of another runner. In other words, only mutate the TaskLocal for nested runners. Nesting, or running one runner in the context of another, is something which is only done in practice when performing tests of the testing library itself. Ordinary usage of the testing library only has one “outer“ runner.

### Result:

The above example code no longer crashes, verified by the new unit test.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Resolves rdar://126132392