### PR TITLE
Missing cast to `DWORD` on Windows.

### DIFF
--- a/Sources/Testing/Support/Additions/CommandLineAdditions.swift
+++ b/Sources/Testing/Support/Additions/CommandLineAdditions.swift
@@ -57,7 +57,7 @@ extension CommandLine {
           throw Win32Error(rawValue: GetLastError())
         }
         guard let path = String.decodeCString(buffer.baseAddress!, as: UTF16.self)?.result else {
-          throw Win32Error(rawValue: ERROR_ILLEGAL_CHARACTER)
+          throw Win32Error(rawValue: DWORD(ERROR_ILLEGAL_CHARACTER))
         }
         return path
       }


### PR DESCRIPTION
This PR fixes a missing cast to `DWORD` on Windows that is causing the Windows build to fail. (Oops!)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
