### PR TITLE
Make Configuration.TestFilter a pure-data type

### DIFF
--- a/Sources/Testing/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/EntryPoints/EntryPoint.swift
@@ -337,8 +337,7 @@ public func configurationForSwiftPMEntryPoint(from args: __CommandLineArguments_
       throw _EntryPointError.featureUnavailable("The `\(label)' option is not supported on this OS version.")
     }
     return try regexes.lazy
-      .map { try Regex($0) }
-      .map { Configuration.TestFilter(membership: membership, matching: $0) }
+      .map { try Configuration.TestFilter(membership: membership, matching: $0) }
       .reduce(into: .unfiltered) { $0.combine(with: $1, using: .or) }
   }
   filters.append(try testFilter(forRegularExpressions: args.filter, label: "--filter", membership: .including))

--- a/Sources/Testing/Running/Configuration.TestFilter.swift
+++ b/Sources/Testing/Running/Configuration.TestFilter.swift
@@ -18,7 +18,7 @@ extension Configuration {
   public struct TestFilter: Sendable {
     /// An enumeration describing how to interpret the result of the underlying
     /// predicate function when applied to a test.
-    enum Membership: Sendable, Codable {
+    enum Membership: Sendable {
       /// The underlying predicate function determines if a test is included in
       /// the result.
       case including
@@ -29,7 +29,7 @@ extension Configuration {
     }
 
     /// An enumeration describing the various kinds of test filter.
-    fileprivate enum Kind: Sendable, Codable {
+    fileprivate enum Kind: Sendable {
       /// The test filter has no effect.
       ///
       /// All tests are allowed when passed to a test filter with this kind.
@@ -349,7 +349,7 @@ extension Configuration.TestFilter {
 extension Configuration.TestFilter {
   /// An enumeration describing operators that can be used to combine test
   /// filters when using ``combining(with:using:)`` or ``combine(with:using:)``.
-  public enum CombinationOperator: Sendable, Codable {
+  public enum CombinationOperator: Sendable {
     /// Both subfilters must allow a test for it to be allowed in the combined
     /// test filter.
     ///

--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -194,8 +194,9 @@ extension Runner.Plan {
       testGraph = try configuration.testFilter.apply(to: testGraph)
     } catch {
       // FIXME: Handle this more gracefully, either by propagating the error
-      // (which will ultimately require `Runner.init(...)` to be throwing) or
-      // recording a single `Issue` representing the planning failure.
+      // (which will ultimately require `Runner.init(...)` to be throwing:
+      // rdar://126631222) or by recording a single `Issue` representing the
+      // planning failure.
       //
       // For now, ignore the error and include all tests. As of this writing,
       // the only scenario where this will throw is when using regex filtering,

--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -190,7 +190,17 @@ extension Runner.Plan {
     // configuration. The action graph is not modified here: actions that lose
     // their corresponding tests are effectively filtered out by the call to
     // zip() near the end of the function.
-    testGraph = configuration.testFilter.apply(to: testGraph)
+    do {
+      testGraph = try configuration.testFilter.apply(to: testGraph)
+    } catch {
+      // FIXME: Handle this more gracefully, either by propagating the error
+      // (which will ultimately require `Runner.init(...)` to be throwing) or
+      // recording a single `Issue` representing the planning failure.
+      //
+      // For now, ignore the error and include all tests. As of this writing,
+      // the only scenario where this will throw is when using regex filtering,
+      // and that is already guarded earlier in the SwiftPM entry point.
+    }
 
     // For each test value, determine the appropriate action for it.
     //


### PR DESCRIPTION
This modifies the structure of `Configuration.TestFilter` so that it's a pure data type and is easier to become serializable.

### Motivation:

For easier integration with tools it would be helpful for the stored properties of `Configuration` to be serializable, or be trivially convertible to/from serializable types at least.

`Configuration`'s nested `TestFilter` type currently includes a closure for filtering tests and is therefore cannot be serialized in its current form. This type doesn't really need to _store_ a closure, however; it only needs to store information about how to perform filtering (e.g. data about criteria to match against), and later that can be interpreted when applying filtering.

### Modifications:

- Change the `Configuration.TestFilter.Kind` enum so that its cases only store data, and no closures.
- Move the filtering logic derived from the pure data `Kind` type above to a new `Configuration.TestFilter.Operation` enum.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Resolves rdar://126627664
