### PR TITLE
Relax the restrictions on exit tests running in the background.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -137,8 +137,7 @@ func callExitTest(
   isRequired: Bool,
   sourceLocation: SourceLocation
 ) async -> Result<Void, any Error> {
-  // FIXME: use lexicalContext to capture these misuses at compile time.
-  guard let configuration = Configuration.current, Test.current != nil else {
+  guard let configuration = Configuration.current ?? Configuration.all.first else {
     preconditionFailure("A test must be running on the current task to use #expect(exitsWith:).")
   }
 

--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -466,12 +466,7 @@ public macro require(
 /// }
 /// ```
 ///
-/// Additionally, an exit test:
-///
-/// - _must_ run within a test function (or a function called by one);
-/// - cannot run within another exit test; and
-/// - cannot be run on a detached child task, a dispatch queue, or a background
-///   thread.
+/// An exit test cannot run within another exit test.
 @_spi(Experimental)
 #if SWT_NO_EXIT_TESTS
 @available(*, unavailable, message: "Exit tests are not available on this platform.")
@@ -546,12 +541,7 @@ public macro require(
 /// }
 /// ```
 ///
-/// Additionally, an exit test:
-///
-/// - _must_ run within a test function (or a function called by one);
-/// - cannot run within another exit test; and
-/// - cannot be run on a detached child task, a dispatch queue, or a background
-///   thread.
+/// An exit test cannot run within another exit test.
 @_spi(Experimental)
 #if SWT_NO_EXIT_TESTS
 @available(*, unavailable, message: "Exit tests are not available on this platform.")

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -42,6 +42,16 @@ private import TestingInternals
       abort()
     }
 #endif
+#if !SWT_NO_UNSTRUCTURED_TASKS
+    // Test the detached (no task-local configuration) path.
+    #expect(Test.current != nil)
+    await Task.detached {
+      #expect(Test.current == nil)
+      await #expect(exitsWith: .failure) {
+        fatalError()
+      }
+    }.value
+#endif
   }
 
 #if SWIFT_PM_SUPPORTS_SWIFT_TESTING

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -43,7 +43,10 @@ private import TestingInternals
     }
 #endif
 #if !SWT_NO_UNSTRUCTURED_TASKS
-    // Test the detached (no task-local configuration) path.
+#if false
+    // Test the detached (no task-local configuration) path. Disabled because,
+    // like other tests using Task.detached, it can interfere with other tests
+    // running concurrently.
     #expect(Test.current != nil)
     await Task.detached {
       #expect(Test.current == nil)
@@ -51,6 +54,7 @@ private import TestingInternals
         fatalError()
       }
     }.value
+#endif
 #endif
   }
 


### PR DESCRIPTION
Although it's not likely going to happen much in the real world, this PR makes it possible to run an exit test on a detached background task.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
