### PR TITLE
Abstract away our dependency on Foundation for JSON encoding/decoding

### DIFF
--- a/Sources/Testing/Parameterization/CustomTestArgumentEncodable.swift
+++ b/Sources/Testing/Parameterization/CustomTestArgumentEncodable.swift
@@ -8,10 +8,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation)
-private import Foundation
-#endif
-
 /// A protocol for customizing how arguments passed to parameterized tests are
 /// encoded, which is used to match against when running specific arguments.
 ///
@@ -107,15 +103,7 @@ extension Test.Case.Argument.ID {
   ///
   /// - Throws: Any error encountered during encoding.
   private static func _encode(_ value: some Encodable, parameter: Test.Parameter) throws -> [UInt8] {
-    let encoder = JSONEncoder()
-
-    // Keys must be sorted to ensure deterministic matching of encoded data.
-    encoder.outputFormatting.insert(.sortedKeys)
-
-    // Set user info keys which clients may wish to use during encoding.
-    encoder.userInfo[._testParameterUserInfoKey] = parameter
-
-    return .init(try encoder.encode(value))
+    try JSON.withEncoding(of: value, userInfo: [._testParameterUserInfoKey: parameter], Array.init)
   }
 #endif
 }

--- a/Sources/Testing/Support/JSON.swift
+++ b/Sources/Testing/Support/JSON.swift
@@ -1,0 +1,65 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+#if canImport(Foundation)
+private import Foundation
+#endif
+
+enum JSON {
+  /// Encode a value as JSON.
+  ///
+  /// - Parameters:
+  ///   - value: The value to encode.
+  ///   - userInfo: Any user info to pass into the encoder during encoding.
+  ///   - body: A function to call.
+  ///
+  /// - Returns: Whatever is returned by `body`.
+  ///
+  /// - Throws: Whatever is thrown by `body` or by the encoding process.
+  static func withEncoding<R>(of value: some Encodable, userInfo: [CodingUserInfoKey: Any] = [:], _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
+#if canImport(Foundation)
+    let encoder = JSONEncoder()
+
+    // Keys must be sorted to ensure deterministic matching of encoded data.
+    encoder.outputFormatting.insert(.sortedKeys)
+
+    // Set user info keys that clients want to use during encoding.
+    encoder.userInfo.merge(userInfo, uniquingKeysWith: { _, rhs in rhs})
+
+    let data = try encoder.encode(value)
+    return try data.withUnsafeBytes(body)
+#else
+    throw SystemError(description: "JSON encoding requires Foundation which is not available in this environment.")
+#endif
+  }
+
+  /// Decode a value from JSON data.
+  ///
+  /// - Parameters:
+  ///   - jsonRepresentation: The JSON encoding of the value to decode.
+  ///
+  /// - Returns: An instance of `T` decoded from `jsonRepresentation`.
+  ///
+  /// - Throws: Whatever is thrown by the decoding process.
+  static func decode<T>(_ _: T.Type, from jsonRepresentation: UnsafeRawBufferPointer) throws -> T where T: Decodable {
+#if canImport(Foundation)
+    try withExtendedLifetime(jsonRepresentation) {
+      let data = Data(
+        bytesNoCopy: .init(mutating: jsonRepresentation.baseAddress!),
+        count: jsonRepresentation.count,
+        deallocator: .none
+      )
+      return try JSONDecoder().decode(T.self, from: data)
+    }
+#else
+    throw SystemError(description: "JSON decoding requires Foundation which is not available in this environment.")
+#endif
+  }
+}

--- a/Sources/Testing/Support/JSON.swift
+++ b/Sources/Testing/Support/JSON.swift
@@ -43,12 +43,13 @@ enum JSON {
   /// Decode a value from JSON data.
   ///
   /// - Parameters:
+  ///   - type: The type of value to decode.
   ///   - jsonRepresentation: The JSON encoding of the value to decode.
   ///
   /// - Returns: An instance of `T` decoded from `jsonRepresentation`.
   ///
   /// - Throws: Whatever is thrown by the decoding process.
-  static func decode<T>(_ _: T.Type, from jsonRepresentation: UnsafeRawBufferPointer) throws -> T where T: Decodable {
+  static func decode<T>(_ type: T.Type, from jsonRepresentation: UnsafeRawBufferPointer) throws -> T where T: Decodable {
 #if canImport(Foundation)
     try withExtendedLifetime(jsonRepresentation) {
       let data = Data(
@@ -56,7 +57,7 @@ enum JSON {
         count: jsonRepresentation.count,
         deallocator: .none
       )
-      return try JSONDecoder().decode(T.self, from: data)
+      return try JSONDecoder().decode(type, from: data)
     }
 #else
     throw SystemError(description: "JSON decoding requires Foundation which is not available in this environment.")

--- a/Sources/Testing/Traits/Tags/Tag.Color+Loading.swift
+++ b/Sources/Testing/Traits/Tags/Tag.Color+Loading.swift
@@ -99,7 +99,9 @@ func loadTagColors(fromFileInDirectoryAtPath swiftTestingDirectoryPath: String =
   // nil is a valid decoded color value (representing "no color") that we can
   // use for merging tag color data from multiple sources, but it is not valid
   // as an actual tag color, so we have a step here that filters it.
-  return try JSONDecoder().decode([Tag: Tag.Color?].self, from: tagColorsData)
-    .compactMapValues { $0 }
+  return try tagColorsData.withUnsafeBytes { tagColorsData in
+    try JSON.decode([Tag: Tag.Color?].self, from: tagColorsData)
+      .compactMapValues { $0 }
+  }
 }
 #endif

--- a/Sources/TestingInternals/include/Includes.h
+++ b/Sources/TestingInternals/include/Includes.h
@@ -43,6 +43,10 @@
 #include <unistd.h>
 #endif
 
+#if __has_include(<sys/fcntl.h>)
+#include <sys/fcntl.h>
+#endif
+
 #if __has_include(<sys/stat.h>)
 #include <sys/stat.h>
 #endif

--- a/Sources/TestingInternals/include/Includes.h
+++ b/Sources/TestingInternals/include/Includes.h
@@ -75,6 +75,10 @@
 #include <limits.h>
 #endif
 
+#if __has_include(<spawn.h>)
+#include <spawn.h>
+#endif
+
 #if __has_include(<crt_externs.h>)
 #include <crt_externs.h>
 #endif

--- a/Tests/TestingTests/BacktraceTests.swift
+++ b/Tests/TestingTests/BacktraceTests.swift
@@ -9,9 +9,6 @@
 //
 
 @testable @_spi(ForToolsIntegrationOnly) import Testing
-#if canImport(Foundation)
-import Foundation
-#endif
 
 struct BacktracedError: Error {}
 
@@ -51,8 +48,7 @@ struct BacktraceTests {
   @Test("Encoding/decoding")
   func encodingAndDecoding() throws {
     let original = Backtrace.current()
-    let data = try JSONEncoder().encode(original)
-    let copy = try JSONDecoder().decode(Backtrace.self, from: data)
+    let copy = try JSON.encodeAndDecode(original)
     #expect(original == copy)
   }
 #endif

--- a/Tests/TestingTests/ClockTests.swift
+++ b/Tests/TestingTests/ClockTests.swift
@@ -8,9 +8,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation)
-import Foundation
-#endif
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 private import TestingInternals
 
@@ -129,9 +126,7 @@ struct ClockTests {
   func codable() async throws {
     let now = Test.Clock.Instant()
     let instant = now.advanced(by: .nanoseconds(100))
-    let decoded = try JSONDecoder().decode(Test.Clock.Instant.self,
-                                           from: JSONEncoder().encode(instant))
-
+    let decoded = try JSON.encodeAndDecode(instant)
     #expect(instant == decoded)
     #expect(instant != now)
   }

--- a/Tests/TestingTests/EventTests.swift
+++ b/Tests/TestingTests/EventTests.swift
@@ -8,9 +8,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation)
-import Foundation
-#endif
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 private import TestingInternals
 
@@ -62,8 +59,7 @@ struct EventTests {
     let testCaseID = Test.Case.ID(argumentIDs: nil)
     let event = Event(kind, testID: testID, testCaseID: testCaseID, instant: .now)
     let eventSnapshot = Event.Snapshot(snapshotting: event)
-    let encoded = try JSONEncoder().encode(eventSnapshot)
-    let decoded = try JSONDecoder().decode(Event.Snapshot.self, from: encoded)
+    let decoded = try JSON.encodeAndDecode(eventSnapshot)
 
     #expect(String(describing: decoded) == String(describing: eventSnapshot))
   }
@@ -73,8 +69,7 @@ struct EventTests {
     let eventContext = Event.Context()
     let snapshot = Event.Context.Snapshot(snapshotting: eventContext)
 
-    let encoded = try JSONEncoder().encode(snapshot)
-    let decoded = try JSONDecoder().decode(Event.Context.Snapshot.self, from: encoded)
+    let decoded = try JSON.encodeAndDecode(snapshot)
 
     #expect(String(describing: decoded.test) == String(describing: eventContext.test.map(Test.Snapshot.init(snapshotting:))))
     #expect(String(describing: decoded.testCase) == String(describing: eventContext.testCase.map(Test.Case.Snapshot.init(snapshotting:))))

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -10,7 +10,6 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 private import TestingInternals
-import Foundation
 
 #if canImport(XCTest)
 import XCTest
@@ -1408,8 +1407,7 @@ struct IssueCodingTests {
                       comments: ["Comment"],
                       sourceContext: SourceContext(backtrace: Backtrace.current(), sourceLocation: SourceLocation()))
     let issueSnapshot = Issue.Snapshot(snapshotting: issue)
-    let encoded = try JSONEncoder().encode(issueSnapshot)
-    let decoded = try JSONDecoder().decode(Issue.Snapshot.self, from: encoded)
+    let decoded = try JSON.encodeAndDecode(issueSnapshot)
 
     #expect(String(describing: decoded) == String(describing: issueSnapshot))
   }

--- a/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
+++ b/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
@@ -10,10 +10,6 @@
 
 @testable @_spi(ForToolsIntegrationOnly) import Testing
 
-#if canImport(Foundation)
-import Foundation
-#endif
-
 @Suite("Runner.Plan.Snapshot tests")
 struct Runner_Plan_SnapshotTests {
 #if canImport(Foundation)
@@ -26,7 +22,7 @@ struct Runner_Plan_SnapshotTests {
 
     let plan = await Runner.Plan(configuration: configuration)
     let snapshot = Runner.Plan.Snapshot(snapshotting: plan)
-    let decoded = try JSONDecoder().decode(Runner.Plan.Snapshot.self, from: JSONEncoder().encode(snapshot))
+    let decoded = try JSON.encodeAndDecode(snapshot)
 
     try #require(decoded.steps.count == snapshot.steps.count)
 

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -151,7 +151,11 @@ struct SwiftPMTests {
   func decodeEventStream(fromFileAt url: URL) throws -> [EventAndContextSnapshot] {
     try Data(contentsOf: url, options: [.mappedIfSafe])
       .split(separator: 10) // "\n"
-      .map { try JSONDecoder().decode(EventAndContextSnapshot.self, from: $0) }
+      .map { line in
+        try line.withUnsafeBytes { line in
+          try JSON.decode(EventAndContextSnapshot.self, from: line)
+        }
+      }
   }
 
   @Test("--experimental-event-stream-output argument (writes to a stream and can be read back)")

--- a/Tests/TestingTests/Test.Case.Argument.IDTests.swift
+++ b/Tests/TestingTests/Test.Case.Argument.IDTests.swift
@@ -9,9 +9,6 @@
 //
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
-#if canImport(Foundation)
-import Foundation
-#endif
 
 @Suite("Test.Case.Argument.ID Tests")
 struct Test_Case_Argument_IDTests {
@@ -41,7 +38,9 @@ struct Test_Case_Argument_IDTests {
     let argument = try #require(testCase.arguments.first)
     let argumentID = try #require(argument.id)
 #if canImport(Foundation)
-    let decodedArgument = try JSONDecoder().decode(MyCustomTestArgument.self, from: Data(argumentID.bytes))
+    let decodedArgument = try argumentID.bytes.withUnsafeBufferPointer { argumentID in
+      try JSON.decode(MyCustomTestArgument.self, from: .init(argumentID))
+    }
     #expect(decodedArgument == MyCustomTestArgument(x: 123, y: "abc"))
 #endif
   }

--- a/Tests/TestingTests/Test.SnapshotTests.swift
+++ b/Tests/TestingTests/Test.SnapshotTests.swift
@@ -8,11 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@_spi(ForToolsIntegrationOnly) import Testing
-
-#if canImport(Foundation)
-import Foundation
-#endif
+@_spi(ForToolsIntegrationOnly) @testable import Testing
 
 @Suite("Test.Snapshot tests")
 struct Test_SnapshotTests {
@@ -21,7 +17,7 @@ struct Test_SnapshotTests {
   func codable() throws {
     let test = try #require(Test.current)
     let snapshot = Test.Snapshot(snapshotting: test)
-    let decoded = try JSONDecoder().decode(Test.Snapshot.self, from: JSONEncoder().encode(snapshot))
+    let decoded = try JSON.encodeAndDecode(snapshot)
 
     #expect(decoded.id == snapshot.id)
     #expect(decoded.name == snapshot.name)

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -348,3 +348,19 @@ extension Configuration {
 /// whose output could make it hard to read "real" output from the testing
 /// library.
 let testsWithSignificantIOAreEnabled = Environment.flag(named: "SWT_ENABLE_TESTS_WITH_SIGNIFICANT_IO") == true
+
+extension JSON {
+  /// Round-trip a value through JSON encoding/decoding.
+  ///
+  /// - Parameters:
+  ///   - value: The value to round-trip.
+  ///
+  /// - Returns: A copy of `value` after encoding and decoding.
+  ///
+  /// - Throws: Any error encountered encoding or decoding `value`.
+  static func encodeAndDecode<T>(_ value: T) throws -> T where T: Codable {
+    try JSON.withEncoding(of: value) { data in
+      try JSON.decode(T.self, from: data)
+    }
+  }
+}

--- a/Tests/TestingTests/Traits/BugTests.swift
+++ b/Tests/TestingTests/Traits/BugTests.swift
@@ -9,9 +9,6 @@
 //
 
 @testable import Testing
-#if canImport(Foundation)
-import Foundation
-#endif
 
 @Suite("Bug Tests", .tags(.traitRelated))
 struct BugTests {
@@ -95,8 +92,7 @@ struct BugTests {
   @Test("Encoding/decoding")
   func encodingAndDecoding() throws {
     let original = Bug.bug(12345, relationship: .failingBecauseOfBug, "Lorem ipsum")
-    let data = try JSONEncoder().encode(original)
-    let copy = try JSONDecoder().decode(Bug.self, from: data)
+    let copy = try JSON.encodeAndDecode(original)
     #expect(original == copy)
   }
 #endif

--- a/Tests/TestingTests/Traits/TagListTests.swift
+++ b/Tests/TestingTests/Traits/TagListTests.swift
@@ -113,8 +113,7 @@ struct TagListTests {
   @Test("Encoding/decoding tags")
   func encodeAndDecodeTags() throws {
     let array: [Tag] = [.red, .orange, Tag("abc123"), Tag(".abc123"), Tag(#"\.abc123"#), Tag(#"\\.abc123"#)]
-    let data = try JSONEncoder().encode(array)
-    let array2 = try JSONDecoder().decode([Tag].self, from: data)
+    let array2 = try JSON.encodeAndDecode(array)
     #expect(array == array2)
   }
 
@@ -128,8 +127,7 @@ struct TagListTests {
       Tag(#"\.abc123"#): 4,
       Tag(#"\\.abc123"#): 4,
     ]
-    let data = try JSONEncoder().encode(dict)
-    let dict2 = try JSONDecoder().decode([Tag: Int].self, from: data)
+    let dict2 = try JSON.encodeAndDecode(dict)
     #expect(dict == dict2)
   }
 
@@ -184,9 +182,11 @@ struct TagListTests {
 
   @Test("Invalid tag color decoding", arguments: [##""#NOTHEX""##, #""garbageColorName""#])
   func noTagColorsReadFromBadPath(tagColorJSON: String) throws {
-    let tagColorJSONData = try #require(tagColorJSON.data(using: .utf8))
-    #expect(throws: (any Error).self) {
-      _ = try JSONDecoder().decode(Tag.Color.self, from: tagColorJSONData)
+    var tagColorJSON = tagColorJSON
+    tagColorJSON.withUTF8 { tagColorJSON in
+      #expect(throws: (any Error).self) {
+        _ = try JSON.decode(Tag.Color.self, from: .init(tagColorJSON))
+      }
     }
   }
 #endif


### PR DESCRIPTION
This PR moves all our uses of `JSONEncoder` and `JSONDecoder` to a new namespace enum, `JSON`, and provides interfaces that don't use Foundation.

This change does _not_ remove our dependency on Foundation's JSON functionality, but it should allow us to replace that functionality in the future with JSON encoding/decoding logic from another library (or home-grown, if necessary.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
