### PR TITLE
Stop using the `SWIFT_PM_SUPPORTS_SWIFT_TESTING` flag.

### DIFF
--- a/Sources/Testing/Running/XCTestScaffold.swift
+++ b/Sources/Testing/Running/XCTestScaffold.swift
@@ -76,7 +76,7 @@ extension XCTIssue {
 /// ## See Also
 ///
 /// - <doc:TemporaryGettingStarted>
-#if SWIFT_PM_SUPPORTS_SWIFT_TESTING
+#if compiler(>=5.11)
 @available(*, deprecated, message: "This version of Swift Package Manager supports running swift-testing tests directly. This type will be removed in a future release.")
 #else
 @available(swift, deprecated: 100000.0, message: "This type is provided temporarily to aid in integrating the testing library with existing tools such as Swift Package Manager. It will be removed in a future release.")
@@ -109,13 +109,13 @@ public enum XCTestScaffold: Sendable {
   /// ## See Also
   ///
   /// - <doc:TemporaryGettingStarted>
-#if SWIFT_PM_SUPPORTS_SWIFT_TESTING
+#if compiler(>=5.11)
   @available(*, deprecated, message: "This version of Swift Package Manager supports running swift-testing tests directly. This function has no effect and will be removed in a future release.")
 #else
   @available(swift, deprecated: 100000.0, message: "This function is provided temporarily to aid in integrating the testing library with existing tools such as Swift Package Manager. It will be removed in a future release.")
 #endif
   public static func runAllTests(hostedBy testCase: XCTestCase, _ functionName: String = #function) async {
-#if SWIFT_PM_SUPPORTS_SWIFT_TESTING
+#if compiler(>=5.11)
     let message = Event.ConsoleOutputRecorder.warning(
       "This version of Swift Package Manager supports running swift-testing tests directly. Ignoring call to \(#function).",
       options: .for(.stderr)

--- a/Tests/TestingMacrosTests/TestSupport/Scaffolding.swift
+++ b/Tests/TestingMacrosTests/TestSupport/Scaffolding.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if !SWT_NO_XCTEST_SCAFFOLDING && !SWIFT_PM_SUPPORTS_SWIFT_TESTING && canImport(XCTest)
+#if !SWT_NO_XCTEST_SCAFFOLDING && compiler(<5.11) && canImport(XCTest)
 import XCTest
 import Testing
 

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -44,7 +44,7 @@ private import TestingInternals
 #endif
   }
 
-#if SWIFT_PM_SUPPORTS_SWIFT_TESTING
+#if compiler(>=5.11)
   @Test("Exit tests (failing)") func failing() async {
     let expectedCount: Int
 #if os(Windows)

--- a/Tests/TestingTests/TestSupport/Scaffolding.swift
+++ b/Tests/TestingTests/TestSupport/Scaffolding.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if !SWT_NO_XCTEST_SCAFFOLDING && !SWIFT_PM_SUPPORTS_SWIFT_TESTING && canImport(XCTest)
+#if !SWT_NO_XCTEST_SCAFFOLDING && compiler(<5.11) && canImport(XCTest)
 import XCTest
 import Testing
 

--- a/Tests/TestingTests/Traits/TagListTests.swift
+++ b/Tests/TestingTests/Traits/TagListTests.swift
@@ -222,7 +222,7 @@ struct TagListTests {
     #expect(Tag.Color.rgb(0, 0, 0) < .rgb(100, 100, 100))
   }
 
-#if !SWT_NO_EXIT_TESTS && SWIFT_PM_SUPPORTS_SWIFT_TESTING && !canImport(SwiftSyntax600)
+#if !SWT_NO_EXIT_TESTS && compiler(>=5.11) && !canImport(SwiftSyntax600)
   @Test("Invalid symbolic tag declaration")
   func invalidSymbolicTag() async {
     await #expect(exitsWith: .failure) {


### PR DESCRIPTION
When we were first bringing up experimental support for swift-testing in Swift Package Manager, I added the flag `SWIFT_PM_SUPPORTS_SWIFT_TESTING` to the build process for test targets so that we could detect if there was built-in support or not. Now that we've announced we're aligning our release with Swift 6, we can instead just check if the compiler is Swift 6 or later. Very early Swift 5.11 toolchain builds did not have support, but they have long since been superseded.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
