### PR TITLE
Only store Mach header addresses for images containing Swift data.

### DIFF
--- a/Sources/TestingInternals/Discovery.cpp
+++ b/Sources/TestingInternals/Discovery.cpp
@@ -237,7 +237,7 @@ static SWTMachHeaderList getMachHeaders(void) {
 
       // Only store the mach header address if the image contains Swift data.
       // Swift does not support unloading images, but images that do not contain
-      // Swift or Objective-C code may be unloaded at runtime and later crash
+      // Swift code may be unloaded at runtime and later crash
       // the testing library when it calls enumerateTypeMetadataSections().
       unsigned long size = 0;
       if (getsectiondata(mhn, SEG_TEXT, "__swift5_types", &size)) {


### PR DESCRIPTION
We currently try to do minimal work in our `objc_addLoadImageFunc()` callback on Darwin—we acquire a lock, add each reported Mach header to a list, relinquish the lock, and immediately return. We then look for appropriate section data on demand in `enumerateTypeMetadataSections()`. This is a problem if an image is unloaded after the callback to `objc_addLoadImageFunc()` returns but before we enumerate images. Images containing Swift do not support unloading, but pure C images might find themselves in this situation.

This PR checks for the presence of a `"__swift5_types"` section before adding an image to the list, so references to images that could be unloaded won't be held indefinitely.

Resolves rdar://124426864.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
