### PR TITLE
Work around issue parsing macro declarations with other attributes.

### DIFF
--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -93,8 +93,9 @@
 /// `optionalValue` may be ambiguous (i.e. it is unclear if the developer
 /// intended to check for a boolean value or unwrap an optional boolean value)
 /// and provides additional compile-time diagnostics when it is.
+@freestanding(expression)
 @_documentation(visibility: private)
-@freestanding(expression) public macro require(
+public macro require(
   _ optionalValue: Bool?,
   _ comment: @autoclosure () -> Comment? = nil,
   sourceLocation: SourceLocation = SourceLocation()

--- a/Sources/Testing/Test+Macro.swift
+++ b/Sources/Testing/Test+Macro.swift
@@ -67,8 +67,9 @@ public typealias __XCTestCompatibleSelector = Never
 /// ## See Also
 ///
 /// - <doc:OrganizingTests>
+@attached(member) @attached(peer)
 @_documentation(visibility: private)
-@attached(member) @attached(peer) public macro Suite(
+public macro Suite(
   _ traits: any SuiteTrait...
 ) = #externalMacro(module: "TestingMacros", type: "SuiteDeclarationMacro")
 
@@ -123,8 +124,9 @@ extension Test {
 /// ## See Also
 ///
 /// - ``Test(_:_:)``
+@attached(peer)
 @_documentation(visibility: private)
-@attached(peer) public macro Test(
+public macro Test(
   _ traits: any TestTrait...
 ) = #externalMacro(module: "TestingMacros", type: "TestDeclarationMacro")
 
@@ -192,8 +194,9 @@ extension [Test.__Parameter] {
 /// ## See Also
 ///
 /// - ``Test(_:arguments:)-35dat``
+@attached(peer)
 @_documentation(visibility: private)
-@attached(peer) public macro Test<C>(
+public macro Test<C>(
   _ traits: any TestTrait...,
   arguments collection: C
 ) = #externalMacro(module: "TestingMacros", type: "TestDeclarationMacro") where C: Collection & Sendable, C.Element: Sendable
@@ -268,8 +271,9 @@ extension Test {
 /// ## See Also
 ///
 /// - <doc:DefiningTests>
+@attached(peer)
 @_documentation(visibility: private)
-@attached(peer) public macro Test<C1, C2>(
+public macro Test<C1, C2>(
   _ traits: any TestTrait...,
   arguments collection1: C1, _ collection2: C2
 ) = #externalMacro(module: "TestingMacros", type: "TestDeclarationMacro") where C1: Collection & Sendable, C1.Element: Sendable, C2: Collection & Sendable, C2.Element: Sendable
@@ -321,8 +325,9 @@ extension Test {
 /// ## See Also
 ///
 /// - <doc:DefiningTests>
+@attached(peer)
 @_documentation(visibility: private)
-@attached(peer) public macro Test<C1, C2>(
+public macro Test<C1, C2>(
   _ traits: any TestTrait...,
   arguments zippedCollections: Zip2Sequence<C1, C2>
 ) = #externalMacro(module: "TestingMacros", type: "TestDeclarationMacro") where C1: Collection & Sendable, C1.Element: Sendable, C2: Collection & Sendable, C2.Element: Sendable


### PR DESCRIPTION
A recent change on the main Swift branch is causing macro expansions to fail to be invoked when macros are declared with other attributes. For example, the following code should fail with an undefined macro error:

```swift
@_documentation(visibility: private)
@attached(peer)
macro Foo() = #externalMacro(module: "ThisMacroModuleDoesNotExist", type: "ThisMacroTypeDoesNotExist")

@Foo func foo() {}
```

But it compiles successfully. Whatever the root cause of the bug, reordering the attributes seems to work around the issue:

```swift
@attached(peer)
@_documentation(visibility: private)
macro Foo() = #externalMacro(module: "ThisMacroModuleDoesNotExist", type: "ThisMacroTypeDoesNotExist")

@Foo func foo() {} // 🛑 External macro implementation type
                   // 'ThisMacroModuleDoesNotExist.ThisMacroTypeDoesNotExist'
                   // could not be found for macro 'Foo()'; plugin for module
                   // 'ThisMacroModuleDoesNotExist' not found
```

:shrug:

Works around rdar://127206128.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
