### PR TITLE
Ignore the .vscode folder created by Visual Studio Code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ DerivedData/
 Package.resolved
 *.profraw
 .*.sw?
+/.vscode


### PR DESCRIPTION
Visual Studio Code wants to create a .vscode folder in the package, but at least for now we don't want to include it in the repo. Exclude it.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
