### PR TITLE
Unlock expression expansions for negated expressions.

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -371,7 +371,7 @@ extension Event.HumanReadableOutputRecorder {
       if verbose, case let .expectationFailed(expectation) = issue.kind {
         let expression = expectation.evaluatedExpression
         func addMessage(about expression: Expression) {
-          let description = expression.expandedDescription(includingTypeNames: true, includingParenthesesIfNeeded: false)
+          let description = expression.expandedDebugDescription()
           additionalMessages.append(Message(symbol: .details, stringValue: description))
         }
         let subexpressions = expression.subexpressions

--- a/Sources/Testing/Parameterization/TypeInfo.swift
+++ b/Sources/Testing/Parameterization/TypeInfo.swift
@@ -45,21 +45,6 @@ public struct TypeInfo: Sendable {
     return nil
   }
 
-  /// Check if this instance describes a given type.
-  ///
-  /// - Parameters:
-  ///   - type: The type to compare against.
-  ///
-  /// - Returns: Whether or not this instance represents `type`.
-  public func describes(_ type: Any.Type) -> Bool {
-    switch _kind {
-    case let .type(selfType):
-      type == selfType
-    case .nameOnly:
-      TypeInfo(describing: type).fullyQualifiedNameComponents == fullyQualifiedNameComponents
-    }
-  }
-
   init(fullyQualifiedName: String, unqualifiedName: String, mangledName: String?) {
     _kind = .nameOnly(
       fullyQualifiedComponents: fullyQualifiedName.split(separator: ".").map(String.init),
@@ -296,6 +281,16 @@ extension TypeInfo: CustomStringConvertible, CustomDebugStringConvertible {
 // MARK: - Equatable, Hashable
 
 extension TypeInfo: Hashable {
+  /// Check if this instance describes a given type.
+  ///
+  /// - Parameters:
+  ///   - type: The type to compare against.
+  ///
+  /// - Returns: Whether or not this instance represents `type`.
+  public func describes(_ type: Any.Type) -> Bool {
+    self == TypeInfo(describing: type)
+  }
+
   public static func ==(lhs: Self, rhs: Self) -> Bool {
     switch (lhs._kind, rhs._kind) {
     case let (.type(lhs), .type(rhs)):

--- a/Sources/Testing/Parameterization/TypeInfo.swift
+++ b/Sources/Testing/Parameterization/TypeInfo.swift
@@ -45,6 +45,21 @@ public struct TypeInfo: Sendable {
     return nil
   }
 
+  /// Check if this instance describes a given type.
+  ///
+  /// - Parameters:
+  ///   - type: The type to compare against.
+  ///
+  /// - Returns: Whether or not this instance represents `type`.
+  public func describes(_ type: Any.Type) -> Bool {
+    switch _kind {
+    case let .type(selfType):
+      type == selfType
+    case .nameOnly:
+      TypeInfo(describing: type).fullyQualifiedNameComponents == fullyQualifiedNameComponents
+    }
+  }
+
   init(fullyQualifiedName: String, unqualifiedName: String, mangledName: String?) {
     _kind = .nameOnly(
       fullyQualifiedComponents: fullyQualifiedName.split(separator: ".").map(String.init),

--- a/Sources/Testing/SourceAttribution/Expression+Macro.swift
+++ b/Sources/Testing/SourceAttribution/Expression+Macro.swift
@@ -66,7 +66,7 @@ extension Expression {
   ///
   /// - Warning: This function is used to implement the `@Test`, `@Suite`,
   ///   `#expect()` and `#require()` macros. Do not call it directly.
-  public static func __functionCall(_ value: Expression?, _ functionName: String, _ arguments: (label: String?, value: Expression)...) -> Self {
+  public static func __fromFunctionCall(_ value: Expression?, _ functionName: String, _ arguments: (label: String?, value: Expression)...) -> Self {
     let arguments = arguments.map(Expression.Kind.FunctionCallArgument.init)
     return Self(kind: .functionCall(value: value, functionName: functionName, arguments: arguments))
   }
@@ -84,5 +84,22 @@ extension Expression {
   ///   `#expect()` and `#require()` macros. Do not call it directly.
   public static func __fromPropertyAccess(_ value: Expression, _ keyPath: Expression) -> Self {
     return Self(kind: .propertyAccess(value: value, keyPath: keyPath))
+  }
+
+  /// Create an instance of ``Expression`` representing a negated expression
+  /// using the `!` operator..
+  ///
+  /// - Parameters:
+  ///   - expression: The expression that was negated.
+  ///   - isParenthetical: Whether or not `expression` was enclosed in
+  ///     parentheses (and the `!` operator was outside it.) This argument
+  ///     affects how this expression is represented as a string.
+  ///
+  /// - Returns: A new instance of ``Expression``.
+  ///
+  /// - Warning: This function is used to implement the `@Test`, `@Suite`,
+  ///   `#expect()` and `#require()` macros. Do not call it directly.
+  public static func __fromNegation(_ expression: Expression, _ isParenthetical: Bool) -> Self {
+    return Self(kind: .negation(expression, isParenthetical: isParenthetical))
   }
 }

--- a/Sources/Testing/SourceAttribution/Expression.swift
+++ b/Sources/Testing/SourceAttribution/Expression.swift
@@ -78,6 +78,18 @@ public struct Expression: Sendable {
     ///   - keyPath: The key path, relative to `value`, that was accessed, not
     ///     including a leading backslash or period.
     indirect case propertyAccess(value: Expression, keyPath: Expression)
+
+    /// The expression negates another expression.
+    ///
+    /// - Parameters:
+    ///   - expression: The expression that was negated.
+    ///   - isParenthetical: Whether or not `expression` was enclosed in
+    ///     parentheses (and the `!` operator was outside it.) This argument
+    ///     affects how this expression is represented as a string.
+    ///
+    /// Unlike other cases in this enumeration, this case affects the runtime
+    /// behavior of the `__check()` family of functions.
+    indirect case negation(_ expression: Expression, isParenthetical: Bool)
   }
 
   /// The kind of syntax node represented by this instance.
@@ -109,6 +121,12 @@ public struct Expression: Sendable {
       return "\(functionName)(\(argumentList))"
     case let .propertyAccess(value, keyPath):
       return "\(value.sourceCode).\(keyPath.sourceCode)"
+    case let .negation(expression, isParenthetical):
+      var sourceCode = expression.sourceCode
+      if isParenthetical {
+        sourceCode = "(\(sourceCode))"
+      }
+      return "!\(sourceCode)"
     }
   }
 
@@ -192,6 +210,9 @@ public struct Expression: Sendable {
   func capturingRuntimeValue(_ value: (some Any)?) -> Self {
     var result = self
     result.runtimeValue = value.map { Value(reflecting: $0) }
+    if case let .negation(subexpression, isParenthetical) = kind, let value = value as? Bool {
+      result.kind = .negation(subexpression.capturingRuntimeValue(!value), isParenthetical: isParenthetical)
+    }
     return result
   }
 
@@ -237,39 +258,94 @@ public struct Expression: Sendable {
         value: value.capturingRuntimeValues(firstValue),
         keyPath: keyPath.capturingRuntimeValues(additionalValuesArray.first ?? nil)
       )
+    case let .negation(expression, isParenthetical):
+      result.kind = .negation(
+        expression.capturingRuntimeValues(firstValue, repeat each additionalValues),
+        isParenthetical: isParenthetical
+      )
     }
 
     return result
+  }
+
+
+  /// Get an expanded description of this instance that contains the source
+  /// code and runtime value (or values) it represents.
+  ///
+  /// - Returns: A string describing this instance.
+  @_spi(ForToolsIntegrationOnly)
+  public func expandedDescription() -> String {
+    _expandedDescription(in: _ExpandedDescriptionContext())
+  }
+
+  /// Get an expanded description of this instance that contains the source
+  /// code and runtime value (or values) it represents.
+  ///
+  /// - Returns: A string describing this instance.
+  ///
+  /// This function produces a more detailed description than
+  /// ``expandedDescription()``, similar to how `String(reflecting:)` produces
+  /// a more detailed description than `String(describing:)`.
+  func expandedDebugDescription() -> String {
+    var context = _ExpandedDescriptionContext()
+    context.includeTypeNames = true
+    context.includeParenthesesIfNeeded = false
+    return _expandedDescription(in: context)
+  }
+
+  /// A structure describing the state tracked while calling
+  /// `_expandedDescription(in:)`.
+  private struct _ExpandedDescriptionContext {
+    /// The depth of recursion at which the function is being called.
+    var depth = 0
+
+    /// Whether or not to include type names in output.
+    var includeTypeNames = false
+
+    /// Whether or not to enclose the resulting string in parentheses (as needed
+    /// depending on what information the resulting string contains.)
+    var includeParenthesesIfNeeded = true
   }
 
   /// Get an expanded description of this instance that contains the source
   /// code and runtime value (or values) it represents.
   ///
   /// - Parameters:
-  ///   - depth: The depth of recursion at which this function is being called.
-  ///   - includingTypeNames: Whether or not to include type names in output.
-  ///   - includingParenthesesIfNeeded: Whether or not to enclose the
-  ///     resulting string in parentheses (as needed depending on what
-  ///     information this instance contains.)
+  ///   - context: The context for this call.
   ///
   /// - Returns: A string describing this instance.
-  @_spi(ForToolsIntegrationOnly)
-  public func expandedDescription(depth: Int = 0, includingTypeNames: Bool = false, includingParenthesesIfNeeded: Bool = true) -> String {
+  ///
+  /// This function provides the implementation of ``expandedDescription()`` and
+  /// ``expandedDebugDescription()``.
+  private func _expandedDescription(in context: _ExpandedDescriptionContext) -> String {
+    // Create a (default) context value to pass to recursive calls for
+    // subexpressions.
+    var childContext = context
+    do {
+      // Bump the depth so that recursive calls track the next depth level.
+      childContext.depth += 1
+
+      // Subexpressions do not automatically disable parentheses if the parent
+      // does; they must opt in.
+      childContext.includeParenthesesIfNeeded = true
+    }
+
     var result = ""
     switch kind {
     case let .generic(sourceCode), let .stringLiteral(sourceCode, _):
-      result = if includingTypeNames, let qualifiedName = runtimeValue?.typeInfo.fullyQualifiedName {
+      result = if context.includeTypeNames, let qualifiedName = runtimeValue?.typeInfo.fullyQualifiedName {
         "\(sourceCode): \(qualifiedName)"
       } else {
         sourceCode
       }
     case let .binaryOperation(lhsExpr, op, rhsExpr):
-      result = "\(lhsExpr.expandedDescription(depth: depth + 1)) \(op) \(rhsExpr.expandedDescription(depth: depth + 1))"
+      result = "\(lhsExpr._expandedDescription(in: childContext)) \(op) \(rhsExpr._expandedDescription(in: childContext))"
     case let .functionCall(value, functionName, arguments):
-      let includeParentheses = arguments.count > 1
+      var argumentContext = childContext
+      argumentContext.includeParenthesesIfNeeded = (arguments.count > 1)
       let argumentList = arguments.lazy
         .map { argument in
-          (argument.label, argument.value.expandedDescription(depth: depth + 1, includingParenthesesIfNeeded: includeParentheses))
+          (argument.label, argument.value._expandedDescription(in: argumentContext))
         }.map { label, value in
           if let label {
             return "\(label): \(value)"
@@ -277,18 +353,34 @@ public struct Expression: Sendable {
           return value
         }.joined(separator: ", ")
       result = if let value {
-        "\(value.expandedDescription(depth: depth + 1)).\(functionName)(\(argumentList))"
+        "\(value._expandedDescription(in: childContext)).\(functionName)(\(argumentList))"
       } else {
         "\(functionName)(\(argumentList))"
       }
     case let .propertyAccess(value, keyPath):
-      result = "\(value.expandedDescription(depth: depth + 1)).\(keyPath.expandedDescription(depth: depth + 1, includingParenthesesIfNeeded: false))"
+      var keyPathContext = childContext
+      keyPathContext.includeParenthesesIfNeeded = false
+      result = "\(value._expandedDescription(in: childContext)).\(keyPath._expandedDescription(in: keyPathContext))"
+    case let .negation(expression, isParenthetical):
+      childContext.includeParenthesesIfNeeded = !isParenthetical
+      var expandedDescription = expression._expandedDescription(in: childContext)
+      if isParenthetical {
+        expandedDescription = "(\(expandedDescription))"
+      }
+      result = "!\(expandedDescription)"
     }
 
-    // If this expression is at the root of the expression graph and has no
-    // value, don't bother reporting the placeholder string for it.
-    if depth == 0 && runtimeValue == nil {
-      return result
+    // If this expression is at the root of the expression graph...
+    if context.depth == 0 {
+      if runtimeValue == nil {
+        // ... and has no value, don't bother reporting the placeholder string
+        // for it...
+        return result
+      } else if let runtimeValue, runtimeValue.typeInfo.describes(Bool.self) {
+        // ... or if it is a boolean value, also don't bother (because it can be
+        // inferred from context.)
+        return result
+      }
     }
 
     let runtimeValueDescription = runtimeValue.map(String.init(describing:)) ?? "<not evaluated>"
@@ -297,7 +389,7 @@ public struct Expression: Sendable {
       result
     } else if runtimeValueDescription == result {
       result
-    } else if includingParenthesesIfNeeded && depth > 0 {
+    } else if context.includeParenthesesIfNeeded && context.depth > 0 {
       "(\(result) → \(runtimeValueDescription))"
     } else {
       "\(result) → \(runtimeValueDescription)"
@@ -322,6 +414,8 @@ public struct Expression: Sendable {
       }
     case let .propertyAccess(value: value, keyPath: keyPath):
       [value, keyPath]
+    case let .negation(expression, _):
+      [expression]
     }
   }
 

--- a/Sources/Testing/SourceAttribution/Expression.swift
+++ b/Sources/Testing/SourceAttribution/Expression.swift
@@ -268,7 +268,6 @@ public struct Expression: Sendable {
     return result
   }
 
-
   /// Get an expanded description of this instance that contains the source
   /// code and runtime value (or values) it represents.
   ///

--- a/Sources/TestingMacros/Support/SourceCodeCapturing.swift
+++ b/Sources/TestingMacros/Support/SourceCodeCapturing.swift
@@ -81,9 +81,18 @@ func createExpressionExprForFunctionCall(_ value: (any SyntaxProtocol)?, _ funct
     }
   }
 
-  return ".__functionCall(\(arguments))"
+  return ".__fromFunctionCall(\(arguments))"
 }
 
+/// Get a swift-syntax expression initializing an instance of ``Expression``
+/// from an arbitrary sequence of syntax nodes representing a property access.
+///
+/// - Parameters:
+///   - value: The value on which the property is being accessed, if any.
+///   - keyPath: The name of the property being accessed.
+///
+/// - Returns: An expression value that initializes an instance of
+///   ``Expression`` for the specified syntax nodes.
 func createExpressionExprForPropertyAccess(_ value: ExprSyntax, _ keyPath: DeclReferenceExprSyntax) -> ExprSyntax {
   let arguments = LabeledExprListSyntax {
     LabeledExprSyntax(expression: createExpressionExpr(from: value))
@@ -91,4 +100,22 @@ func createExpressionExprForPropertyAccess(_ value: ExprSyntax, _ keyPath: DeclR
   }
 
   return ".__fromPropertyAccess(\(arguments))"
+}
+
+/// Get a swift-syntax expression initializing an instance of ``Expression``
+/// from an arbitrary sequence of syntax nodes representing the negation of
+/// another expression.
+///
+/// - Parameters:
+///   - expression: An expression representing a previously-initialized instance
+///     of ``Expression`` (that is, not the expression in source, but the result
+///     of a call to ``createExpressionExpr(from:)`` etc.)
+///   - isParenthetical: Whether or not `expression` was enclosed in
+///     parentheses (and the `!` operator was outside it.) This argument
+///     affects how this expression is represented as a string.
+///
+/// - Returns: An expression value that initializes an instance of
+///   ``Expression`` for the specified syntax nodes.
+func createExpressionExprForNegation(of expression: ExprSyntax, isParenthetical: Bool) -> ExprSyntax {
+  ".__fromNegation(\(expression.trimmed), \(literal: isParenthetical))"
 }

--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -37,7 +37,7 @@ struct ConditionMacroTests {
       ##"#expect("a" == "b")"##:
         ##"Testing.__checkBinaryOperation("a", { $0 == $1() }, "b", expression: .__fromBinaryOperation(.__fromStringLiteral(#""a""#, "a"), "==", .__fromStringLiteral(#""b""#, "b")), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(!Bool.random())"##:
-        ##"Testing.__checkValue(!Bool.random(), expression: .__fromSyntaxNode("!Bool.random()"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkFunctionCall(Bool.self, calling: { $0.random() }, expression: .__fromNegation(.__fromFunctionCall(.__fromSyntaxNode("Bool"), "random"), false), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect((true && false))"##:
         ##"Testing.__checkBinaryOperation(true, { $0 && $1() }, false, expression: .__fromBinaryOperation(.__fromSyntaxNode("true"), "&&", .__fromSyntaxNode("false")), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(try x())"##:
@@ -53,15 +53,15 @@ struct ConditionMacroTests {
       ##"#expect(a, "b", c: c)"##:
         ##"Testing.__checkValue(a, c: c, expression: .__fromSyntaxNode("a"), comments: ["b"], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(a())"##:
-        ##"Testing.__checkFunctionCall((), calling: { _ in a() }, expression: .__functionCall(nil, "a"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkFunctionCall((), calling: { _ in a() }, expression: .__fromFunctionCall(nil, "a"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(b(c))"##:
-        ##"Testing.__checkFunctionCall((), calling: { b($1) }, c, expression: .__functionCall(nil, "b", (nil, .__fromSyntaxNode("c"))), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkFunctionCall((), calling: { b($1) }, c, expression: .__fromFunctionCall(nil, "b", (nil, .__fromSyntaxNode("c"))), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(a.b(c))"##:
-        ##"Testing.__checkFunctionCall(a.self, calling: { $0.b($1) }, c, expression: .__functionCall(.__fromSyntaxNode("a"), "b", (nil, .__fromSyntaxNode("c"))), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkFunctionCall(a.self, calling: { $0.b($1) }, c, expression: .__fromFunctionCall(.__fromSyntaxNode("a"), "b", (nil, .__fromSyntaxNode("c"))), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(a.b(c, d: e))"##:
-        ##"Testing.__checkFunctionCall(a.self, calling: { $0.b($1, d: $2) }, c, e, expression: .__functionCall(.__fromSyntaxNode("a"), "b", (nil, .__fromSyntaxNode("c")), ("d", .__fromSyntaxNode("e"))), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkFunctionCall(a.self, calling: { $0.b($1, d: $2) }, c, e, expression: .__fromFunctionCall(.__fromSyntaxNode("a"), "b", (nil, .__fromSyntaxNode("c")), ("d", .__fromSyntaxNode("e"))), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(a.b(&c))"##:
-        ##"Testing.__checkInoutFunctionCall(a.self, calling: { $0.b(&$1) }, &c, expression: .__functionCall(.__fromSyntaxNode("a"), "b", (nil, .__fromSyntaxNode("&c"))), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkInoutFunctionCall(a.self, calling: { $0.b(&$1) }, &c, expression: .__fromFunctionCall(.__fromSyntaxNode("a"), "b", (nil, .__fromSyntaxNode("&c"))), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(a.b(&c, &d))"##:
         ##"Testing.__checkValue(a.b(&c, &d), expression: .__fromSyntaxNode("a.b(&c, &d)"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(a.b(&c, d))"##:
@@ -69,15 +69,15 @@ struct ConditionMacroTests {
       ##"#expect(a.b(try c()))"##:
         ##"Testing.__checkValue(a.b(try c()), expression: .__fromSyntaxNode("a.b(try c())"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(a?.b(c))"##:
-        ##"Testing.__checkFunctionCall(a.self, calling: { $0?.b($1) }, c, expression: .__functionCall(.__fromSyntaxNode("a"), "b", (nil, .__fromSyntaxNode("c"))), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkFunctionCall(a.self, calling: { $0?.b($1) }, c, expression: .__fromFunctionCall(.__fromSyntaxNode("a"), "b", (nil, .__fromSyntaxNode("c"))), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(a???.b(c))"##:
-        ##"Testing.__checkFunctionCall(a.self, calling: { $0???.b($1) }, c, expression: .__functionCall(.__fromSyntaxNode("a"), "b", (nil, .__fromSyntaxNode("c"))), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkFunctionCall(a.self, calling: { $0???.b($1) }, c, expression: .__fromFunctionCall(.__fromSyntaxNode("a"), "b", (nil, .__fromSyntaxNode("c"))), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(a?.b.c(d))"##:
-        ##"Testing.__checkFunctionCall(a?.b.self, calling: { $0?.c($1) }, d, expression: .__functionCall(.__fromSyntaxNode("a?.b"), "c", (nil, .__fromSyntaxNode("d"))), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkFunctionCall(a?.b.self, calling: { $0?.c($1) }, d, expression: .__fromFunctionCall(.__fromSyntaxNode("a?.b"), "c", (nil, .__fromSyntaxNode("d"))), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect({}())"##:
         ##"Testing.__checkValue({}(), expression: .__fromSyntaxNode("{}()"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(a.b(c: d))"##:
-        ##"Testing.__checkFunctionCall(a.self, calling: { $0.b(c: $1) }, d, expression: .__functionCall(.__fromSyntaxNode("a"), "b", ("c", .__fromSyntaxNode("d"))), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
+        ##"Testing.__checkFunctionCall(a.self, calling: { $0.b(c: $1) }, d, expression: .__fromFunctionCall(.__fromSyntaxNode("a"), "b", ("c", .__fromSyntaxNode("d"))), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(a.b { c })"##:
         ##"Testing.__checkValue(a.b { c }, expression: .__fromSyntaxNode("a.b { c }"), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation()).__expected()"##,
       ##"#expect(a, sourceLocation: someValue)"##:
@@ -113,7 +113,7 @@ struct ConditionMacroTests {
       ##"#require("a" == "b")"##:
         ##"Testing.__checkBinaryOperation("a", { $0 == $1() }, "b", expression: .__fromBinaryOperation(.__fromStringLiteral(#""a""#, "a"), "==", .__fromStringLiteral(#""b""#, "b")), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(!Bool.random())"##:
-        ##"Testing.__checkValue(!Bool.random(), expression: .__fromSyntaxNode("!Bool.random()"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkFunctionCall(Bool.self, calling: { $0.random() }, expression: .__fromNegation(.__fromFunctionCall(.__fromSyntaxNode("Bool"), "random"), false), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require((true && false))"##:
         ##"Testing.__checkBinaryOperation(true, { $0 && $1() }, false, expression: .__fromBinaryOperation(.__fromSyntaxNode("true"), "&&", .__fromSyntaxNode("false")), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(try x())"##:
@@ -129,15 +129,15 @@ struct ConditionMacroTests {
       ##"#require(a, "b", c: c)"##:
         ##"Testing.__checkValue(a, c: c, expression: .__fromSyntaxNode("a"), comments: ["b"], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(a())"##:
-        ##"Testing.__checkFunctionCall((), calling: { _ in a() }, expression: .__functionCall(nil, "a"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkFunctionCall((), calling: { _ in a() }, expression: .__fromFunctionCall(nil, "a"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(b(c))"##:
-        ##"Testing.__checkFunctionCall((), calling: { b($1) }, c, expression: .__functionCall(nil, "b", (nil, .__fromSyntaxNode("c"))), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkFunctionCall((), calling: { b($1) }, c, expression: .__fromFunctionCall(nil, "b", (nil, .__fromSyntaxNode("c"))), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(a.b(c))"##:
-        ##"Testing.__checkFunctionCall(a.self, calling: { $0.b($1) }, c, expression: .__functionCall(.__fromSyntaxNode("a"), "b", (nil, .__fromSyntaxNode("c"))), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkFunctionCall(a.self, calling: { $0.b($1) }, c, expression: .__fromFunctionCall(.__fromSyntaxNode("a"), "b", (nil, .__fromSyntaxNode("c"))), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(a.b(c, d: e))"##:
-        ##"Testing.__checkFunctionCall(a.self, calling: { $0.b($1, d: $2) }, c, e, expression: .__functionCall(.__fromSyntaxNode("a"), "b", (nil, .__fromSyntaxNode("c")), ("d", .__fromSyntaxNode("e"))), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkFunctionCall(a.self, calling: { $0.b($1, d: $2) }, c, e, expression: .__fromFunctionCall(.__fromSyntaxNode("a"), "b", (nil, .__fromSyntaxNode("c")), ("d", .__fromSyntaxNode("e"))), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(a.b(&c))"##:
-        ##"Testing.__checkInoutFunctionCall(a.self, calling: { $0.b(&$1) }, &c, expression: .__functionCall(.__fromSyntaxNode("a"), "b", (nil, .__fromSyntaxNode("&c"))), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkInoutFunctionCall(a.self, calling: { $0.b(&$1) }, &c, expression: .__fromFunctionCall(.__fromSyntaxNode("a"), "b", (nil, .__fromSyntaxNode("&c"))), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(a.b(&c, &d))"##:
         ##"Testing.__checkValue(a.b(&c, &d), expression: .__fromSyntaxNode("a.b(&c, &d)"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(a.b(&c, d))"##:
@@ -145,15 +145,15 @@ struct ConditionMacroTests {
       ##"#require(a.b(try c()))"##:
         ##"Testing.__checkValue(a.b(try c()), expression: .__fromSyntaxNode("a.b(try c())"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(a?.b(c))"##:
-        ##"Testing.__checkFunctionCall(a.self, calling: { $0?.b($1) }, c, expression: .__functionCall(.__fromSyntaxNode("a"), "b", (nil, .__fromSyntaxNode("c"))), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkFunctionCall(a.self, calling: { $0?.b($1) }, c, expression: .__fromFunctionCall(.__fromSyntaxNode("a"), "b", (nil, .__fromSyntaxNode("c"))), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(a???.b(c))"##:
-        ##"Testing.__checkFunctionCall(a.self, calling: { $0???.b($1) }, c, expression: .__functionCall(.__fromSyntaxNode("a"), "b", (nil, .__fromSyntaxNode("c"))), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkFunctionCall(a.self, calling: { $0???.b($1) }, c, expression: .__fromFunctionCall(.__fromSyntaxNode("a"), "b", (nil, .__fromSyntaxNode("c"))), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(a?.b.c(d))"##:
-        ##"Testing.__checkFunctionCall(a?.b.self, calling: { $0?.c($1) }, d, expression: .__functionCall(.__fromSyntaxNode("a?.b"), "c", (nil, .__fromSyntaxNode("d"))), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkFunctionCall(a?.b.self, calling: { $0?.c($1) }, d, expression: .__fromFunctionCall(.__fromSyntaxNode("a?.b"), "c", (nil, .__fromSyntaxNode("d"))), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require({}())"##:
         ##"Testing.__checkValue({}(), expression: .__fromSyntaxNode("{}()"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(a.b(c: d))"##:
-        ##"Testing.__checkFunctionCall(a.self, calling: { $0.b(c: $1) }, d, expression: .__functionCall(.__fromSyntaxNode("a"), "b", ("c", .__fromSyntaxNode("d"))), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
+        ##"Testing.__checkFunctionCall(a.self, calling: { $0.b(c: $1) }, d, expression: .__fromFunctionCall(.__fromSyntaxNode("a"), "b", ("c", .__fromSyntaxNode("d"))), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(a.b { c })"##:
         ##"Testing.__checkValue(a.b { c }, expression: .__fromSyntaxNode("a.b { c }"), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation()).__required()"##,
       ##"#require(a, sourceLocation: someValue)"##:


### PR DESCRIPTION
This PR enables expression expansion for expressions of the forms `!x`, `!f()`, `!y.g()`, etc. such that the value of the expressions they negate are available at runtime to inspect in a test failure. For example, consider this test:

```swift
func f() -> Int { 123 }
func g() -> Int { 123 }

@Test func myTest() {
  #expect(!(f() == g())) // ♦️ Expectation failed: !(f() == g())
}
```

(i.e., testing that the result of `f()` is not equal to the result of `g()`, but using `!(==)` instead of the more typical `!=`.)

This is a trivial/contrived example where we can tell at a glance that the values equal `123`, of course. Still, previously this test would (correctly) fail, but would not be able to provide the return values of `f()` and `g()`. With this change, the following test issue is recorded:

```swift
 #expect(!(f() == g())) // ♦️ Expectation failed: !((f() → 123) == (g() → 123) → true)
```

This increasing the amount of diagnostic information available.

This PR also makes adjustments to the `Expression` type to improve the information we log during test runs. In particular, when `--verbose` is passed to `swift test`, we will capture type information about more parts of a failed expectation/expression.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
