### PR TITLE
Rename `Expression` to `__Expression`.

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -370,7 +370,7 @@ extension Event.HumanReadableOutputRecorder {
 
       if verbose, case let .expectationFailed(expectation) = issue.kind {
         let expression = expectation.evaluatedExpression
-        func addMessage(about expression: Expression) {
+        func addMessage(about expression: __Expression) {
           let description = expression.expandedDebugDescription()
           additionalMessages.append(Message(symbol: .details, stringValue: description))
         }

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -132,7 +132,7 @@ extension ExitTest {
 func callExitTest(
   exitsWith expectedExitCondition: ExitCondition,
   performing body: @escaping @Sendable () async -> Void,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation

--- a/Sources/Testing/Expectations/Expectation.swift
+++ b/Sources/Testing/Expectations/Expectation.swift
@@ -11,6 +11,7 @@
 /// A type describing an expectation that has been evaluated.
 public struct Expectation: Sendable {
   /// The expression evaluated by this expectation.
+  @_spi(ForToolsIntegrationOnly)
   public var evaluatedExpression: Expression
 
   /// A description of the error mismatch that occurred, if any.
@@ -65,7 +66,6 @@ extension Expectation {
     ///
     /// If this expectation passed, the value of this property is `nil` because no
     /// error mismatch occurred.
-    @_spi(ForToolsIntegrationOnly)
     public var mismatchedErrorDescription: String?
 
     /// A description of the difference between the operands in the expression
@@ -74,7 +74,6 @@ extension Expectation {
     /// If this expectation passed, the value of this property is `nil` because
     /// the difference is only computed when necessary to assist with diagnosing
     /// test failures.
-    @_spi(ForToolsIntegrationOnly)
     public var differenceDescription: String?
 
     /// Whether the expectation passed or failed.

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -60,8 +60,8 @@
 ///   `#require()` macros. Do not call it directly.
 public func __checkValue(
   _ condition: Bool,
-  expression: Expression,
-  expressionWithCapturedRuntimeValues: @autoclosure () -> Expression? = nil,
+  expression: __Expression,
+  expressionWithCapturedRuntimeValues: @autoclosure () -> __Expression? = nil,
   mismatchedErrorDescription: @autoclosure () -> String? = nil,
   difference: @autoclosure () -> String? = nil,
   comments: @autoclosure () -> [Comment],
@@ -73,7 +73,7 @@ public func __checkValue(
   // in case of multiple prefix operators (!!(a == b), for example.)
   var condition = condition
   do {
-    var expression: Expression? = expression
+    var expression: __Expression? = expression
     while case let .negation(subexpression, _) = expression?.kind {
       defer {
         expression = subexpression
@@ -163,7 +163,7 @@ private func _callBinaryOperator<T, U, R>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkBinaryOperation<T, U>(
   _ lhs: T, _ op: (T, () -> U) -> Bool, _ rhs: @autoclosure () -> U,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -194,7 +194,7 @@ public func __checkBinaryOperation<T, U>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkFunctionCall<T, each U>(
   _ lhs: T, calling functionCall: (T, repeat each U) throws -> Bool, _ arguments: repeat each U,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -222,7 +222,7 @@ public func __checkFunctionCall<T, each U>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkFunctionCall<T, Arg0>(
   _ lhs: T, calling functionCall: (T, Arg0) throws -> Bool, _ argument0: Arg0,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -249,7 +249,7 @@ public func __checkFunctionCall<T, Arg0>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkFunctionCall<T, Arg0, Arg1>(
   _ lhs: T, calling functionCall: (T, Arg0, Arg1) throws -> Bool, _ argument0: Arg0, _ argument1: Arg1,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -276,7 +276,7 @@ public func __checkFunctionCall<T, Arg0, Arg1>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkFunctionCall<T, Arg0, Arg1, Arg2>(
   _ lhs: T, calling functionCall: (T, Arg0, Arg1, Arg2) throws -> Bool, _ argument0: Arg0, _ argument1: Arg1, _ argument2: Arg2,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -303,7 +303,7 @@ public func __checkFunctionCall<T, Arg0, Arg1, Arg2>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkFunctionCall<T, Arg0, Arg1, Arg2, Arg3>(
   _ lhs: T, calling functionCall: (T, Arg0, Arg1, Arg2, Arg3) throws -> Bool, _ argument0: Arg0, _ argument1: Arg1, _ argument2: Arg2, _ argument3: Arg3,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -333,7 +333,7 @@ public func __checkFunctionCall<T, Arg0, Arg1, Arg2, Arg3>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkInoutFunctionCall<T, /*each*/ U>(
   _ lhs: T, calling functionCall: (T, inout /*repeat each*/ U) throws -> Bool, _ arguments: inout /*repeat each*/ U,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -363,7 +363,7 @@ public func __checkInoutFunctionCall<T, /*each*/ U>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkFunctionCall<T, each U, R>(
   _ lhs: T, calling functionCall: (T, repeat each U) throws -> R?, _ arguments: repeat each U,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -391,7 +391,7 @@ public func __checkFunctionCall<T, each U, R>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkFunctionCall<T, Arg0, R>(
   _ lhs: T, calling functionCall: (T, Arg0) throws -> R?, _ argument0: Arg0,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -418,7 +418,7 @@ public func __checkFunctionCall<T, Arg0, R>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkFunctionCall<T, Arg0, Arg1, R>(
   _ lhs: T, calling functionCall: (T, Arg0, Arg1) throws -> R?, _ argument0: Arg0, _ argument1: Arg1,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -445,7 +445,7 @@ public func __checkFunctionCall<T, Arg0, Arg1, R>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkFunctionCall<T, Arg0, Arg1, Arg2, R>(
   _ lhs: T, calling functionCall: (T, Arg0, Arg1, Arg2) throws -> R?, _ argument0: Arg0, _ argument1: Arg1, _ argument2: Arg2,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -472,7 +472,7 @@ public func __checkFunctionCall<T, Arg0, Arg1, Arg2, R>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkFunctionCall<T, Arg0, Arg1, Arg2, Arg3, R>(
   _ lhs: T, calling functionCall: (T, Arg0, Arg1, Arg2, Arg3) throws -> R?, _ argument0: Arg0, _ argument1: Arg1, _ argument2: Arg2, _ argument3: Arg3,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -503,7 +503,7 @@ public func __checkFunctionCall<T, Arg0, Arg1, Arg2, Arg3, R>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkInoutFunctionCall<T, /*each*/ U, R>(
   _ lhs: T, calling functionCall: (T, inout /*repeat each*/ U) throws -> R?, _ arguments: inout /*repeat each*/ U,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -534,7 +534,7 @@ public func __checkInoutFunctionCall<T, /*each*/ U, R>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkPropertyAccess<T>(
   _ lhs: T, getting memberAccess: (T) -> Bool,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -564,7 +564,7 @@ public func __checkPropertyAccess<T>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkPropertyAccess<T, U>(
   _ lhs: T, getting memberAccess: (T) -> U?,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -592,7 +592,7 @@ public func __checkPropertyAccess<T, U>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkBinaryOperation<T>(
   _ lhs: T, _ op: (T, () -> T) -> Bool, _ rhs: @autoclosure () -> T,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -639,7 +639,7 @@ public func __checkBinaryOperation<T>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkBinaryOperation(
   _ lhs: String, _ op: (String, () -> String) -> Bool, _ rhs: @autoclosure () -> String,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -666,7 +666,7 @@ public func __checkBinaryOperation(
 public func __checkCast<V, T>(
   _ value: V,
   is _: T.Type,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -698,8 +698,8 @@ public func __checkCast<V, T>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkValue<T>(
   _ optionalValue: T?,
-  expression: Expression,
-  expressionWithCapturedRuntimeValues: @autoclosure () -> Expression? = nil,
+  expression: __Expression,
+  expressionWithCapturedRuntimeValues: @autoclosure () -> __Expression? = nil,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -738,7 +738,7 @@ public func __checkValue<T>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkBinaryOperation<T>(
   _ lhs: T?, _ op: (T?, () -> T?) -> T?, _ rhs: @autoclosure () -> T?,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -764,7 +764,7 @@ public func __checkBinaryOperation<T>(
 public func __checkCast<V, T>(
   _ value: V,
   as _: T.Type,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -797,7 +797,7 @@ public func __checkCast<V, T>(
 public func __checkClosureCall<E>(
   throws errorType: E.Type,
   performing body: () throws -> some Any,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -834,7 +834,7 @@ public func __checkClosureCall<E>(
 public func __checkClosureCall<E>(
   throws errorType: E.Type,
   performing body: () async throws -> some Any,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -874,7 +874,7 @@ public func __checkClosureCall<E>(
 public func __checkClosureCall(
   throws _: Never.Type,
   performing body: () throws -> some Any,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -910,7 +910,7 @@ public func __checkClosureCall(
 public func __checkClosureCall(
   throws _: Never.Type,
   performing body: () async throws -> some Any,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -946,7 +946,7 @@ public func __checkClosureCall(
 public func __checkClosureCall<E>(
   throws error: E,
   performing body: () throws -> some Any,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -972,7 +972,7 @@ public func __checkClosureCall<E>(
 public func __checkClosureCall<E>(
   throws error: E,
   performing body: () async throws -> some Any,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -1000,7 +1000,7 @@ public func __checkClosureCall<R>(
   performing body: () throws -> R,
   throws errorMatcher: (any Error) throws -> Bool,
   mismatchExplanation: ((any Error) -> String)? = nil,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -1048,7 +1048,7 @@ public func __checkClosureCall<R>(
   performing body: () async throws -> R,
   throws errorMatcher: (any Error) async throws -> Bool,
   mismatchExplanation: ((any Error) -> String)? = nil,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -1102,7 +1102,7 @@ public func __checkClosureCall<R>(
 public func __checkClosureCall(
   exitsWith expectedExitCondition: ExitCondition,
   performing body: @convention(thin) () async -> Void,
-  expression: Expression,
+  expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation

--- a/Sources/Testing/Parameterization/Test.Case.swift
+++ b/Sources/Testing/Parameterization/Test.Case.swift
@@ -198,7 +198,6 @@ extension Test.Case.Argument {
 
     /// A representation of this parameterized test argument's
     /// ``Test/Case/Argument/value`` property.
-    @_spi(ForToolsIntegrationOnly)
     public var value: Expression.Value
 
     /// The parameter of the test function to which this argument was passed.

--- a/Sources/Testing/SourceAttribution/Expression+Macro.swift
+++ b/Sources/Testing/SourceAttribution/Expression+Macro.swift
@@ -8,14 +8,14 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-extension Expression {
-  /// Create an instance of ``Expression`` representing a complete syntax node.
+extension __Expression {
+  /// Create an instance of this type representing a complete syntax node.
   ///
   /// - Parameters:
   ///   - syntaxNode: The complete syntax node (expression, declaration,
   ///     statement, etc.)
   ///
-  /// - Returns: A new instance of ``Expression``.
+  /// - Returns: A new instance of this type.
   ///
   /// - Warning: This function is used to implement the `@Test`, `@Suite`,
   ///   `#expect()` and `#require()` macros. Do not call it directly.
@@ -23,14 +23,14 @@ extension Expression {
     Self(kind: .generic(syntaxNode))
   }
 
-  /// Create an instance of ``Expression`` representing a string literal.
+  /// Create an instance of this type representing a string literal.
   ///
   /// - Parameters:
   ///   - sourceCode: The source code representation of the string literal,
   ///     including leading and trailing punctuation.
   ///   - stringValue: The actual string value of the string literal
   ///
-  /// - Returns: A new instance of ``Expression``.
+  /// - Returns: A new instance of this type.
   ///
   /// - Warning: This function is used to implement the `@Test`, `@Suite`,
   ///   `#expect()` and `#require()` macros. Do not call it directly.
@@ -38,22 +38,22 @@ extension Expression {
     Self(kind: .stringLiteral(sourceCode: sourceCode, stringValue: stringValue))
   }
 
-  /// Create an instance of ``Expression`` representing a binary operation.
+  /// Create an instance of this type representing a binary operation.
   ///
   /// - Parameters:
   ///   - lhs: The left-hand operand.
   ///   - op: The operator.
   ///   - rhs: The right-hand operand.
   ///
-  /// - Returns: A new instance of ``Expression``.
+  /// - Returns: A new instance of this type.
   ///
   /// - Warning: This function is used to implement the `@Test`, `@Suite`,
   ///   `#expect()` and `#require()` macros. Do not call it directly.
-  public static func __fromBinaryOperation(_ lhs: Expression, _ op: String, _ rhs: Expression) -> Self {
+  public static func __fromBinaryOperation(_ lhs: Self, _ op: String, _ rhs: Self) -> Self {
     return Self(kind: .binaryOperation(lhs: lhs, operator: op, rhs: rhs))
   }
 
-  /// Create an instance of ``Expression`` representing a function call.
+  /// Create an instance of this type representing a function call.
   ///
   /// - Parameters:
   ///   - value: The value on which the member function is being invoked, if
@@ -62,31 +62,31 @@ extension Expression {
   ///   - argumentLabel: Optionally, the argument label.
   ///   - argumentValue: The value of the argument to the function.
   ///
-  /// - Returns: A new instance of ``Expression``.
+  /// - Returns: A new instance of this type.
   ///
   /// - Warning: This function is used to implement the `@Test`, `@Suite`,
   ///   `#expect()` and `#require()` macros. Do not call it directly.
-  public static func __fromFunctionCall(_ value: Expression?, _ functionName: String, _ arguments: (label: String?, value: Expression)...) -> Self {
-    let arguments = arguments.map(Expression.Kind.FunctionCallArgument.init)
+  public static func __fromFunctionCall(_ value: Self?, _ functionName: String, _ arguments: (label: String?, value: Self)...) -> Self {
+    let arguments = arguments.map(Kind.FunctionCallArgument.init)
     return Self(kind: .functionCall(value: value, functionName: functionName, arguments: arguments))
   }
 
-  /// Create an instance of ``Expression`` representing a property access.
+  /// Create an instance of this type representing a property access.
   ///
   /// - Parameters:
   ///   - value: The value whose property was accessed.
   ///   - keyPath: The key path, relative to `value`, that was accessed, not
   ///     including a leading backslash or period.
   ///
-  /// - Returns: A new instance of ``Expression``.
+  /// - Returns: A new instance of this type.
   ///
   /// - Warning: This function is used to implement the `@Test`, `@Suite`,
   ///   `#expect()` and `#require()` macros. Do not call it directly.
-  public static func __fromPropertyAccess(_ value: Expression, _ keyPath: Expression) -> Self {
+  public static func __fromPropertyAccess(_ value: Self, _ keyPath: Self) -> Self {
     return Self(kind: .propertyAccess(value: value, keyPath: keyPath))
   }
 
-  /// Create an instance of ``Expression`` representing a negated expression
+  /// Create an instance of this type representing a negated expression
   /// using the `!` operator..
   ///
   /// - Parameters:
@@ -95,11 +95,11 @@ extension Expression {
   ///     parentheses (and the `!` operator was outside it.) This argument
   ///     affects how this expression is represented as a string.
   ///
-  /// - Returns: A new instance of ``Expression``.
+  /// - Returns: A new instance of this type.
   ///
   /// - Warning: This function is used to implement the `@Test`, `@Suite`,
   ///   `#expect()` and `#require()` macros. Do not call it directly.
-  public static func __fromNegation(_ expression: Expression, _ isParenthetical: Bool) -> Self {
+  public static func __fromNegation(_ expression: Self, _ isParenthetical: Bool) -> Self {
     return Self(kind: .negation(expression, isParenthetical: isParenthetical))
   }
 }

--- a/Sources/Testing/Testing.docc/Expectations.md
+++ b/Sources/Testing/Testing.docc/Expectations.md
@@ -49,7 +49,6 @@ you can't check directly using an expectation.
 - ``Expectation``
 - ``ExpectationFailedError``
 - ``CustomTestStringConvertible``
-- ``Expression``
 
 ### Representing source locations
 

--- a/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
+++ b/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
@@ -28,7 +28,7 @@ struct Condition {
   var arguments: [Argument]
 
   /// The condition's source code as an expression that produces an instance of
-  /// the testing library's ``Expression`` type.
+  /// the testing library's `__Expression` type.
   var expression: ExprSyntax
 
   init(_ expandedFunctionName: String, arguments: [Argument], expression: ExprSyntax) {

--- a/Sources/TestingMacros/Support/SourceCodeCapturing.swift
+++ b/Sources/TestingMacros/Support/SourceCodeCapturing.swift
@@ -14,15 +14,15 @@ import SwiftSyntax
 public import SwiftSyntax
 #endif
 
-/// Get a swift-syntax expression initializing an instance of ``Expression``
+/// Get a swift-syntax expression initializing an instance of `__Expression`
 /// from an arbitrary syntax node.
 ///
 /// - Parameters:
 ///   - node: A syntax node from which to construct an instance of
-///     ``Expression``.
+///     `__Expression`.
 ///
 /// - Returns: An expression value that initializes an instance of
-///   ``Expression`` for the specified syntax node.
+///   `__Expression` for the specified syntax node.
 func createExpressionExpr(from node: any SyntaxProtocol) -> ExprSyntax {
   if let stringLiteralExpr = node.as(StringLiteralExprSyntax.self),
      let stringValue = stringLiteralExpr.representedLiteralValue {
@@ -31,7 +31,7 @@ func createExpressionExpr(from node: any SyntaxProtocol) -> ExprSyntax {
   return ".__fromSyntaxNode(\(literal: node.trimmedDescription))"
 }
 
-/// Get a swift-syntax expression initializing an instance of ``Expression``
+/// Get a swift-syntax expression initializing an instance of `__Expression`
 /// from an arbitrary sequence of syntax nodes representing a binary operation.
 ///
 /// - Parameters:
@@ -40,7 +40,7 @@ func createExpressionExpr(from node: any SyntaxProtocol) -> ExprSyntax {
 ///   - rhs: The right-hand operand.
 ///
 /// - Returns: An expression value that initializes an instance of
-///   ``Expression`` for the specified syntax nodes.
+///   `__Expression` for the specified syntax nodes.
 func createExpressionExprForBinaryOperation(_ lhs: some SyntaxProtocol, _ `operator`: some SyntaxProtocol, _ rhs: some SyntaxProtocol) -> ExprSyntax {
   let arguments = LabeledExprListSyntax {
     LabeledExprSyntax(expression: createExpressionExpr(from: lhs))
@@ -51,7 +51,7 @@ func createExpressionExprForBinaryOperation(_ lhs: some SyntaxProtocol, _ `opera
   return ".__fromBinaryOperation(\(arguments))"
 }
 
-/// Get a swift-syntax expression initializing an instance of ``Expression``
+/// Get a swift-syntax expression initializing an instance of `__Expression`
 /// from an arbitrary sequence of syntax nodes representing a function call.
 ///
 /// - Parameters:
@@ -60,7 +60,7 @@ func createExpressionExprForBinaryOperation(_ lhs: some SyntaxProtocol, _ `opera
 ///   - arguments: The arguments to the member function.
 ///
 /// - Returns: An expression value that initializes an instance of
-///   ``Expression`` for the specified syntax nodes.
+///   `__Expression` for the specified syntax nodes.
 func createExpressionExprForFunctionCall(_ value: (any SyntaxProtocol)?, _ functionName: some SyntaxProtocol, _ arguments: some Sequence<Argument>) -> ExprSyntax {
   let arguments = LabeledExprListSyntax {
     if let value {
@@ -84,7 +84,7 @@ func createExpressionExprForFunctionCall(_ value: (any SyntaxProtocol)?, _ funct
   return ".__fromFunctionCall(\(arguments))"
 }
 
-/// Get a swift-syntax expression initializing an instance of ``Expression``
+/// Get a swift-syntax expression initializing an instance of `__Expression`
 /// from an arbitrary sequence of syntax nodes representing a property access.
 ///
 /// - Parameters:
@@ -92,7 +92,7 @@ func createExpressionExprForFunctionCall(_ value: (any SyntaxProtocol)?, _ funct
 ///   - keyPath: The name of the property being accessed.
 ///
 /// - Returns: An expression value that initializes an instance of
-///   ``Expression`` for the specified syntax nodes.
+///   `__Expression` for the specified syntax nodes.
 func createExpressionExprForPropertyAccess(_ value: ExprSyntax, _ keyPath: DeclReferenceExprSyntax) -> ExprSyntax {
   let arguments = LabeledExprListSyntax {
     LabeledExprSyntax(expression: createExpressionExpr(from: value))
@@ -102,20 +102,20 @@ func createExpressionExprForPropertyAccess(_ value: ExprSyntax, _ keyPath: DeclR
   return ".__fromPropertyAccess(\(arguments))"
 }
 
-/// Get a swift-syntax expression initializing an instance of ``Expression``
+/// Get a swift-syntax expression initializing an instance of `__Expression`
 /// from an arbitrary sequence of syntax nodes representing the negation of
 /// another expression.
 ///
 /// - Parameters:
 ///   - expression: An expression representing a previously-initialized instance
-///     of ``Expression`` (that is, not the expression in source, but the result
+///     of `__Expression` (that is, not the expression in source, but the result
 ///     of a call to ``createExpressionExpr(from:)`` etc.)
 ///   - isParenthetical: Whether or not `expression` was enclosed in
 ///     parentheses (and the `!` operator was outside it.) This argument
 ///     affects how this expression is represented as a string.
 ///
 /// - Returns: An expression value that initializes an instance of
-///   ``Expression`` for the specified syntax nodes.
+///   `__Expression` for the specified syntax nodes.
 func createExpressionExprForNegation(of expression: ExprSyntax, isParenthetical: Bool) -> ExprSyntax {
   ".__fromNegation(\(expression.trimmed), \(literal: isParenthetical))"
 }

--- a/Tests/TestingTests/EventTests.swift
+++ b/Tests/TestingTests/EventTests.swift
@@ -18,7 +18,7 @@ struct EventTests {
         arguments: [
           Event.Kind.expectationChecked(
             Expectation(
-              evaluatedExpression: Expression("SyntaxNode"),
+              evaluatedExpression: __Expression("SyntaxNode"),
               mismatchedErrorDescription: "Mismatched Error Description",
               differenceDescription: "Difference Description",
               isPassing: false,

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -353,7 +353,7 @@ final class IssueTests: XCTestCase {
   struct ExpressionRuntimeValueCapture_Value {}
 
   func testExpressionRuntimeValueCapture() throws {
-    var expression = Expression.__fromSyntaxNode("abc123")
+    var expression = __Expression.__fromSyntaxNode("abc123")
     XCTAssertEqual(expression.sourceCode, "abc123")
     XCTAssertNil(expression.runtimeValue)
 
@@ -390,7 +390,7 @@ final class IssueTests: XCTestCase {
   }
 
   func testExpressionRuntimeValueChildren() throws {
-    var expression = Expression.__fromSyntaxNode("abc123")
+    var expression = __Expression.__fromSyntaxNode("abc123")
     XCTAssertEqual(expression.sourceCode, "abc123")
     XCTAssertNil(expression.runtimeValue)
 


### PR DESCRIPTION
This PR renames the `Expression` type, which represents source code and syntax captured during macro expansion, so that it does not conflict with Foundation's [`Expression`](https://github.com/apple/swift-foundation/blob/main/Sources/FoundationEssentials/Predicate/Expression.swift) type used with predicates.

We also expose a typealias to `__Expression` for use when integrating with tools that care about captured source code (e.g. to present it in their output.)

Resolves rdar://125988077.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
