### PR TITLE
`ExitTest.find(withArguments:)` -> `ExitTest.findInEnvironmentForSwiftPM()`

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -213,11 +213,8 @@ extension ExitTest {
   /// recording any issues that occur.
   public typealias Handler = @Sendable (_ exitTest: borrowing ExitTest) async throws -> ExitCondition
 
-  /// Find the exit test function specified by the given command-line arguments,
-  /// if any.
-  ///
-  /// - Parameters:
-  ///   - args: The command-line arguments to this process.
+  /// Find the exit test function specified in the environment of the current
+  /// process, if any.
   ///
   /// - Returns: The exit test this process should run, or `nil` if it is not
   ///   expected to run any.
@@ -225,7 +222,7 @@ extension ExitTest {
   /// This function should only be used when the process was started via the
   /// `__swiftPMEntryPoint()` function. The effect of using it under other
   /// configurations is undefined.
-  public static func find(withArguments args: [String]) -> Self? {
+  static func findInEnvironmentForSwiftPM() -> Self? {
     let sourceLocationString = Environment.variable(named: "SWT_EXPERIMENTAL_EXIT_TEST_SOURCE_LOCATION")
     if let sourceLocationData = sourceLocationString?.data(using: .utf8),
        let sourceLocation = try? JSONDecoder().decode(SourceLocation.self, from: sourceLocationData) {

--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -55,7 +55,7 @@ private import Foundation
       options.isVerbose = args.contains("--verbose")
 
 #if !SWT_NO_EXIT_TESTS
-      if let exitTest = ExitTest.find(withArguments: args) {
+      if let exitTest = ExitTest.findInEnvironmentForSwiftPM() {
         await exitTest()
         return exitCode.rawValue
       }

--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -161,7 +161,7 @@ public enum XCTestScaffold: Sendable {
 
 #if !SWT_NO_EXIT_TESTS
     // Exit test handling.
-    if let exitTest = ExitTest.find(withArguments: CommandLine.arguments()) {
+    if let exitTest = ExitTest.findInEnvironmentForSwiftPM() {
       await exitTest()
       exit(EXIT_SUCCESS)
     }


### PR DESCRIPTION
Rename the `ExitTest.find(withArguments:)` function because it doesn't actually use command-line arguments in the current implementation.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
