### PR TITLE
Fix the Linux build using the 5.10 toolchain.

### DIFF
--- a/Sources/Testing/ExitTests/WaitFor.swift
+++ b/Sources/Testing/ExitTests/WaitFor.swift
@@ -46,15 +46,6 @@ private let _waitThreadNoChildrenCondition = {
   return UncheckedSendable(rawValue: result)
 }()
 
-#if os(Linux)
-/// Set the name of the current thread.
-///
-/// This function declaration is provided because `pthread_setname_np()` is
-/// only declared if `_GNU_SOURCE` is set, but setting it causes build errors
-/// due to conflicts with Swift's Glibc module.
-@_extern(c) func pthread_setname_np(_: pthread_t, _: UnsafePointer<CChar>) -> CInt
-#endif
-
 /// The implementation of `_createWaitThread()`, run only once.
 private let _createWaitThreadImpl: Void = {
   // The body of the thread's run loop.

--- a/Sources/TestingInternals/include/Stubs.h
+++ b/Sources/TestingInternals/include/Stubs.h
@@ -88,6 +88,13 @@ SWT_EXTERN char *_Nullable *_Null_unspecified environ;
 static char *_Nullable *_Null_unspecified swt_environ(void) {
   return environ;
 }
+
+/// Set the name of the current thread.
+///
+/// This function declaration is provided because `pthread_setname_np()` is
+/// only declared if `_GNU_SOURCE` is set, but setting it causes build errors
+/// due to conflicts with Swift's Glibc module.
+SWT_IMPORT_FROM_STDLIB int pthread_setname_np(pthread_t, const char *);
 #endif
 
 #if __has_include(<signal.h>) && defined(si_pid)


### PR DESCRIPTION
`@_extern(c)` is new in 6.0, so let's just declare `pthread_setname_np()` in Stubs.h.

See https://ci.swift.org/job/swift-testing-main-swift-5.10-linux/204/console for more information on the build failure.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
