### PR TITLE
Fix thread name length in exit tests' call to `pthread_setname_np()`.

### DIFF
--- a/Sources/Testing/ExitTests/WaitFor.swift
+++ b/Sources/Testing/ExitTests/WaitFor.swift
@@ -85,8 +85,8 @@ private let _createWaitThreadImpl: Void = {
     }
   }
 
-  // Create the thread. We immediately detach it upon success to allow the
-  // system to reclaim its resources when done.
+  // Create the thread. It will run immediately; because it runs in an infinite
+  // loop, we aren't worried about detaching or joining it.
 #if SWT_TARGET_OS_APPLE
   var thread: pthread_t?
 #else
@@ -96,12 +96,13 @@ private let _createWaitThreadImpl: Void = {
     &thread,
     nil,
     { _ in
-      // Set the thread name to help with diagnostics.
-      let threadName = "swift-testing exit test monitor"
+      // Set the thread name to help with diagnostics. Note that different
+      // platforms support different thread name lengths. See MAXTHREADNAMESIZE
+      // on Darwin and TASK_COMM_LEN on Linux.
 #if SWT_TARGET_OS_APPLE
-      _ = pthread_setname_np(threadName)
+      _ = pthread_setname_np("swift-testing exit test monitor")
 #else
-      _ = pthread_setname_np(pthread_self(), threadName)
+      _ = pthread_setname_np(pthread_self(), "SWT ExT monitor")
 #endif
 
       // Run an infinite loop that waits for child processes to terminate and


### PR DESCRIPTION
On Linux, the maximum length of a thread's name is defined by `TASK_COMM_LEN` to be 16 bytes (including the trailing null character.) We currently manually create one thread on Linux in order to monitor for termination of exit tests' child processes. This PR changes the name of the monitor thread on Linux to one that is less than 16 characters long.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
