### PR TITLE
Change Graph's 'mapValues' APIs to pass key path in addition to value to transform closure

### DIFF
--- a/Sources/Testing/Running/Configuration.TestFilter.swift
+++ b/Sources/Testing/Running/Configuration.TestFilter.swift
@@ -219,7 +219,7 @@ extension Configuration.TestFilter.Kind {
     case .unfiltered:
       return testGraph
     case let .precomputed(selection, membership):
-      return testGraph.mapValues { test in
+      return testGraph.mapValues { _, test in
         guard let test else {
           return nil
         }
@@ -250,7 +250,7 @@ extension Configuration.TestFilter.Kind {
       return zip(
         lhs.apply(to: testGraph),
         rhs.apply(to: testGraph)
-      ).mapValues(op.functionValue)
+      ).mapValues { op.functionValue($1.0, $1.1) }
     }
   }
 }
@@ -271,7 +271,7 @@ extension Configuration.TestFilter {
     // combined test filters. It is only consulted on the outermost call to
     // apply(to:), not in _apply(to:).
     if !includeHiddenTests {
-      result = result.mapValues { test in
+      result = result.mapValues { _, test in
         (test?.isHidden == true) ? nil : test
       }
     }

--- a/Sources/Testing/Running/Configuration.TestFilter.swift
+++ b/Sources/Testing/Running/Configuration.TestFilter.swift
@@ -250,7 +250,9 @@ extension Configuration.TestFilter.Kind {
       return zip(
         lhs.apply(to: testGraph),
         rhs.apply(to: testGraph)
-      ).mapValues { op.functionValue($1.0, $1.1) }
+      ).mapValues { _, value in
+        op.functionValue(value.0, value.1)
+      }
     }
   }
 }

--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -237,13 +237,13 @@ extension Runner.Plan {
 
     // Now that we have allowed all the traits to update their corresponding
     // actions, recursively apply those actions to child tests in the graph.
-    actionGraph = actionGraph.mapValues { action in
+    actionGraph = actionGraph.mapValues { _, action in
       (action, recursivelyApply: action.isRecursive)
     }
 
     // Zip the tests and actions together and return them.
-    return zip(testGraph, actionGraph).mapValues { test, action in
-      test.map { Step(test: $0, action: action) }
+    return zip(testGraph, actionGraph).mapValues { _, pair in
+      pair.0.map { Step(test: $0, action: pair.1) }
     }
   }
 


### PR DESCRIPTION
This is a small change which begins passing key path _in addition to_ value to Graph's `mapValue` and `compactMapValue` APIs.

### Motivation:

This was extracted out from work in #366, and is initially intended for use in that PR but is a generally-useful enhancement.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
