### PR TITLE
Block tests/suites in extensions to syntactic sugar types (`[T]`, `[T:U]`, `T?`)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
   ],
 
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.1"),
+    .package(url: "https://github.com/apple/swift-syntax.git", from: Version(stringLiteral: Context.environment["SWT_SWIFT_SYNTAX_VERSION"] ?? "510.0.1")),
   ],
 
   targets: [

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -33,7 +33,7 @@ let package = Package(
   ],
 
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.1"),
+    .package(url: "https://github.com/apple/swift-syntax.git", from: Version(stringLiteral: Context.environment["SWT_SWIFT_SYNTAX_VERSION"] ?? "510.0.1")),
   ],
 
   targets: [

--- a/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
@@ -122,9 +122,14 @@ func diagnoseIssuesWithLexicalContext(
 
   // Generic suites are not supported.
   if let genericClause = lexicalContext.asProtocol((any WithGenericParametersSyntax).self)?.genericParameterClause {
-    diagnostics.append(.genericDeclarationNotSupported(decl, whenUsing: attribute, becauseOf: genericClause))
+    diagnostics.append(.genericDeclarationNotSupported(decl, whenUsing: attribute, becauseOf: genericClause, on: lexicalContext))
   } else if let whereClause = lexicalContext.genericWhereClause {
-    diagnostics.append(.genericDeclarationNotSupported(decl, whenUsing: attribute, becauseOf: whereClause))
+    diagnostics.append(.genericDeclarationNotSupported(decl, whenUsing: attribute, becauseOf: whereClause, on: lexicalContext))
+  } else if [.arrayType, .dictionaryType, .optionalType, .implicitlyUnwrappedOptionalType].contains(lexicalContext.type.kind) {
+    // These types are all syntactic sugar over generic types (Array<T>,
+    // Dictionary<T>, and Optional<T>) and are just as unsupported. T! is
+    // unsupported in this position, but it's still forbidden so don't even try!
+    diagnostics.append(.genericDeclarationNotSupported(decl, whenUsing: attribute, becauseOf: lexicalContext.type, on: lexicalContext))
   }
 
   // Suites that are classes must be final.

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -101,13 +101,13 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
     // generic functions when they are parameterized and the types line up, we
     // have not identified a need for them.
     if let genericClause = function.genericParameterClause {
-      diagnostics.append(.genericDeclarationNotSupported(function, whenUsing: testAttribute, becauseOf: genericClause))
+      diagnostics.append(.genericDeclarationNotSupported(function, whenUsing: testAttribute, becauseOf: genericClause, on: function))
     } else if let whereClause = function.genericWhereClause {
-      diagnostics.append(.genericDeclarationNotSupported(function, whenUsing: testAttribute, becauseOf: whereClause))
+      diagnostics.append(.genericDeclarationNotSupported(function, whenUsing: testAttribute, becauseOf: whereClause, on: function))
     } else {
       for parameter in parameterList {
         if parameter.type.isSome {
-          diagnostics.append(.genericDeclarationNotSupported(function, whenUsing: testAttribute, becauseOf: parameter))
+          diagnostics.append(.genericDeclarationNotSupported(function, whenUsing: testAttribute, becauseOf: parameter, on: function))
         }
       }
     }

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -124,9 +124,9 @@ struct TestDeclarationMacroTests {
       "struct S { func f(x: Int) { @Suite struct S { } } }":
         "Attribute 'Suite' cannot be applied to a structure within function 'f(x:)'",
       "struct S<T> { @Test func f() {} }":
-        "Attribute 'Test' cannot be applied to a generic function",
+        "Attribute 'Test' cannot be applied to a function within generic structure 'S'",
       "struct S<T> { @Suite struct S {} }":
-        "Attribute 'Suite' cannot be applied to a generic structure",
+        "Attribute 'Suite' cannot be applied to a structure within generic structure 'S'",
       "class C { @Test func f() {} }":
         "Attribute 'Test' cannot be applied to a function within non-final class 'C'",
       "class C { @Suite struct S {} }":
@@ -143,6 +143,22 @@ struct TestDeclarationMacroTests {
         "Attribute 'Test' cannot be applied to this function because it has been marked '@available(*, noasync)'",
       "@available(*, noasync) struct S { @Suite struct S {} }":
         "Attribute 'Suite' cannot be applied to this structure because it has been marked '@available(*, noasync)'",
+      "extension [T] { @Test func f() {} }":
+        "Attribute 'Test' cannot be applied to a function within a generic extension to type '[T]'",
+      "extension [T] { @Suite struct S {} }":
+        "Attribute 'Suite' cannot be applied to a structure within a generic extension to type '[T]'",
+      "extension [T:U] { @Test func f() {} }":
+        "Attribute 'Test' cannot be applied to a function within a generic extension to type '[T:U]'",
+      "extension [T:U] { @Suite struct S {} }":
+        "Attribute 'Suite' cannot be applied to a structure within a generic extension to type '[T:U]'",
+      "extension T? { @Test func f() {} }":
+        "Attribute 'Test' cannot be applied to a function within a generic extension to type 'T?'",
+      "extension T? { @Suite struct S {} }":
+        "Attribute 'Suite' cannot be applied to a structure within a generic extension to type 'T?'",
+      "extension T! { @Test func f() {} }":
+        "Attribute 'Test' cannot be applied to a function within a generic extension to type 'T!'",
+      "extension T! { @Suite struct S {} }":
+        "Attribute 'Suite' cannot be applied to a structure within a generic extension to type 'T!'",
     ]
   )
   func invalidLexicalContext(input: String, expectedMessage: String) throws {
@@ -221,9 +237,10 @@ struct TestDeclarationMacroTests {
     ]
   )
   func availabilityAttributeCapture(input: String, expectedOutputs: [String]) throws {
-    let (actualOutput, _) = try parse(input)
+    let (actualOutput, _) = try parse(input, removeWhitespace: true)
 
     for expectedOutput in expectedOutputs {
+      let (expectedOutput, _) = try parse(expectedOutput, removeWhitespace: true)
       #expect(actualOutput.contains(expectedOutput))
     }
   }

--- a/Tests/TestingTests/Traits/TagListTests.swift
+++ b/Tests/TestingTests/Traits/TagListTests.swift
@@ -222,7 +222,7 @@ struct TagListTests {
     #expect(Tag.Color.rgb(0, 0, 0) < .rgb(100, 100, 100))
   }
 
-#if !SWT_NO_EXIT_TESTS && SWIFT_PM_SUPPORTS_SWIFT_TESTING
+#if !SWT_NO_EXIT_TESTS && SWIFT_PM_SUPPORTS_SWIFT_TESTING && !canImport(SwiftSyntax600)
   @Test("Invalid symbolic tag declaration")
   func invalidSymbolicTag() async {
     await #expect(exitsWith: .failure) {


### PR DESCRIPTION
This PR blocks tests and suites in extensions to types declared using syntactic sugar. For example, the following is invalid:

```swift
extension [Int] {
  @Test func f() {}
}
```

I doubt this is going to be a common pattern, but it's just as invalid as saying `extension Array<Int>` for the same reasons: if it successfully compiles, it produces metadata for a test that we cannot instantiate at runtime (because the type we can see in the metadata is still generic, not specialized.)

There is a guard symbol emitted by our macro already that triggers a diagnostic if a test or suite is in a generic type, but `extension [T]` is fully specialized and does not trigger the diagnostic, so it's important that we catch this issue and make sure some diagnostic is emitted.

With this change, when using swift-syntax-600, you should now see:

```swift
extension [Int] {
  @Test func f() {} // 🛑 Attribute 'Test' cannot be applied to a function
                    // within a generic extension to type '[Int]'
}
```

This PR also introduces an environment variable you can set when running `swift test` to opt into a different swift-syntax version, which makes testing with swift-syntax-600 easier. This diagnostic will be removed as redundant if/when #338 is merged.

Finally, this PR fixes some unrelated unit tests that fail when using swift-syntax-600.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
