### PR TITLE
Work around miscompilation of entry point function on Windows with Swift 5.10 (Take 2).

### DIFF
--- a/Sources/Testing/EntryPoints/ABIEntryPoint.swift
+++ b/Sources/Testing/EntryPoints/ABIEntryPoint.swift
@@ -60,12 +60,12 @@ public typealias ABIEntryPoint_v0 = @Sendable (
 @usableFromInline
 func abiEntryPoint_v0(_ outEntryPoint: UnsafeMutableRawPointer) {
   outEntryPoint.initializeMemory(as: ABIEntryPoint_v0.self) { argumentsJSON, eventHandler in
-    var args = try! argumentsJSON.map { argumentsJSON in
+    let args = try! argumentsJSON.map { argumentsJSON in
       try JSON.decode(__CommandLineArguments_v0.self, from: argumentsJSON)
     }
 
     let eventHandler = eventHandlerForStreamingEvents_v0(to: eventHandler)
-    return await entryPoint(passing: &args, eventHandler: eventHandler)
+    return await entryPoint(passing: args, eventHandler: eventHandler)
   }
 }
 #endif

--- a/Sources/Testing/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/EntryPoints/EntryPoint.swift
@@ -26,8 +26,7 @@ private import TestingInternals
 /// - Warning: This function is used by Swift Package Manager. Do not call it
 ///   directly.
 @_disfavoredOverload public func __swiftPMEntryPoint(passing args: __CommandLineArguments_v0? = nil) async -> CInt {
-  var args = args
-  return await entryPoint(passing: &args, eventHandler: nil)
+  await entryPoint(passing: args, eventHandler: nil)
 }
 
 /// The entry point to the testing library used by Swift Package Manager.
@@ -56,17 +55,12 @@ public func __swiftPMEntryPoint(passing args: __CommandLineArguments_v0? = nil) 
 ///   - args: A previously-parsed command-line arguments structure to interpret.
 ///     If `nil`, a new instance is created from the command-line arguments to
 ///     the current process.
-///   - eventHandler: An event handler.
-///
-/// - Bug: This function takes `args` as a pointer in order to work around a
-///   code generation bug when using the Swift 5.10 toolchain on Windows. This
-///   function should be updated to take `args` directly when Swift 5.10
-///   support is removed.
-func entryPoint(passing args: UnsafePointer<__CommandLineArguments_v0?>, eventHandler: Event.Handler?) async -> CInt {
+///   - eventHandler: An event handler
+func entryPoint(passing args: consuming __CommandLineArguments_v0?, eventHandler: Event.Handler?) async -> CInt {
   let exitCode = Locked(rawValue: EXIT_SUCCESS)
 
   do {
-    let args = try args.pointee ?? parseCommandLineArguments(from: CommandLine.arguments())
+    let args = try args ?? parseCommandLineArguments(from: CommandLine.arguments())
     if args.listTests {
       for testID in await listTestsForSwiftPM(Test.all) {
 #if SWT_TARGET_OS_APPLE && !SWT_NO_FILE_IO

--- a/Sources/Testing/EntryPoints/XCTestScaffold.swift
+++ b/Sources/Testing/EntryPoints/XCTestScaffold.swift
@@ -144,9 +144,8 @@ public enum XCTestScaffold: Sendable {
       functionName[...]
     }
     args.xcTestCaseHostIdentifier = "\(typeName)/\(functionName)"
-    var argsCopy: __CommandLineArguments_v0? = args
 
-    _ = await entryPoint(passing: &argsCopy) { event, _ in
+    _ = await entryPoint(passing: args) { event, _ in
       guard case let .issueRecorded(issue) = event.kind else {
         return
       }


### PR DESCRIPTION
I saw our [Windows
CI](https://ci-external.swift.org/job/swift-testing-main-swift-5.10-windows/66/) fail even after the changes in #381. Trying a different approach here by using `consuming` to transfer ownership of the troublesome value rather than using a pointer to trick the ownership checker.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
