### PR TITLE
Fix dead code following #349.

### DIFF
--- a/Sources/Testing/Running/EntryPoint.swift
+++ b/Sources/Testing/Running/EntryPoint.swift
@@ -57,7 +57,6 @@ private import Foundation
 #if !SWT_NO_EXIT_TESTS
       if let exitTest = ExitTest.findInEnvironmentForSwiftPM() {
         await exitTest()
-        return exitCode.rawValue
       }
 #endif
 

--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -163,7 +163,6 @@ public enum XCTestScaffold: Sendable {
     // Exit test handling.
     if let exitTest = ExitTest.findInEnvironmentForSwiftPM() {
       await exitTest()
-      exit(EXIT_SUCCESS)
     }
     let typeName = String(reflecting: type(of: testCase.rawValue as Any))
     let functionName = if let parenIndex = functionName.lastIndex(of: "(") {


### PR DESCRIPTION
Fix some new warnings from #349 that I missed locally.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
