### PR TITLE
Remove the new diagnostic added in #302.

### DIFF
--- a/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
+++ b/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
@@ -128,64 +128,6 @@ func removeParentheses(from expr: ExprSyntax) -> ExprSyntax? {
   return nil
 }
 
-/// A class that walks a syntax tree looking for `try` and `await` expressions.
-///
-/// - Bug: This class does not use `lexicalContext` to check for the presence of
-///   `try` or `await` _outside_ the current macro expansion.
-private final class _EffectFinder: SyntaxVisitor {
-  /// The effectful expressions discovered so far.
-  var effectfulExprs = [ExprSyntax]()
-
-  /// Common implementation for `visit(_: TryExprSyntax)` and
-  /// `visit(_: AwaitExprSyntax)`.
-  ///
-  /// - Parameters:
-  ///   - node: The `try` or `await` expression.
-  ///   - expression: The `.expression` property of `node`.
-  ///
-  /// - Returns: Whether or not to recurse into `node`.
-  private func _visitEffectful(_ node: some ExprSyntaxProtocol, expression: ExprSyntax) -> SyntaxVisitorContinueKind {
-    if let parentNode = node.parent, parentNode.is(TryExprSyntax.self) {
-      // Suppress this expression as its immediate parent is also an effectful
-      // expression (e.g. it's a `try await` expression overall.) The diagnostic
-      // reported for the parent expression should include both as needed.
-      return .visitChildren
-    } else if expression.is(AsExprSyntax.self) {
-      // Do not walk into explicit `as T` casts. This provides an escape hatch
-      // for expressions that should not diagnose.
-      return .skipChildren
-    } else if let awaitExpr = expression.as(AwaitExprSyntax.self), awaitExpr.expression.is(AsExprSyntax.self) {
-      // As above but for `try await _ as T`.
-      return .skipChildren
-    }
-    effectfulExprs.append(ExprSyntax(node))
-    return .visitChildren
-  }
-
-  override func visit(_ node: TryExprSyntax) -> SyntaxVisitorContinueKind {
-    _visitEffectful(node, expression: node.expression)
-  }
-
-  override func visit(_ node: AwaitExprSyntax) -> SyntaxVisitorContinueKind {
-    _visitEffectful(node, expression: node.expression)
-  }
-
-  override func visit(_ node: AsExprSyntax) -> SyntaxVisitorContinueKind {
-    // Do not walk into explicit `as T` casts. This provides an escape hatch for
-    // expressions that should not diagnose.
-    return .skipChildren
-  }
-
-  override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
-    // Do not walk into closures. Although they are not meant to be an escape
-    // hatch like `as` casts, it is very difficult (often impossible) to reason
-    // about effectful expressions inside the scope of a closure. If the closure
-    // is invoked locally, its caller will also need to say `try`/`await` and we
-    // can still diagnose those outer expressions.
-    return .skipChildren
-  }
-}
-
 // MARK: -
 
 /// Parse a condition argument from a binary operation expression.
@@ -554,17 +496,6 @@ private func _parseCondition(from expr: ExprSyntax, for macro: some Freestanding
 ///
 /// - Returns: An instance of ``Condition`` describing `expr`.
 func parseCondition(from expr: ExprSyntax, for macro: some FreestandingMacroExpansionSyntax, in context: some MacroExpansionContext) -> Condition {
-  // Handle `await` first. If present in the expression or a subexpression,
-  // diagnose and don't expand further.
-  let effectFinder = _EffectFinder(viewMode: .sourceAccurate)
-  effectFinder.walk(expr)
-  guard effectFinder.effectfulExprs.isEmpty else {
-    for effectfulExpr in effectFinder.effectfulExprs {
-      context.diagnose(.effectfulExpressionNotParsed(effectfulExpr, in: macro))
-    }
-    return Condition(expression: expr)
-  }
-
   let result = _parseCondition(from: expr, for: macro, in: context)
   if result.arguments.count == 1, let onlyArgument = result.arguments.first {
     _diagnoseTrivialBooleanValue(from: onlyArgument.expression, for: macro, in: context)

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -56,31 +56,6 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
     )
   }
 
-  /// Create a diagnostic message stating that an effectful (`try` or `await`)
-  /// expression cannot be parsed and should be broken apart.
-  ///
-  /// - Parameters:
-  ///   - expr: The expression being diagnosed.
-  ///   - macro: The macro expression.
-  ///
-  /// - Returns: A diagnostic message.
-  static func effectfulExpressionNotParsed(_ expr: ExprSyntax, in macro: some FreestandingMacroExpansionSyntax) -> Self {
-    let effectful = if let tryExpr = expr.as(TryExprSyntax.self) {
-      if tryExpr.expression.is(AwaitExprSyntax.self) {
-        "throwing/asynchronous"
-      } else {
-        "throwing"
-      }
-    } else {
-      "asynchronous"
-    }
-    return Self(
-      syntax: Syntax(expr),
-      message: "Expression '\(expr.trimmed)' will not be expanded on failure; move the \(effectful) part out of the call to \(_macroName(macro))",
-      severity: .warning
-    )
-  }
-
   /// Get the human-readable name of the given freestanding macro.
   ///
   /// - Parameters:

--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -331,49 +331,6 @@ struct ConditionMacroTests {
     #expect(diagnostics.isEmpty)
   }
 
-  @Test("#expect(try/await) produces a diagnostic",
-    arguments: [
-      "#expect(try foo())": ["Expression 'try foo()' will not be expanded on failure; move the throwing part out of the call to '#expect(_:_:)'"],
-      "#expect(await foo())": ["Expression 'await foo()' will not be expanded on failure; move the asynchronous part out of the call to '#expect(_:_:)'"],
-      "#expect(try await foo())": ["Expression 'try await foo()' will not be expanded on failure; move the throwing/asynchronous part out of the call to '#expect(_:_:)'"],
-      "#expect(try await foo(try bar(await quux())))": [
-        "Expression 'try await foo(try bar(await quux()))' will not be expanded on failure; move the throwing/asynchronous part out of the call to '#expect(_:_:)'",
-        "Expression 'try bar(await quux())' will not be expanded on failure; move the throwing part out of the call to '#expect(_:_:)'",
-        "Expression 'await quux()' will not be expanded on failure; move the asynchronous part out of the call to '#expect(_:_:)'",
-      ],
-
-      // Diagnoses because the diagnostic for `await` is suppressed due to the
-      // `as T` cast, but the parentheses limit the effect of the suppression.
-      "#expect(try (await foo() as T))": ["Expression 'try (await foo() as T)' will not be expanded on failure; move the throwing part out of the call to '#expect(_:_:)'"],
-    ]
-  )
-  func effectfulExpectationDiagnoses(input: String, diagnosticMessages: [String]) throws {
-    let (_, diagnostics) = try parse(input)
-    #expect(diagnostics.count == diagnosticMessages.count)
-    for message in diagnosticMessages {
-      #expect(diagnostics.contains { $0.diagMessage.message == message }, "Missing \(message): \(diagnostics.map(\.diagMessage.message))")
-    }
-  }
-
-  @Test("#expect(try/await as Bool) suppresses its diagnostic",
-    arguments: [
-      "#expect(try foo() as Bool)",
-      "#expect(await foo() as Bool)",
-      "#expect(try await foo(try await bar()) as Bool)",
-      "#expect(try foo() as T?)",
-      "#expect(await foo() as? T)",
-      "#expect(try await foo(try await bar()) as! T)",
-      "#expect((try foo()) as T)",
-      "#expect((await foo()) as T)",
-      "#expect((try await foo(try await bar())) as T)",
-      "#expect(try (await foo()) as T)",
-    ]
-  )
-  func effectfulExpectationDiagnosticSuppressWithExplicitBool(input: String) throws {
-    let (_, diagnostics) = try parse(input)
-    #expect(diagnostics.isEmpty)
-  }
-
   @Test("Expectation inside an exit test diagnoses",
     arguments: [
       "#expectExitTest(exitsWith: .failure) { #expect(1 > 2) }",

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -150,11 +150,12 @@ struct EventRecorderTests {
       One(.anyGraphemeCluster)
       " \(isSuite ? "Suite" : "Test") \(testName) started."
     }
-    let match = try buffer
-      .split(whereSeparator: \.isNewline)
-      .compactMap(testFailureRegex.wholeMatch(in:))
-      .first
-    #expect(match != nil)
+    #expect(
+      try buffer
+        .split(whereSeparator: \.isNewline)
+        .compactMap(testFailureRegex.wholeMatch(in:))
+        .first != nil
+    )
   }
 
   @available(_regexAPI, *)

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -52,7 +52,7 @@ final class IssueTests: XCTestCase {
     }
 
     await Test { () throws in
-      #expect(try { throw MyError() }() as Bool)
+      #expect(try { throw MyError() }())
     }.run(configuration: configuration)
 
     await Test { () throws in
@@ -283,8 +283,8 @@ final class IssueTests: XCTestCase {
     }
 
     await Test { () throws in
-      #expect(try TypeWithMemberFunctions.n(0) as Bool)
-      #expect(TypeWithMemberFunctions.f(try { () throws in 0 }()) as Bool)
+      #expect(try TypeWithMemberFunctions.n(0))
+      #expect(TypeWithMemberFunctions.f(try { () throws in 0 }()))
     }.run(configuration: configuration)
 
     await fulfillment(of: [expectationFailed], timeout: 0.0)

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -194,26 +194,24 @@ struct TestsWithAsyncArguments {
 struct MiscellaneousTests {
   @Test("Free function's name")
   func unnamedFreeFunctionTest() async throws {
-    let tests = await Test.all
-    let testFunction = try #require(tests.first(where: { $0.name.contains("freeSyncFunction") }))
+    let testFunction = try #require(await Test.all.first(where: { $0.name.contains("freeSyncFunction") }))
     #expect(testFunction.name == "freeSyncFunction()")
   }
 
   @Test("Test suite type's name")
   func unnamedMemberFunctionTest() async throws {
-    let testType = try #require(await test(for: SendableTests.self) as Test?)
+    let testType = try #require(await test(for: SendableTests.self))
     #expect(testType.name == "SendableTests")
   }
 
   @Test("Free function has custom display name")
   func namedFreeFunctionTest() async throws {
-    let tests = await Test.all
-    #expect(tests.first { $0.displayName == "Named Free Sync Function" && !$0.isSuite && $0.containingTypeInfo == nil } != nil)
+    #expect(await Test.all.first { $0.displayName == "Named Free Sync Function" && !$0.isSuite && $0.containingTypeInfo == nil } != nil)
   }
 
   @Test("Member function has custom display name")
   func namedMemberFunctionTest() async throws {
-    let testType = try #require(await test(for: NamedSendableTests.self) as Test?)
+    let testType = try #require(await test(for: NamedSendableTests.self))
     #expect(testType.displayName == "Named Sendable test type")
   }
 
@@ -321,18 +319,18 @@ struct MiscellaneousTests {
   @Test("Test.parameters property")
   func parametersProperty() async throws {
     do {
-      let theTest = try #require(await test(for: SendableTests.self) as Test?)
+      let theTest = try #require(await test(for: SendableTests.self))
       #expect(theTest.parameters == nil)
     }
 
     do {
-      let test = try #require(await testFunction(named: "succeeds()", in: SendableTests.self) as Test?)
+      let test = try #require(await testFunction(named: "succeeds()", in: SendableTests.self))
       let parameters = try #require(test.parameters)
       #expect(parameters.isEmpty)
     } catch {}
 
     do {
-      let test = try #require(await testFunction(named: "parameterized(i:)", in: NonSendableTests.self) as Test?)
+      let test = try #require(await testFunction(named: "parameterized(i:)", in: NonSendableTests.self))
       let parameters = try #require(test.parameters)
       #expect(parameters.count == 1)
       let firstParameter = try #require(parameters.first)
@@ -345,7 +343,7 @@ struct MiscellaneousTests {
     } catch {}
 
     do {
-      let test = try #require(await testFunction(named: "parameterized2(i:j:)", in: NonSendableTests.self) as Test?)
+      let test = try #require(await testFunction(named: "parameterized2(i:j:)", in: NonSendableTests.self))
       let parameters = try #require(test.parameters)
       #expect(parameters.count == 2)
       let firstParameter = try #require(parameters.first)

--- a/Tests/TestingTests/PlanTests.swift
+++ b/Tests/TestingTests/PlanTests.swift
@@ -23,10 +23,10 @@ struct PlanTests {
 
   @Test("Selected tests by ID")
   func selectedTests() async throws {
-    let outerTestType = try #require(await test(for: SendableTests.self) as Test?)
-    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self) as Test?)
-    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self) as Test?)
-    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self) as Test?)
+    let outerTestType = try #require(await test(for: SendableTests.self))
+    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self))
+    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self))
+    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self))
 
     let tests = [
       outerTestType,
@@ -48,10 +48,10 @@ struct PlanTests {
 
   @Test("Multiple selected tests by ID")
   func multipleSelectedTests() async throws {
-    let outerTestType = try #require(await test(for: SendableTests.self) as Test?)
-    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self) as Test?)
-    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self) as Test?)
-    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self) as Test?)
+    let outerTestType = try #require(await test(for: SendableTests.self))
+    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self))
+    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self))
+    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self))
 
     let tests = [
       outerTestType,
@@ -74,10 +74,10 @@ struct PlanTests {
 
   @Test("Excluded tests by ID")
   func excludedTests() async throws {
-    let outerTestType = try #require(await test(for: SendableTests.self) as Test?)
-    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self) as Test?)
-    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self) as Test?)
-    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self) as Test?)
+    let outerTestType = try #require(await test(for: SendableTests.self))
+    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self))
+    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self))
+    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self))
 
     let tests = [
       outerTestType,
@@ -101,11 +101,11 @@ struct PlanTests {
 
   @Test("Selected tests by any tag")
   func selectedTestsByAnyTag() async throws {
-    let outerTestType = try #require(await test(for: SendableTests.self) as Test?)
-    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self) as Test?)
-    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self) as Test?)
-    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self) as Test?)
-    let testC = try #require(await testFunction(named: "otherSucceeds()", in: SendableTests.NestedSendableTests.self) as Test?)
+    let outerTestType = try #require(await test(for: SendableTests.self))
+    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self))
+    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self))
+    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self))
+    let testC = try #require(await testFunction(named: "otherSucceeds()", in: SendableTests.NestedSendableTests.self))
 
     let tests = [
       outerTestType,
@@ -131,11 +131,11 @@ struct PlanTests {
 
   @Test("Selected tests by all tags")
   func selectedTestsByAllTags() async throws {
-    let outerTestType = try #require(await test(for: SendableTests.self) as Test?)
-    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self) as Test?)
-    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self) as Test?)
-    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self) as Test?)
-    let testC = try #require(await testFunction(named: "otherSucceeds()", in: SendableTests.NestedSendableTests.self) as Test?)
+    let outerTestType = try #require(await test(for: SendableTests.self))
+    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self))
+    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self))
+    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self))
+    let testC = try #require(await testFunction(named: "otherSucceeds()", in: SendableTests.NestedSendableTests.self))
 
     let tests = [
       outerTestType,
@@ -161,11 +161,11 @@ struct PlanTests {
 
   @Test("Excluded tests by any tag")
   func excludedTestsByAnyTag() async throws {
-    let outerTestType = try #require(await test(for: SendableTests.self) as Test?)
-    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self) as Test?)
-    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self) as Test?)
-    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self) as Test?)
-    let testC = try #require(await testFunction(named: "otherSucceeds()", in: SendableTests.NestedSendableTests.self) as Test?)
+    let outerTestType = try #require(await test(for: SendableTests.self))
+    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self))
+    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self))
+    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self))
+    let testC = try #require(await testFunction(named: "otherSucceeds()", in: SendableTests.NestedSendableTests.self))
 
     let tests = [
       outerTestType,
@@ -191,11 +191,11 @@ struct PlanTests {
 
   @Test("Excluded tests by all tags")
   func excludedTestsByAllTags() async throws {
-    let outerTestType = try #require(await test(for: SendableTests.self) as Test?)
-    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self) as Test?)
-    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self) as Test?)
-    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self) as Test?)
-    let testC = try #require(await testFunction(named: "otherSucceeds()", in: SendableTests.NestedSendableTests.self) as Test?)
+    let outerTestType = try #require(await test(for: SendableTests.self))
+    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self))
+    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self))
+    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self))
+    let testC = try #require(await testFunction(named: "otherSucceeds()", in: SendableTests.NestedSendableTests.self))
 
     let tests = [
       outerTestType,
@@ -221,11 +221,11 @@ struct PlanTests {
 
   @Test("Mixed included and excluded tests by ID")
   func mixedIncludedAndExcludedTests() async throws {
-    let outerTestType = try #require(await test(for: SendableTests.self) as Test?)
-    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self) as Test?)
-    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self) as Test?)
-    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self) as Test?)
-    let testC = try #require(await testFunction(named: "otherSucceeds()", in: SendableTests.NestedSendableTests.self) as Test?)
+    let outerTestType = try #require(await test(for: SendableTests.self))
+    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self))
+    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self))
+    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self))
+    let testC = try #require(await testFunction(named: "otherSucceeds()", in: SendableTests.NestedSendableTests.self))
 
     let tests = [
       outerTestType,
@@ -252,10 +252,10 @@ struct PlanTests {
 
   @Test("Combining test filter by ID with .unfiltered (rhs)")
   func combiningTestFilterWithUnfilteredRHS() async throws {
-    let outerTestType = try #require(await test(for: SendableTests.self) as Test?)
-    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self) as Test?)
-    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self) as Test?)
-    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self) as Test?)
+    let outerTestType = try #require(await test(for: SendableTests.self))
+    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self))
+    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self))
+    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self))
 
     let tests = [
       outerTestType,
@@ -281,10 +281,10 @@ struct PlanTests {
 
   @Test("Combining test filter by ID with .unfiltered (lhs)")
   func combiningTestFilterWithUnfilteredLHS() async throws {
-    let outerTestType = try #require(await test(for: SendableTests.self) as Test?)
-    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self) as Test?)
-    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self) as Test?)
-    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self) as Test?)
+    let outerTestType = try #require(await test(for: SendableTests.self))
+    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self))
+    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self))
+    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self))
 
     let tests = [
       outerTestType,
@@ -310,10 +310,10 @@ struct PlanTests {
 
   @Test("Combining test filter by ID with by tag")
   func combiningTestFilterByIDAndByTag() async throws {
-    let outerTestType = try #require(await test(for: SendableTests.self) as Test?)
-    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self) as Test?)
-    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self) as Test?)
-    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self) as Test?)
+    let outerTestType = try #require(await test(for: SendableTests.self))
+    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self))
+    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self))
+    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self))
 
     let tests = [
       outerTestType,
@@ -339,11 +339,11 @@ struct PlanTests {
 
   @Test("Combining test filters with .or")
   func combiningTestFilterWithOr() async throws {
-    let outerTestType = try #require(await test(for: SendableTests.self) as Test?)
-    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self) as Test?)
-    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self) as Test?)
-    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self) as Test?)
-    let testC = try #require(await testFunction(named: "otherSucceeds()", in: SendableTests.NestedSendableTests.self) as Test?)
+    let outerTestType = try #require(await test(for: SendableTests.self))
+    let testA = try #require(await testFunction(named: "succeeds()", in: SendableTests.self))
+    let innerTestType = try #require(await test(for: SendableTests.NestedSendableTests.self))
+    let testB = try #require(await testFunction(named: "succeeds()", in: SendableTests.NestedSendableTests.self))
+    let testC = try #require(await testFunction(named: "otherSucceeds()", in: SendableTests.NestedSendableTests.self))
 
     let tests = [
       outerTestType,
@@ -371,9 +371,9 @@ struct PlanTests {
 
   @Test("Recursive trait application")
   func recursiveTraitApplication() async throws {
-    let outerTestType = try #require(await test(for: OuterTest.self) as Test?)
+    let outerTestType = try #require(await test(for: OuterTest.self))
     // Intentionally omitting intermediate tests here...
-    let deeplyNestedTest = try #require(await testFunction(named: "example()", in: OuterTest.IntermediateType.InnerTest.self) as Test?)
+    let deeplyNestedTest = try #require(await testFunction(named: "example()", in: OuterTest.IntermediateType.InnerTest.self))
 
     let tests = [outerTestType, deeplyNestedTest]
 
@@ -389,10 +389,10 @@ struct PlanTests {
 
   @Test("Relative order of recursively applied traits")
   func recursiveTraitOrder() async throws {
-    let testSuiteA = try #require(await test(for: RelativeTraitOrderingTests.A.self) as Test?)
-    let testSuiteB = try #require(await test(for: RelativeTraitOrderingTests.A.B.self) as Test?)
-    let testSuiteC = try #require(await test(for: RelativeTraitOrderingTests.A.B.C.self) as Test?)
-    let testFuncX = try #require(await testFunction(named: "x()", in: RelativeTraitOrderingTests.A.B.C.self) as Test?)
+    let testSuiteA = try #require(await test(for: RelativeTraitOrderingTests.A.self))
+    let testSuiteB = try #require(await test(for: RelativeTraitOrderingTests.A.B.self))
+    let testSuiteC = try #require(await test(for: RelativeTraitOrderingTests.A.B.C.self))
+    let testFuncX = try #require(await testFunction(named: "x()", in: RelativeTraitOrderingTests.A.B.C.self))
 
     let tests = [testSuiteA, testSuiteB, testSuiteC, testFuncX]
 

--- a/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
+++ b/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
@@ -19,7 +19,7 @@ struct Runner_Plan_SnapshotTests {
 #if canImport(Foundation)
   @Test("Codable")
   func codable() async throws {
-    let suite = try #require(await test(for: Runner_Plan_SnapshotFixtures.self) as Test?)
+    let suite = try #require(await test(for: Runner_Plan_SnapshotFixtures.self))
 
     var configuration = Configuration()
     configuration.setTestFilter(toInclude: [suite.id], includeHiddenTests: true)

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -255,8 +255,8 @@ final class RunnerTests: XCTestCase {
   }
 
   func testConditionTraitsAreEvaluatedOutermostToInnermost() async throws {
-    let testSuite = try #require(await test(for: NeverRunTests.self) as Test?)
-    let testFunc = try #require(await testFunction(named: "duelingConditions()", in: NeverRunTests.self) as Test?)
+    let testSuite = try #require(await test(for: NeverRunTests.self))
+    let testFunc = try #require(await testFunction(named: "duelingConditions()", in: NeverRunTests.self))
 
     var configuration = Configuration()
     let selection = [testSuite.id]

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -145,7 +145,7 @@ struct SwiftPMTests {
       configuration.eventHandler(Event(.runStarted, testID: nil, testCaseID: nil), eventContext)
       configuration.eventHandler(Event(.runEnded, testID: nil, testCaseID: nil), eventContext)
     }
-    #expect(try temporaryFileURL.checkResourceIsReachable() as Bool)
+    #expect(try temporaryFileURL.checkResourceIsReachable())
   }
 
   func decodeEventStream(fromFileAt url: URL) throws -> [EventAndContextSnapshot] {
@@ -174,7 +174,7 @@ struct SwiftPMTests {
       }
       configuration.handleEvent(Event(.runEnded, testID: nil, testCaseID: nil), in: eventContext)
     }
-    #expect(try temporaryFileURL.checkResourceIsReachable() as Bool)
+    #expect(try temporaryFileURL.checkResourceIsReachable())
 
     let decodedEvents = try decodeEventStream(fromFileAt: temporaryFileURL)
     #expect(decodedEvents.count == 4)

--- a/Tests/TestingTests/Test.SnapshotTests.swift
+++ b/Tests/TestingTests/Test.SnapshotTests.swift
@@ -40,12 +40,12 @@ struct Test_SnapshotTests {
       #expect(!snapshot.isParameterized)
     }
     do {
-      let test = try #require(await testFunction(named: "parameterized(i:)", in: MainActorIsolatedTests.self) as Test?)
+      let test = try #require(await testFunction(named: "parameterized(i:)", in: MainActorIsolatedTests.self))
       let snapshot = Test.Snapshot(snapshotting: test)
       #expect(snapshot.isParameterized)
     }
     do {
-      let suite = try #require(await test(for: Self.self) as Test?)
+      let suite = try #require(await test(for: Self.self))
       let snapshot = Test.Snapshot(snapshotting: suite)
       #expect(!snapshot.isParameterized)
     }
@@ -59,12 +59,12 @@ struct Test_SnapshotTests {
       #expect(!snapshot.isSuite)
     }
     do {
-      let test = try #require(await testFunction(named: "parameterized(i:)", in: MainActorIsolatedTests.self) as Test?)
+      let test = try #require(await testFunction(named: "parameterized(i:)", in: MainActorIsolatedTests.self))
       let snapshot = Test.Snapshot(snapshotting: test)
       #expect(!snapshot.isSuite)
     }
     do {
-      let suite = try #require(await test(for: Self.self) as Test?)
+      let suite = try #require(await test(for: Self.self))
       let snapshot = Test.Snapshot(snapshotting: suite)
       #expect(snapshot.isSuite)
     }


### PR DESCRIPTION
In #302, we added a compile-time diagnostic (warning) for expressions like:

```swift
#expect(try await foo())
```

Because we figured that the lack of expression expansion for effectful expressions might be confusing. However, we've found that the diagnostic is significantly noisier than we'd like and the cons outweigh the pros. Hence, this PR removes that diagnostic.

Resolves rdar://126393932.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
