### PR TITLE
Only block a single thread on Linux (and none on Windows) when waiting for exit tests.

### DIFF
--- a/Sources/Testing/ExitTests/WaitFor.swift
+++ b/Sources/Testing/ExitTests/WaitFor.swift
@@ -70,7 +70,7 @@ private let _createWaitThreadImpl: Void = {
         }
 
         // If we had a continuation for this PID, allow the process to be reaped
-        // and resume the caller and pass back the resulting exit condition. If
+        // and pass the resulting exit condition back to the calling task. If
         // there is no continuation, then either it hasn't been stored yet or
         // this child process is not tracked by the waiter thread.
         if let continuation, 0 == waitid(P_PID, id_t(pid), &siginfo, WEXITED) {

--- a/Sources/TestingInternals/include/Stubs.h
+++ b/Sources/TestingInternals/include/Stubs.h
@@ -88,25 +88,48 @@ SWT_EXTERN char *_Nullable *_Null_unspecified environ;
 static char *_Nullable *_Null_unspecified swt_environ(void) {
   return environ;
 }
+
+/// What process is associated with this instance of `siginfo_t`?
+///
+/// This function is provided because `si_pid` is a complex macro on some
+/// platforms and cannot be imported directly into Swift.
+static pid_t swt_siginfo_t_si_pid(const siginfo_t *siginfo) {
+  return siginfo->si_pid;
+}
 #endif
 
 #if __has_include(<sys/wait.h>)
+/// Does the given exit code indicate the process was signalled?
+///
+/// This function is provided because `WIFSIGNALED()` is a complex macro and
+/// cannot be imported directly into Swift.
 static bool swt_WIFSIGNALED(int exitCode) {
   return WIFSIGNALED(exitCode);
 }
 
+/// What signal was used to terminate the process?
+///
+/// This function is provided because `WTERMSIG()` is a complex macro and
+/// cannot be imported directly into Swift.
 static int swt_WTERMSIG(int exitCode) {
   return WTERMSIG(exitCode);
 }
 
+/// Does the given exit code indicate the process exited normally?
+///
+/// This function is provided because `WIFEXITED()` is a complex macro and
+/// cannot be imported directly into Swift.
 static bool swt_WIFEXITED(int exitCode) {
   return WIFEXITED(exitCode);
 }
 
+/// What exit code was used to terminate the process?
+///
+/// This function is provided because `WEXITSTATUS()` is a complex macro and
+/// cannot be imported directly into Swift.
 static int swt_WEXITSTATUS(int exitCode) {
   return WEXITSTATUS(exitCode);
 }
-
 #endif
 
 SWT_ASSUME_NONNULL_END

--- a/Sources/TestingInternals/include/Stubs.h
+++ b/Sources/TestingInternals/include/Stubs.h
@@ -90,47 +90,27 @@ static char *_Nullable *_Null_unspecified swt_environ(void) {
 }
 #endif
 
-#if __has_include(<signal.h>) && (defined(__linux__) || defined(__APPLE__))
-/// What process is associated with this instance of `siginfo_t`?
+#if __has_include(<signal.h>) && defined(si_pid)
+/// Get the value of the `si_pid` field of a `siginfo_t` structure.
 ///
 /// This function is provided because `si_pid` is a complex macro on some
-/// platforms and cannot be imported directly into Swift.
+/// platforms and cannot be imported directly into Swift. It is renamed back to
+/// `siginfo_t.si_pid` in Swift.
+SWT_SWIFT_NAME(getter:siginfo_t.si_pid(self:))
 static pid_t swt_siginfo_t_si_pid(const siginfo_t *siginfo) {
   return siginfo->si_pid;
 }
 #endif
 
-#if __has_include(<sys/wait.h>)
-/// Does the given exit code indicate the process was signalled?
+#if __has_include(<signal.h>) && defined(si_status)
+/// Get the value of the `si_status` field of a `siginfo_t` structure.
 ///
-/// This function is provided because `WIFSIGNALED()` is a complex macro and
-/// cannot be imported directly into Swift.
-static bool swt_WIFSIGNALED(int exitCode) {
-  return WIFSIGNALED(exitCode);
-}
-
-/// What signal was used to terminate the process?
-///
-/// This function is provided because `WTERMSIG()` is a complex macro and
-/// cannot be imported directly into Swift.
-static int swt_WTERMSIG(int exitCode) {
-  return WTERMSIG(exitCode);
-}
-
-/// Does the given exit code indicate the process exited normally?
-///
-/// This function is provided because `WIFEXITED()` is a complex macro and
-/// cannot be imported directly into Swift.
-static bool swt_WIFEXITED(int exitCode) {
-  return WIFEXITED(exitCode);
-}
-
-/// What exit code was used to terminate the process?
-///
-/// This function is provided because `WEXITSTATUS()` is a complex macro and
-/// cannot be imported directly into Swift.
-static int swt_WEXITSTATUS(int exitCode) {
-  return WEXITSTATUS(exitCode);
+/// This function is provided because `si_status` is a complex macro on some
+/// platforms and cannot be imported directly into Swift. It is renamed back to
+/// `siginfo_t.si_status` in Swift.
+SWT_SWIFT_NAME(getter:siginfo_t.si_status(self:))
+static pid_t swt_siginfo_t_si_status(const siginfo_t *siginfo) {
+  return siginfo->si_status;
 }
 #endif
 

--- a/Sources/TestingInternals/include/Stubs.h
+++ b/Sources/TestingInternals/include/Stubs.h
@@ -88,7 +88,9 @@ SWT_EXTERN char *_Nullable *_Null_unspecified environ;
 static char *_Nullable *_Null_unspecified swt_environ(void) {
   return environ;
 }
+#endif
 
+#if __has_include(<signal.h>) && (defined(__linux__) || defined(__APPLE__))
 /// What process is associated with this instance of `siginfo_t`?
 ///
 /// This function is provided because `si_pid` is a complex macro on some


### PR DESCRIPTION
This PR refines the implementation of exit tests on Linux so that multiple exit tests running concurrently only need to block a single thread rather than one thread per child process.

This PR also refines the implementation of exit tests on Windows to use `RegisterWaitForSingleObject()` for asynchronous notification of process termination rather than requiring a thread per child process.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
