### PR TITLE
Re-enable some pre-swift-syntax-600 code.

### DIFF
--- a/Sources/TestingMacros/Support/Additions/MacroExpansionContextAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/MacroExpansionContextAdditions.swift
@@ -28,7 +28,12 @@ extension MacroExpansionContext {
   ///
   /// If the lexical context includes functions, closures, or some other
   /// non-type scope, the value of this property is `nil`.
-  var typeOfLexicalContext: TypeSyntax? {
+  ///
+  /// When using the Swift 6 or newer compiler, `node` is ignored. The argument
+  /// can be removed once the testing library is updated to require the Swift 6
+  /// compiler.
+  func typeOfLexicalContext(containing node: some WithAttributesSyntax) -> TypeSyntax? {
+#if compiler(>=5.11)
     var typeNames = [String]()
     for lexicalContext in lexicalContext.reversed() {
       guard let decl = lexicalContext.asProtocol((any DeclGroupSyntax).self) else {
@@ -41,6 +46,42 @@ extension MacroExpansionContext {
     }
 
     return "\(raw: typeNames.joined(separator: "."))"
+#else
+    // Find the beginning of the first attribute on the declaration, including
+    // those embedded in #if statements, to account for patterns like
+    // `@MainActor @Test func` where there's a space ahead of @Test, but the
+    // whole function is still at the top level.
+    func firstAttribute(in attributes: AttributeListSyntax) -> AttributeSyntax? {
+      attributes.lazy
+        .compactMap { attribute in
+          switch (attribute as AttributeListSyntax.Element?) {
+          case let .ifConfigDecl(ifConfigDecl):
+            ifConfigDecl.clauses.lazy
+              .compactMap { clause in
+                if case let .attributes(attributes) = clause.elements {
+                  return firstAttribute(in: attributes)
+                }
+                return nil
+              }.first
+          case let .attribute(attribute):
+            attribute
+          default:
+            nil
+          }
+        }.first
+    }
+    let firstAttribute = firstAttribute(in: node.attributes)!
+
+    // HACK: If the test function appears to be indented, assume it is nested in
+    // a type. Use `Self` as the presumptive name of the type.
+    //
+    // This hack works around rdar://105470382.
+    if let lastLeadingTrivia = firstAttribute.leadingTrivia.pieces.last,
+       lastLeadingTrivia.isWhitespace && !lastLeadingTrivia.isNewline {
+      return TypeSyntax(IdentifierTypeSyntax(name: .keyword(.Self)))
+    }
+    return nil
+#endif
   }
 }
 

--- a/Sources/TestingMacros/TagMacro.swift
+++ b/Sources/TestingMacros/TagMacro.swift
@@ -40,11 +40,12 @@ public struct TagMacro: PeerMacro, AccessorMacro, Sendable {
 
     // Figure out what type the tag is declared on. It must be declared on Tag
     // or a type nested in Tag.
-    guard let type = context.typeOfLexicalContext else {
+    guard let type = context.typeOfLexicalContext(containing: variableDecl) else {
       context.diagnose(.nonMemberTagDeclarationNotSupported(variableDecl, whenUsing: node))
       return _fallbackAccessorDecls
     }
 
+#if compiler(>=5.11)
     // Check that the tag is declared within Tag's namespace.
     let typeNameTokens: [String] = type.tokens(viewMode: .fixedUp).lazy
       .filter { $0.tokenKind != .period }
@@ -74,6 +75,7 @@ public struct TagMacro: PeerMacro, AccessorMacro, Sendable {
         return _fallbackAccessorDecls
       }
     }
+#endif
 
     // We know the tag is nested in Tag. Now check that it is a static member.
     guard variableDecl.modifiers.map(\.name.tokenKind).contains(.keyword(.static)) else {

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -26,7 +26,7 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
     }
 
     let functionDecl = declaration.cast(FunctionDeclSyntax.self)
-    let typeName = context.typeOfLexicalContext
+    let typeName = context.typeOfLexicalContext(containing: functionDecl)
 
     return _createTestContainerDecls(for: functionDecl, on: typeName, testAttribute: node, in: context)
   }
@@ -381,9 +381,36 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
   ) -> [DeclSyntax] {
     var result = [DeclSyntax]()
 
+#if compiler(>=5.11)
     // Get the name of the type containing the function for passing to the test
     // factory function later.
     let typealiasExpr: ExprSyntax = typeName.map { "\($0).self" } ?? "nil"
+#else
+    // We cannot directly refer to Self here because it will end up being
+    // resolved as the __TestContainer type we generate. Create a uniquely-named
+    // reference to Self outside the context of the generated type, and use it
+    // when the generated type needs to refer to the containing type.
+    //
+    // To support covariant Self on classes, we embed the reference to Self
+    // inside a static computed property instead of a typealias (where covariant
+    // Self is disallowed.)
+    //
+    // This "typealias" is not necessary when using the Swift 6 compiler.
+    var typealiasExpr: ExprSyntax = "nil"
+    if let typeName {
+      let typealiasName = context.makeUniqueName(thunking: functionDecl)
+      result.append(
+        """
+        @available(*, deprecated, message: "This property is an implementation detail of the testing library. Do not use it directly.")
+        private static nonisolated var \(typealiasName): Any.Type {
+          \(typeName).self
+        }
+        """
+      )
+
+      typealiasExpr = "\(typealiasName)"
+    }
+#endif
 
     if typeName != nil, let genericGuardDecl = makeGenericGuardDecl(guardingAgainst: functionDecl, in: context) {
       result.append(genericGuardDecl)

--- a/Tests/TestingMacrosTests/TagMacroTests.swift
+++ b/Tests/TestingMacrosTests/TagMacroTests.swift
@@ -17,7 +17,13 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
-@Suite("TagMacro Tests")
+#if compiler(>=5.11)
+private let swift6Compiler = true
+#else
+private let swift6Compiler = false
+#endif
+
+@Suite("TagMacro Tests", .enabled(if: swift6Compiler, "@Tag tests require lexical context"))
 struct TagMacroTests {
   @Test("@Tag macro",
     arguments: [

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -17,9 +17,16 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
+#if compiler(>=5.11)
+private let swift6Compiler = true
+#else
+private let swift6Compiler = false
+#endif
+
 @Suite("TestDeclarationMacro Tests")
 struct TestDeclarationMacroTests {
   @Test("Error diagnostics emitted on API misuse",
+    .enabled(if: swift6Compiler, "Some error diagnostics require lexical context"),
     arguments: [
       // Generic declarations
       "@Suite struct S<T> {}":


### PR DESCRIPTION
The Swift 5.10 compiler does not populate the new `lexicalContext` property during macro expansion. This PR ensures we maintain minimal 5.10 compatibility by continuing to use our whitespace trick to "get" the containing type of a test or suite.

This change can be reverted once support for the Swift 5.10 compiler is dropped.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
