### PR TITLE
Add internal function to get the entire environment block.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -273,7 +273,7 @@ extension ExitTest {
 
       // Inherit the environment from the parent process and make any necessary
       // platform-specific changes.
-      var childEnvironment = ProcessInfo.processInfo.environment
+      var childEnvironment = Environment.get()
 #if SWT_TARGET_OS_APPLE
       // We need to remove Xcode's environment variables from the child
       // environment to avoid accidentally accidentally recursing.

--- a/Sources/Testing/Support/Environment.swift
+++ b/Sources/Testing/Support/Environment.swift
@@ -53,7 +53,7 @@ enum Environment {
     var result = [String: String]()
 
     for i in 0... {
-      guard let rowp = environ.advanced(by: i).pointee else {
+      guard let rowp = environ[i] else {
         break
       }
 
@@ -91,7 +91,7 @@ enum Environment {
     var rowp = environ
     while rowp.pointee != 0 {
       defer {
-        rowp = rowp.advanced(by: wcslen(rowp) + 1)
+        rowp += wcslen(rowp) + 1
       }
       if let row = String.decodeCString(rowp, as: UTF16.self)?.result,
          let (key, value) = _splitEnvironmentVariable(row) {

--- a/Sources/Testing/Support/Environment.swift
+++ b/Sources/Testing/Support/Environment.swift
@@ -42,13 +42,14 @@ enum Environment {
     }
   }
 
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(WASI)
   /// Get all environment variables from a POSIX environment block.
   ///
   /// - Parameters:
   ///   - environ: The environment block, i.e. the global `environ` variable.
   ///
   /// - Returns: A dictionary of environment variables.
-  private static func _getFromEnviron(_ environ: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>) -> [String: String] {
+  private static func _get(fromEnviron environ: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>) -> [String: String] {
     var result = [String: String]()
 
     for i in 0... {
@@ -64,6 +65,7 @@ enum Environment {
 
     return result
   }
+#endif
 
   /// Get all environment variables in the current process.
   ///
@@ -72,11 +74,11 @@ enum Environment {
 #if SWT_NO_ENVIRONMENT_VARIABLES
     simulatedEnvironment.rawValue
 #elseif SWT_TARGET_OS_APPLE
-    _getFromEnviron(_NSGetEnviron()!.pointee!)
+    _get(fromEnviron: _NSGetEnviron()!.pointee!)
 #elseif os(Linux)
-    _getFromEnviron(swt_environ())
+    _get(fromEnviron: swt_environ())
 #elseif os(WASI)
-    _getFromEnviron(__wasilibc_get_environ())
+    _get(fromEnviron: __wasilibc_get_environ())
 #elseif os(Windows)
     guard let environ = GetEnvironmentStringsW() else {
       return [:]

--- a/Sources/Testing/Support/Environment.swift
+++ b/Sources/Testing/Support/Environment.swift
@@ -53,12 +53,12 @@ enum Environment {
     var result = [String: String]()
 
     for i in 0... {
-      guard let rowp = environ.advanced(by: i).pointee,
-            let row = String(validatingUTF8: rowp) else {
+      guard let rowp = environ.advanced(by: i).pointee else {
         break
       }
 
-      if let (key, value) = _splitEnvironmentVariable(row) {
+      if let row = String(validatingUTF8: rowp),
+         let (key, value) = _splitEnvironmentVariable(row) {
         result[key] = value
       }
     }

--- a/Sources/Testing/Support/Environment.swift
+++ b/Sources/Testing/Support/Environment.swift
@@ -26,6 +26,80 @@ enum Environment {
   static let simulatedEnvironment = Locked<[String: String]>()
 #endif
 
+  /// Split a string containing an environment variable's name and value into
+  /// two strings.
+  ///
+  /// - Parameters:
+  ///   - row: The environment variable, of the form `"KEY=VALUE"`.
+  ///
+  /// - Returns: The name and value of the environment variable, or `nil` if it
+  ///   could not be parsed.
+  private static func _splitEnvironmentVariable(_ row: String) -> (key: String, value: String)? {
+    row.firstIndex(of: "=").map { equalsIndex in
+      let key = String(row[..<equalsIndex])
+      let value = String(row[equalsIndex...].dropFirst())
+      return (key, value)
+    }
+  }
+
+  /// Get all environment variables from a POSIX environment block.
+  ///
+  /// - Parameters:
+  ///   - environ: The environment block, i.e. the global `environ` variable.
+  ///
+  /// - Returns: A dictionary of environment variables.
+  private static func _getFromEnviron(_ environ: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>) -> [String: String] {
+    var result = [String: String]()
+
+    for i in 0... {
+      guard let rowp = environ.advanced(by: i).pointee,
+            let row = String(validatingUTF8: rowp) else {
+        break
+      }
+
+      if let (key, value) = _splitEnvironmentVariable(row) {
+        result[key] = value
+      }
+    }
+
+    return result
+  }
+
+  /// Get all environment variables in the current process.
+  ///
+  /// - Returns: A copy of the current process' environment dictionary.
+  static func get() -> [String: String] {
+#if SWT_NO_ENVIRONMENT_VARIABLES
+    simulatedEnvironment.rawValue
+#elseif SWT_TARGET_OS_APPLE
+    _getFromEnviron(_NSGetEnviron()!.pointee!)
+#elseif os(Linux)
+    _getFromEnviron(swt_environ())
+#elseif os(WASI)
+    _getFromEnviron(__wasilibc_get_environ())
+#elseif os(Windows)
+    guard let environ = GetEnvironmentStringsW() else {
+      return [:]
+    }
+    defer {
+      FreeEnvironmentStringsW(environ)
+    }
+
+    var result = [String: String]()
+    var rowp = environ
+    while rowp.pointee != 0 {
+      defer {
+        rowp = rowp.advanced(by: wcslen(rowp) + 1)
+      }
+      if let row = String.decodeCString(rowp, as: UTF16.self)?.result,
+         let (key, value) = _splitEnvironmentVariable(row) {
+        result[key] = value
+      }
+    }
+    return result
+#endif
+  }
+
   /// Get the environment variable with the specified name.
   ///
   /// - Parameters:

--- a/Sources/TestingInternals/include/Includes.h
+++ b/Sources/TestingInternals/include/Includes.h
@@ -67,6 +67,14 @@
 #include <limits.h>
 #endif
 
+#if __has_include(<crt_externs.h>)
+#include <crt_externs.h>
+#endif
+
+#if __has_include(<wasi/libc-environ.h>)
+#include <wasi/libc-environ.h>
+#endif
+
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX

--- a/Sources/TestingInternals/include/Stubs.h
+++ b/Sources/TestingInternals/include/Stubs.h
@@ -74,6 +74,22 @@ static LANGID swt_MAKELANGID(int p, int s) {
 }
 #endif
 
+#if defined(__linux__)
+/// The environment block.
+///
+/// By POSIX convention, the environment block variable is declared in client
+/// code rather than in a header.
+SWT_EXTERN char *_Nullable *_Null_unspecified environ;
+
+/// Get the environment block.
+///
+/// This function is provided because directly accessing `environ` from Swift
+/// triggers concurrency warnings about accessing shared mutable state.
+static char *_Nullable *_Null_unspecified swt_environ(void) {
+  return environ;
+}
+#endif
+
 SWT_ASSUME_NONNULL_END
 
 #endif

--- a/Tests/TestingTests/Support/EnvironmentTests.swift
+++ b/Tests/TestingTests/Support/EnvironmentTests.swift
@@ -15,6 +15,17 @@ private import TestingInternals
 struct EnvironmentTests {
   var name = "SWT_ENVIRONMENT_VARIABLE_FOR_TESTING"
 
+  @Test("Get whole environment block")
+  func getWholeEnvironment() throws {
+    let value = "\(UInt64.random(in: 0 ... .max))"
+    try #require(Environment.setVariable(value, named: name))
+    defer {
+      Environment.setVariable(nil, named: name)
+    }
+    let env = Environment.get()
+    #expect(env[name] == value)
+  }
+
   @Test("Read environment variable")
   func readEnvironmentVariable() throws {
     let value = "\(UInt64.random(in: 0 ... .max))"


### PR DESCRIPTION
This PR adds `Environment.get()` in place of `ProcessInfo.environment` so that we aren't dependent on Foundation for this functionality.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
