### PR TITLE
Use `_NSGetExecutablePath()` instead of `proc_pidpath()` to get the main executable path.

### DIFF
--- a/Sources/Testing/Support/Additions/CommandLineAdditions.swift
+++ b/Sources/Testing/Support/Additions/CommandLineAdditions.swift
@@ -57,7 +57,7 @@ extension CommandLine {
           throw Win32Error(rawValue: GetLastError())
         }
         guard let path = String.decodeCString(buffer.baseAddress!, as: UTF16.self)?.result else {
-          throw CError(rawValue: ERROR_ILLEGAL_CHARACTER)
+          throw Win32Error(rawValue: ERROR_ILLEGAL_CHARACTER)
         }
         return path
       }

--- a/Sources/Testing/Support/Additions/CommandLineAdditions.swift
+++ b/Sources/Testing/Support/Additions/CommandLineAdditions.swift
@@ -28,12 +28,20 @@ extension CommandLine {
   static var executablePath: String {
     get throws {
 #if os(macOS)
-      return try withUnsafeTemporaryAllocation(of: CChar.self, capacity: Int(PATH_MAX) * 2) { buffer in
-        guard 0 != proc_pidpath(getpid(), buffer.baseAddress!, UInt32(buffer.count)) else {
-          throw CError(rawValue: swt_errno())
+      var result: String?
+      var bufferCount = UInt32(1024)
+      while result == nil {
+        result = withUnsafeTemporaryAllocation(of: CChar.self, capacity: Int(bufferCount)) { buffer in
+          // _NSGetExecutablePath returns 0 on success and -1 if bufferCount is
+          // too small. If that occurs, we'll return nil here and loop with the
+          // new value of bufferCount.
+          if 0 == _NSGetExecutablePath(buffer.baseAddress, &bufferCount) {
+            return String(cString: buffer.baseAddress!)
+          }
+          return nil
         }
-        return String(cString: buffer.baseAddress!)
       }
+      return result!
 #elseif os(Linux)
       return try withUnsafeTemporaryAllocation(of: CChar.self, capacity: Int(PATH_MAX) * 2) { buffer in
         let readCount = readlink("/proc/\(getpid())/exe", buffer.baseAddress!, buffer.count - 1)


### PR DESCRIPTION
This PR switches to `_NSGetExecutablePath()` when getting the path to the current process. `_NSGetExecutablePath()` pulls from the current process' address space, while `proc_pidpath()` involves a syscall and potential sandbox checks.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
