### PR TITLE
Add CustomStringConvertible and CustomDebugStringConvertible to Issue.Snapshot and Issue.Kind.Snapshot

### DIFF
--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -405,3 +405,54 @@ extension Issue.Kind {
     }
   }
 }
+
+// MARK: - Snapshot CustomStringConvertible, CustomDebugStringConvertible
+
+extension Issue.Snapshot: CustomStringConvertible, CustomDebugStringConvertible {
+  public var description: String {
+    if comments.isEmpty {
+      return String(describing: kind)
+    }
+    let joinedComments = comments.lazy
+      .map(\.rawValue)
+      .joined(separator: "\n")
+    return "\(kind): \(joinedComments)"
+  }
+
+  public var debugDescription: String {
+    if comments.isEmpty {
+      return "\(kind)\(sourceLocation.map { " at \($0)" } ?? "")"
+    }
+    let joinedComments: String = comments.lazy
+      .map(\.rawValue)
+      .joined(separator: "\n")
+    return "\(kind)\(sourceLocation.map { " at \($0)" } ?? ""): \(joinedComments)"
+  }
+}
+
+extension Issue.Kind.Snapshot: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case .unconditional:
+      "Unconditionally failed"
+    case let .expectationFailed(expectation):
+      if let mismatchedErrorDescription = expectation.mismatchedErrorDescription {
+        "Expectation failed: \(mismatchedErrorDescription)"
+      } else {
+        "Expectation failed: \(expectation.evaluatedExpression.expandedDescription())"
+      }
+    case let .confirmationMiscounted(actual: actual, expected: expected):
+      "Confirmation was confirmed \(actual.counting("time")), but expected to be confirmed \(expected.counting("time"))"
+    case let .errorCaught(error):
+      "Caught error: \(error)"
+    case let .timeLimitExceeded(timeLimitComponents: timeLimitComponents):
+      "Time limit was exceeded: \(TimeValue(timeLimitComponents))"
+    case .knownIssueNotRecorded:
+      "Known issue was not recorded"
+    case .apiMisused:
+      "An API was misused"
+    case .system:
+      "A system failure occurred"
+    }
+  }
+}


### PR DESCRIPTION
Make `Issue.Snapshot` and `Issue.Kind.Snapshot` conform to `CustomStringConvertible` and `CustomDebugStringConvertible` using the same implementation as their original types.

Resolves rdar://126646993