### PR TITLE
Remove dependencies on Foundation's file handling APIs.

### DIFF
--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -71,6 +71,16 @@ struct FileHandle: ~Copyable, Sendable {
     self.init(unsafeCFILEHandle: fileHandle, closeWhenDone: true)
   }
 
+  /// Initialize an instance of this type to read from the given path.
+  ///
+  /// - Parameters:
+  ///   - path: The path to read from.
+  ///
+  /// - Throws: Any error preventing the stream from being opened.
+  init(forReadingAtPath path: String) throws {
+    try self.init(atPath: path, mode: "rb")
+  }
+
   /// Initialize an instance of this type to write to the given path.
   ///
   /// - Parameters:
@@ -205,6 +215,62 @@ struct FileHandle: ~Copyable, Sendable {
 #endif
       return try body()
     }
+  }
+}
+
+// MARK: - Reading
+
+extension FileHandle {
+  /// Read to the end of the file handle.
+  ///
+  /// - Returns: A copy of the contents of the file handle starting at the
+  ///   current offset and ending at the end of the file.
+  ///
+  /// - Throws: Any error that occurred while reading the file.
+  func readToEnd() throws -> [UInt8] {
+    var result = [UInt8]()
+
+    // If possible, reserve enough space in the resulting buffer to contain
+    // the contents of the file being read.
+    var size: Int?
+#if SWT_TARGET_OS_APPLE || os(Linux)
+    withUnsafePOSIXFileDescriptor { fd in
+      var s = stat()
+      if let fd, 0 == fstat(fd, &s) {
+        size = Int(exactly: s.st_size)
+      }
+    }
+#elseif os(Windows)
+    withUnsafeWindowsHANDLE { handle in
+      var liSize = LARGE_INTEGER(QuadPart: 0)
+      if let handle, GetFileSizeEx(handle, &liSize) {
+        size = Int(exactly: liSize.QuadPart)
+      }
+    }
+#endif
+    if let size, size > 0 {
+      result.reserveCapacity(size)
+    }
+
+    try withUnsafeCFILEHandle { file in
+      try withUnsafeTemporaryAllocation(byteCount: 1024, alignment: 1) { buffer in
+        while true {
+          let countRead = fread(buffer.baseAddress, 1, buffer.count, file)
+          if 0 != ferror(file) {
+            throw CError(rawValue: swt_errno())
+          }
+          if countRead > 0 {
+            let endIndex = buffer.index(buffer.startIndex, offsetBy: countRead)
+            result.append(contentsOf: buffer[..<endIndex])
+          }
+          if 0 != feof(file) {
+            break
+          }
+        }
+      }
+    }
+
+    return result
   }
 }
 
@@ -356,5 +422,31 @@ extension FileHandle {
     return false
 #endif
   }
+}
+
+// MARK: - General path utilities
+
+/// Append a path component to a path.
+///
+/// - Parameters:
+///   - pathComponent: The path component to append.
+///   - path: The path to which `pathComponent` should be appended.
+///
+/// - Returns: The full path to `pathComponent`, or `nil` if the resulting
+///   string could not be created.
+func appendPathComponent(_ pathComponent: String, to path: String) -> String {
+#if os(Windows)
+  path.withCString(encodedAs: UTF16.self) { path in
+    pathComponent.withCString(encodedAs: UTF16.self) { pathComponent in
+      withUnsafeTemporaryAllocation(of: wchar_t.self, capacity: wcslen(path) + wcslen(pathComponent) + 1) { buffer in
+        _ = wcscpy_s(buffer.baseAddress, buffer.count, path)
+        _ = PathCchAppendEx(buffer.baseAddress, buffer.count, pathComponent, ULONG(PATHCCH_ALLOW_LONG_PATHS.rawValue))
+        return (String.decodeCString(buffer.baseAddress, as: UTF16.self)?.result)!
+      }
+    }
+  }
+#else
+  "\(path)/\(pathComponent)"
+#endif
 }
 #endif

--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -438,7 +438,7 @@ func appendPathComponent(_ pathComponent: String, to path: String) -> String {
 #if os(Windows)
   path.withCString(encodedAs: UTF16.self) { path in
     pathComponent.withCString(encodedAs: UTF16.self) { pathComponent in
-      withUnsafeTemporaryAllocation(of: wchar_t.self, capacity: wcslen(path) + wcslen(pathComponent) + 1) { buffer in
+      withUnsafeTemporaryAllocation(of: wchar_t.self, capacity: (wcslen(path) + wcslen(pathComponent)) * 2 + 1) { buffer in
         _ = wcscpy_s(buffer.baseAddress, buffer.count, path)
         _ = PathCchAppendEx(buffer.baseAddress, buffer.count, pathComponent, ULONG(PATHCCH_ALLOW_LONG_PATHS.rawValue))
         return (String.decodeCString(buffer.baseAddress, as: UTF16.self)?.result)!

--- a/Sources/TestingInternals/include/Includes.h
+++ b/Sources/TestingInternals/include/Includes.h
@@ -75,6 +75,10 @@
 #include <pty.h>
 #endif
 
+#if __has_include(<pwd.h>)
+#include <pwd.h>
+#endif
+
 #if __has_include(<limits.h>)
 #include <limits.h>
 #endif

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -56,23 +56,27 @@ struct FileHandleTests {
 
   @Test("Can write to a file")
   func canWrite() throws {
-    // NOTE: we are not trying to test mkstemp() here. We are trying to test the
-    // capacity of FileHandle to open a file for writing, and need a temporary
-    // file to write to.
-#if os(Windows)
-    let path = try String(unsafeUninitializedCapacity: 1024) { buffer in
-      try #require(0 == tmpnam_s(buffer.baseAddress!, buffer.count))
-      return strnlen(buffer.baseAddress!, buffer.count)
+    try withTemporaryPath { path in
+      let fileHandle = try FileHandle(forWritingAtPath: path)
+      try fileHandle.write([0, 1, 2, 3, 4, 5])
+      try fileHandle.write("Hello world!")
     }
-#else
-    let path = "/tmp/can_write_to_file_\(UInt64.random(in: 0 ..< .max))"
-#endif
-    defer {
-      remove(path)
+  }
+
+  @Test("Can read from a file")
+  func canRead() throws {
+    let bytes: [UInt8] = (0 ..< 8192).map { _ in
+      UInt8.random(in: .min ... .max)
     }
-    let fileHandle = try FileHandle(forWritingAtPath: path)
-    try fileHandle.write([0, 1, 2, 3, 4, 5])
-    try fileHandle.write("Hello world!")
+    try withTemporaryPath { path in
+      do {
+        let fileHandle = try FileHandle(forWritingAtPath: path)
+        try fileHandle.write(bytes)
+      }
+      let fileHandle = try FileHandle(forReadingAtPath: path)
+      let bytes2 = try fileHandle.readToEnd()
+      #expect(bytes == bytes2)
+    }
   }
 
   @Test("Cannot write bytes to a read-only file")
@@ -159,6 +163,44 @@ struct FileHandleTests {
 }
 
 // MARK: - Fixtures
+
+func temporaryDirectory() throws -> String {
+#if SWT_TARGET_OS_APPLE
+  try withUnsafeTemporaryAllocation(of: CChar.self, capacity: Int(PATH_MAX)) { buffer in
+    if 0 != confstr(_CS_DARWIN_USER_TEMP_DIR, buffer.baseAddress, buffer.count) {
+      return String(cString: buffer.baseAddress!)
+    }
+    return try #require(Environment.variable(named: "TMPDIR"))
+  }
+#elseif os(Linux)
+  "/tmp"
+#elseif os(Windows)
+  try withUnsafeTemporaryAllocation(of: wchar_t.self, capacity: Int(MAX_PATH + 1)) { buffer in
+    if 0 == GetTempPath2W(DWORD(buffer.count), buffer.baseAddress) {
+      throw Win32Error(rawValue: GetLastError())
+    }
+    return try #require(String.decodeCString(buffer.baseAddress, as: UTF16.self)?.result)
+  }
+#endif
+}
+
+func withTemporaryPath<R>(_ body: (_ path: String) throws -> R) throws -> R {
+  // NOTE: we are not trying to test mkstemp() here. We are trying to test the
+  // capacity of FileHandle to open a file for reading or writing and we need a
+  // temporary file to write to.
+#if os(Windows)
+  let path = try String(unsafeUninitializedCapacity: 1024) { buffer in
+    try #require(0 == tmpnam_s(buffer.baseAddress!, buffer.count))
+    return strnlen(buffer.baseAddress!, buffer.count)
+  }
+#else
+  let path = appendPathComponent("file_named_\(UInt64.random(in: 0 ..< .max))", to: try temporaryDirectory())
+#endif
+  defer {
+    _ = remove(path)
+  }
+  return try body(path)
+}
 
 extension FileHandle {
   static func temporary() throws -> FileHandle {

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -176,7 +176,8 @@ func temporaryDirectory() throws -> String {
   "/tmp"
 #elseif os(Windows)
   try withUnsafeTemporaryAllocation(of: wchar_t.self, capacity: Int(MAX_PATH + 1)) { buffer in
-    if 0 == GetTempPath2W(DWORD(buffer.count), buffer.baseAddress) {
+    // NOTE: GetTempPath2W() was introduced in Windows 10 Build 20348.
+    if 0 == GetTempPathW(DWORD(buffer.count), buffer.baseAddress) {
       throw Win32Error(rawValue: GetLastError())
     }
     return try #require(String.decodeCString(buffer.baseAddress, as: UTF16.self)?.result)

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -9,9 +9,6 @@
 //
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
-#if canImport(Foundation)
-import Foundation
-#endif
 private import TestingInternals
 
 @Suite("Swift Package Manager Integration Tests")
@@ -130,26 +127,32 @@ struct SwiftPMTests {
     }
   }
 
-#if canImport(Foundation)
   @Test("--xunit-output argument (writes to file)")
   func xunitOutputIsWrittenToFile() throws {
     // Test that a file is opened when requested. Testing of the actual output
     // occurs in ConsoleOutputRecorderTests.
-    let temporaryFileURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: false)
+    let tempDirPath = try temporaryDirectory()
+    let temporaryFilePath = appendPathComponent("\(UInt64.random(in: 0 ..< .max))", to: tempDirPath)
     defer {
-      try? FileManager.default.removeItem(at: temporaryFileURL)
+      _ = remove(temporaryFilePath)
     }
     do {
-      let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--xunit-output", temporaryFileURL.path])
+      let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--xunit-output", temporaryFilePath])
       let eventContext = Event.Context()
       configuration.eventHandler(Event(.runStarted, testID: nil, testCaseID: nil), eventContext)
       configuration.eventHandler(Event(.runEnded, testID: nil, testCaseID: nil), eventContext)
     }
-    #expect(try temporaryFileURL.checkResourceIsReachable())
+
+    let fileHandle = try FileHandle(forReadingAtPath: temporaryFilePath)
+    let fileContents = try fileHandle.readToEnd()
+    #expect(!fileContents.isEmpty)
+    #expect(fileContents.contains(UInt8(ascii: "<")))
+    #expect(fileContents.contains(UInt8(ascii: ">")))
   }
 
-  func decodeEventStream(fromFileAt url: URL) throws -> [EventAndContextSnapshot] {
-    try Data(contentsOf: url, options: [.mappedIfSafe])
+#if canImport(Foundation)
+  func decodeEventStream(fromFileAtPath path: String) throws -> [EventAndContextSnapshot] {
+    try FileHandle(forReadingAtPath: path).readToEnd()
       .split(separator: 10) // "\n"
       .map { line in
         try line.withUnsafeBytes { line in
@@ -162,12 +165,13 @@ struct SwiftPMTests {
   func eventStreamOutput() async throws {
     // Test that events are successfully streamed to a file and can be read
     // back as snapshots.
-    let temporaryFileURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: false)
+    let tempDirPath = try temporaryDirectory()
+    let temporaryFilePath = appendPathComponent("\(UInt64.random(in: 0 ..< .max))", to: tempDirPath)
     defer {
-      try? FileManager.default.removeItem(at: temporaryFileURL)
+      _ = remove(temporaryFilePath)
     }
     do {
-      let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--experimental-event-stream-output", temporaryFileURL.path])
+      let configuration = try configurationForSwiftPMEntryPoint(withArguments: ["PATH", "--experimental-event-stream-output", temporaryFilePath])
       let eventContext = Event.Context()
       configuration.handleEvent(Event(.runStarted, testID: nil, testCaseID: nil), in: eventContext)
       do {
@@ -178,9 +182,8 @@ struct SwiftPMTests {
       }
       configuration.handleEvent(Event(.runEnded, testID: nil, testCaseID: nil), in: eventContext)
     }
-    #expect(try temporaryFileURL.checkResourceIsReachable())
 
-    let decodedEvents = try decodeEventStream(fromFileAt: temporaryFileURL)
+    let decodedEvents = try decodeEventStream(fromFileAtPath: temporaryFilePath)
     #expect(decodedEvents.count == 4)
   }
 #endif


### PR DESCRIPTION
This PR removes dependencies on Foundation's file handling APIs (`FileManager`, `URL`, `Data(contentsOf:)`, _et al._) in favor of directly using standard C API where possible via `FileHandle`.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
