### PR TITLE
Define and implement a strawman stable JSON schema for output.

### DIFF
--- a/Documentation/ABI/JSON.md
+++ b/Documentation/ABI/JSON.md
@@ -1,0 +1,222 @@
+# JSON schema
+
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2024 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+This document outlines the JSON schemas used by the testing library for its ABI
+entry point and for the `--experimental-event-stream-output` command-line
+argument. For more information about the ABI entry point, see the documentation
+for [ABI.EntryPoint_v0](https://github.com/search?q=repo%3Aapple%2Fswift-testing%EntryPoint_v0&type=code).
+
+> [!WARNING]
+> This JSON schema is still being developed and is subject to any and all
+> changes including removal from the package.
+
+## Modified Backus-Naur form
+
+This schema is expressed using a modified Backus-Naur syntax. `{`, `}`, `:`, and
+`,` represent their corresponding JSON tokens. `\n` represents an ASCII newline
+character.
+
+The order of keys in JSON objects is not normative. Whitespace in this schema is
+not normative; it is present to help the reader understand the content of the
+various JSON objects in the schema. The event stream is output using the JSON
+Lines format and does not include newline characters (except **one** at the end
+of the `<output-record-line>` rule.)
+
+Trailing commas in JSON objects and arrays are only to be included where
+syntactically valid.
+
+### Common data types
+
+`<string>` and `<number>` are defined as in JSON. `<array:T>` represents an
+array (also defined as in JSON) whose elements all follow rule `<T>`.
+
+```
+<bool> ::= true | false ; as in JSON
+
+<source-location> ::= {
+  "fileID": <string>, ; the Swift file ID of the file
+  "line": <number>,
+  "column": <number>,
+}
+
+<version> ::= "version": 0 ; will be incremented as the format changes
+
+<boolean> ::= true | false ; boolean value as in JSON
+```
+
+<!--
+TODO: implement input/configuration
+
+### Configuration
+
+A single configuration is passed into the testing library prior to running any
+tests and, as the name suggests, configures the test run. The configuration is
+encoded as a single [JSON Lines](https://jsonlines.org) value.
+
+```
+<configuration-record> ::= {
+  <version>,
+  "kind": "configuration",
+  "payload": <configuration>
+}
+
+<configuration> ::= {
+  ["verbosity": <number>,] ; 0 is the default; higher means more verbose output
+                           ; while negative values mean quieter output.
+  ["filters": <array:test-filter>,] ; how to filter the tests in the test run
+  ["parallel": <bool>,] ; whether to enable parallel testing (on by default)
+  ; more TBD
+}
+
+<test-filter> ::= <test-filter-tag> | <test-filter-id>
+
+<test-filter-action> ::= "include" | "exclude"
+
+<test-filter-tag> ::= {
+  "action": <test-filter-action>,
+  "tags": <array:string>, ; the names of tags to include
+  "operator": <test-filter-tag-operator> ; how to combine the values in "tags"
+}
+
+<test-filter-tag-operator> ::= "any" | "all"
+
+<test-filter-id> ::= {
+  "action": <test-filter-action>,
+  "id": <test-id> ; the ID of the test to filter in/out
+}
+```
+-->
+
+### Streams
+
+A stream consists of a sequence of values encoded as [JSON Lines](https://jsonlines.org).
+A single instance of `<output-stream>` is defined per test process and can be
+accessed by passing `--experimental-event-stream-output` to the test executable
+created by `swift build --build-tests`.
+
+```
+<output-stream> ::= <output-record>\n | <output-record>\n <output-stream>
+```
+
+### Records
+
+Records represent the values produced on a stream. Each record is encoded on a
+single line and can be decoded independently of other lines. If a decoder
+encounters a record whose `"kind"` field is unrecognized, the decoder should
+ignore that line.
+
+```
+<output-record> ::= <metadata-record> | <test-record> | <event-record>
+
+<metadata-record> ::= {
+  <version>,
+  "kind": "metadata",
+  "payload": <metadata>
+}
+
+<test-record> ::= {
+  <version>,
+  "kind": "test",
+  "payload": <test>
+}
+
+<event-record> ::= {
+  <version>,
+  "kind": "event",
+  "payload": <event>
+}
+```
+
+### Metadata
+
+Metadata records are reserved for future use.
+
+```
+<metadata> ::= {
+  ; unspecified JSON object content
+}
+```
+
+### Tests
+
+Test records represent individual test functions and test suites. Test records
+are passed through the record stream **before** most events.
+
+<!--
+If a test record represents a parameterized test function whose inputs are
+enumerable and can be independently replayed, the test record will include an
+additional `"testCases"` field describing the individual test cases.
+--> 
+
+```
+<test> ::= {
+  "kind": <test-kind>,
+  "name": <string>, ; the unformatted function or non-qualified type name
+  ["displayName": <string>,] ; the user-supplied custom display name
+  "sourceLocation": <source-location>, ; where the test is defined
+  "id": <test-id>,
+}
+
+<test-kind> ::= "suite" | "function" | "parameterizedFunction"
+
+<test-id> ::= <string> ; an opaque string representing the test case
+```
+
+<!--
+  TODO: define a round-trippable format for a test case ID
+  ["testCases": <array:test-case>] ; if kind is "parameterizedFunction" and
+                                     ; the inputs are enumerable, all test case
+                                     ; IDs, otherwise not present
+
+<test-case> ::= {
+  "id": <string>, ; an opaque string representing the test case
+  "displayName": <string> ; a string representing the corresponding Swift value
+}
+```
+-->
+
+### Events
+
+Event records represent things that can happen during testing. They include
+information about the event such as when it occurred and where in the test
+source it occurred. They also include a `"messages"` field that contains
+sufficient information to display the event in a human-readable format.
+
+```
+<event> ::= {
+  "kind": <event-kind>,
+  ["sourceLocation": <source-location>,]
+  "timestamp": <number>, ; floating-point seconds since test epoch
+  "timestampSince1970": <number>, ; floating-point seconds since UNIX epoch
+  "messages": <array:message>,
+  ["testID": <test-id>,]
+}
+
+<event-kind> ::= "runStarted" | "testStarted" | "testCaseStarted" |
+  "issueRecorded" | "knownIssueRecorded" | "testCaseEnded" | "testEnded" |
+  "testSkipped" | "runEnded" ; additional event kinds may be added in the future
+
+<message> ::= {
+  "symbol": <message-symbol>,
+  "text": <string>, ; the human-readable text of this message
+  ["markdown": <string>] ; if available/desired/whatever, Markdown encoding
+                         ; the same string as "text"
+}
+
+<message-symbol> ::= "default" | "skip" | "pass" | "passWithKnownIssue" | "fail"
+  "difference" | "warning" | "details"
+```
+
+<!--
+  ["testID": <test-id>,
+    ["testCase": <test-case>]]
+-->

--- a/Documentation/ABI/JSON.md
+++ b/Documentation/ABI/JSON.md
@@ -48,7 +48,7 @@ array (also defined as in JSON) whose elements all follow rule `<T>`.
   "column": <number>,
 }
 
-<timestamp> ::= {
+<instant> ::= {
   "absolute": <number>, ; floating-point seconds since system-defined epoch
   "since1970": <number>, ; floating-point seconds since 1970-01-01 00:00:00 UT
 }
@@ -118,13 +118,7 @@ encounters a record whose `"kind"` field is unrecognized, the decoder should
 ignore that line.
 
 ```
-<output-record> ::= <metadata-record> | <test-record> | <event-record>
-
-<metadata-record> ::= {
-  <version>,
-  "kind": "metadata",
-  "payload": <metadata>
-}
+<output-record> ::= <test-record> | <event-record>
 
 <test-record> ::= {
   <version>,
@@ -136,16 +130,6 @@ ignore that line.
   <version>,
   "kind": "event",
   "payload": <event>
-}
-```
-
-### Metadata
-
-Metadata records are reserved for future use.
-
-```
-<metadata> ::= {
-  ; unspecified JSON object content
 }
 ```
 

--- a/Documentation/ABI/JSON.md
+++ b/Documentation/ABI/JSON.md
@@ -145,24 +145,33 @@ additional `"testCases"` field describing the individual test cases.
 -->
 
 ```
-<test> ::= {
-  "kind": <test-kind>,
-  "name": <string>, ; the unformatted function or non-qualified type name
+<test> ::= <test-suite> | <test-function>
+
+<test-suite> ::= {
+  "kind": "suite",
+  "name": <string>, ; the unformatted, unqualified type name
   ["displayName": <string>,] ; the user-supplied custom display name
-  "sourceLocation": <source-location>, ; where the test is defined
+  "sourceLocation": <source-location>, ; where the test suite is defined
   "id": <test-id>,
 }
 
-<test-kind> ::= "suite" | "function" | "parameterizedFunction"
+<test-function> ::= {
+  "kind": "function",
+  "name": <string>, ; the unformatted function name
+  ["displayName": <string>,] ; the user-supplied custom display name
+  "sourceLocation": <source-location>, ; where the test is defined
+  "id": <test-id>,
+  "isParameterized": <bool> ; is this a parameterized test function or not?
+}
 
 <test-id> ::= <string> ; an opaque string representing the test case
 ```
 
 <!--
   TODO: define a round-trippable format for a test case ID
-  ["testCases": <array:test-case>] ; if kind is "parameterizedFunction" and
-                                     ; the inputs are enumerable, all test case
-                                     ; IDs, otherwise not present
+  ["testCases": <array:test-case>] ; if "isParameterized": true and the inputs
+                                   ; are enumerable, all test case IDs,
+                                   ; otherwise not present
 
 <test-case> ::= {
   "id": <string>, ; an opaque string representing the test case

--- a/Documentation/ABI/JSON.md
+++ b/Documentation/ABI/JSON.md
@@ -208,8 +208,6 @@ sufficient information to display the event in a human-readable format.
 <message> ::= {
   "symbol": <message-symbol>,
   "text": <string>, ; the human-readable text of this message
-  ["markdown": <string>] ; if available/desired/whatever, Markdown encoding
-                         ; the same string as "text"
 }
 
 <message-symbol> ::= "default" | "skip" | "pass" | "passWithKnownIssue" | "fail"

--- a/Documentation/ABI/JSON.md
+++ b/Documentation/ABI/JSON.md
@@ -48,9 +48,12 @@ array (also defined as in JSON) whose elements all follow rule `<T>`.
   "column": <number>,
 }
 
-<version> ::= "version": 0 ; will be incremented as the format changes
+<timestamp> ::= {
+  "absolute": <number>, ; floating-point seconds since system-defined epoch
+  "since1970": <number>, ; floating-point seconds since 1970-01-01 00:00:00 UT
+}
 
-<boolean> ::= true | false ; boolean value as in JSON
+<version> ::= "version": 0 ; will be incremented as the format changes
 ```
 
 <!--
@@ -155,7 +158,7 @@ are passed through the record stream **before** most events.
 If a test record represents a parameterized test function whose inputs are
 enumerable and can be independently replayed, the test record will include an
 additional `"testCases"` field describing the individual test cases.
---> 
+-->
 
 ```
 <test> ::= {
@@ -194,16 +197,20 @@ sufficient information to display the event in a human-readable format.
 ```
 <event> ::= {
   "kind": <event-kind>,
-  ["sourceLocation": <source-location>,]
-  "timestamp": <number>, ; floating-point seconds since test epoch
-  "timestampSince1970": <number>, ; floating-point seconds since UNIX epoch
+  "instant": <instant>, ; when the event occurred
+  ["issue": <issue>,] ; the recorded issue (if "kind" is "issueRecorded")
   "messages": <array:message>,
   ["testID": <test-id>,]
 }
 
 <event-kind> ::= "runStarted" | "testStarted" | "testCaseStarted" |
-  "issueRecorded" | "knownIssueRecorded" | "testCaseEnded" | "testEnded" |
-  "testSkipped" | "runEnded" ; additional event kinds may be added in the future
+  "issueRecorded" | "testCaseEnded" | "testEnded" | "testSkipped" |
+  "runEnded" ; additional event kinds may be added in the future
+
+<issue> ::= {
+  "isKnown": <bool>, ; is this a known issue or not?
+  ["sourceLocation": <source-location>,] ; where the issue occurred, if known
+}
 
 <message> ::= {
   "symbol": <message-symbol>,

--- a/Sources/Testing/EntryPoints/ABIv0/ABIv0.Record+Streaming.swift
+++ b/Sources/Testing/EntryPoints/ABIv0/ABIv0.Record+Streaming.swift
@@ -1,0 +1,106 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+#if canImport(Foundation) && (!SWT_NO_FILE_IO || !SWT_NO_ABI_ENTRY_POINT)
+extension ABIv0.Record {
+  /// Create an event handler that encodes events as JSON and forwards them to
+  /// an ABI-friendly event handler.
+  ///
+  /// - Parameters:
+  ///   - eventHandler: The event handler to forward events to. See
+  ///     ``ABIv0/EntryPoint`` for more information.
+  ///
+  /// - Returns: An event handler.
+  ///
+  /// The resulting event handler outputs data as JSON. For each event handled
+  /// by the resulting event handler, a JSON object representing it and its
+  /// associated context is created and is passed to `eventHandler`.
+  ///
+  /// Note that `_eventHandlerForStreamingEvents(toFileAtPath:)` calls this
+  /// function and performs additional postprocessing before writing JSON data.
+  static func eventHandler(
+    forwardingTo eventHandler: @escaping @Sendable (_ recordJSON: UnsafeRawBufferPointer) -> Void
+  ) -> Event.Handler {
+    let humanReadableOutputRecorder = Event.HumanReadableOutputRecorder()
+    return { event, context in
+      if case let .runStarted(plan) = event.kind {
+        // Gather all tests in the run and forward records for them.
+        for test in plan.steps.lazy.map(\.test) {
+          try? JSON.withEncoding(of: Self(encoding: test)) { testJSON in
+            eventHandler(testJSON)
+          }
+        }
+      }
+
+      let messages = humanReadableOutputRecorder.record(event, in: context)
+      if let eventRecord = Self(encoding: event, in: context, messages: messages) {
+        try? JSON.withEncoding(of: eventRecord, eventHandler)
+      }
+    }
+  }
+}
+
+// MARK: - Experimental event streaming
+
+/// A type containing an event snapshot and snapshots of the contents of an
+/// event context suitable for streaming over JSON.
+///
+/// This type is not part of the public interface of the testing library.
+/// External adopters are not necessarily written in Swift and are expected to
+/// decode the JSON produced for this type in implementation-specific ways.
+///
+/// - Warning: This type will be removed when the ABI version 0 JSON schema is
+///   finalized.
+struct EventAndContextSnapshot {
+  /// A snapshot of the event.
+  var event: Event.Snapshot
+
+  /// A snapshot of the event context.
+  var eventContext: Event.Context.Snapshot
+}
+
+extension EventAndContextSnapshot: Codable {}
+
+/// Create an event handler that encodes events as JSON and forwards them to an
+/// ABI-friendly event handler.
+///
+/// - Parameters:
+///   - eventHandler: The event handler to forward events to. See
+///     ``ABIEntryPoint_v0`` for more information.
+///
+/// - Returns: An event handler.
+///
+/// The resulting event handler outputs data as JSON. For each event handled by
+/// the resulting event handler, a JSON object representing it and its
+/// associated context is created and is passed to `eventHandler`. These JSON
+/// objects are guaranteed not to contain any ASCII newline characters (`"\r"`
+/// or `"\n"`).
+///
+/// Note that `_eventHandlerForStreamingEvents_v0(toFileAtPath:)` calls this
+/// function and performs additional postprocessing before writing JSON data.
+///
+/// - Warning: This function will be removed when the ABI version 0 JSON schema
+///   is finalized.
+func eventHandlerForStreamingEventSnapshots(
+  to eventHandler: @escaping @Sendable (_ eventAndContextJSON: UnsafeRawBufferPointer) -> Void
+) -> Event.Handler {
+  return { event, context in
+    let snapshot = EventAndContextSnapshot(
+      event: Event.Snapshot(snapshotting: event),
+      eventContext: Event.Context.Snapshot(snapshotting: context)
+    )
+    try? JSON.withEncoding(of: snapshot) { eventAndContextJSON in
+      eventAndContextJSON.withUnsafeBytes { eventAndContextJSON in
+        eventHandler(eventAndContextJSON)
+      }
+    }
+  }
+}
+#endif

--- a/Sources/Testing/EntryPoints/ABIv0/ABIv0.Record.swift
+++ b/Sources/Testing/EntryPoints/ABIv0/ABIv0.Record.swift
@@ -1,0 +1,85 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+extension ABIv0 {
+  /// A type implementing the JSON encoding of records for the ABI entry point
+  /// and event stream output.
+  ///
+  /// This type is not part of the public interface of the testing library. It
+  /// assists in converting values to JSON; clients that consume this JSON are
+  /// expected to write their own decoders.
+  struct Record: Sendable {
+    /// The version of this record.
+    ///
+    /// The value of this property corresponds to the ABI version i.e. `0`.
+    var version = 0
+
+    /// An enumeration describing the various kinds of record.
+    enum Kind: Sendable {
+      /// A test record.
+      case test(EncodedTest)
+
+      /// An event record.
+      case event(EncodedEvent)
+    }
+
+    /// The kind of record.
+    var kind: Kind
+
+    init(encoding test: borrowing Test) {
+      kind = .test(EncodedTest(encoding: test))
+    }
+
+    init?(encoding event: borrowing Event, in eventContext: borrowing Event.Context, messages: borrowing [Event.HumanReadableOutputRecorder.Message]) {
+      guard let event = EncodedEvent(encoding: event, in: eventContext, messages: messages) else {
+        return nil
+      }
+      kind = .event(event)
+    }
+  }
+}
+
+// MARK: - Codable
+
+extension ABIv0.Record: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case version
+    case kind
+    case payload
+  }
+
+  func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(version, forKey: .version)
+    switch kind {
+    case let .test(test):
+      try container.encode("test", forKey: .kind)
+      try container.encode(test, forKey: .payload)
+    case let .event(event):
+      try container.encode("event", forKey: .kind)
+      try container.encode(event, forKey: .payload)
+    }
+  }
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    version = try container.decode(Int.self, forKey: .version)
+    switch try container.decode(String.self, forKey: .kind) {
+    case "test":
+      let test = try container.decode(ABIv0.EncodedTest.self, forKey: .payload)
+      kind = .test(test)
+    case "event":
+      let event = try container.decode(ABIv0.EncodedEvent.self, forKey: .payload)
+      kind = .event(event)
+    case let kind:
+      throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Unrecognized record kind '\(kind)'"))
+    }
+  }
+}

--- a/Sources/Testing/EntryPoints/ABIv0/ABIv0.swift
+++ b/Sources/Testing/EntryPoints/ABIv0/ABIv0.swift
@@ -1,0 +1,12 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+/// A namespace for ABI version 0 symbols.
+enum ABIv0: Sendable {}

--- a/Sources/Testing/EntryPoints/ABIv0/Encoded/ABIv0.EncodedEvent.swift
+++ b/Sources/Testing/EntryPoints/ABIv0/Encoded/ABIv0.EncodedEvent.swift
@@ -1,0 +1,103 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+extension ABIv0 {
+  /// A type implementing the JSON encoding of ``Event`` for the ABI entry point
+  /// and event stream output.
+  ///
+  /// This type is not part of the public interface of the testing library. It
+  /// assists in converting values to JSON; clients that consume this JSON are
+  /// expected to write their own decoders.
+  struct EncodedEvent: Sendable {
+    /// An enumeration describing the various kinds of event.
+    ///
+    /// Note that the set of encodable events is a subset of all events
+    /// generated at runtime by the testing library.
+    ///
+    /// For descriptions of individual cases, see ``Event/Kind``.
+    enum Kind: String, Sendable {
+      case runStarted
+      case testStarted
+      case testCaseStarted
+      case issueRecorded
+      case knownIssueRecorded
+      case testCaseEnded
+      case testEnded
+      case testSkipped
+      case runEnded
+    }
+
+    /// The kind of event.
+    var kind: Kind
+
+    /// The source location of the event, if applicable.
+    var sourceLocation: SourceLocation?
+
+    /// The instant at which the event occurred on the current system's
+    /// suspending clock.
+    var timestamp: Double
+
+    /// The instant at which the event occurred on the wall clock.
+    var timestampSince1970: Double
+
+    /// Human-readable messages associated with this event that can be presented
+    /// to the user.
+    var messages: [EncodedMessage]
+
+    /// The ID of the test associated with this event, if any.
+    var testID: EncodedTest.ID?
+
+    /// The ID of the test case associated with this event, if any.
+    ///
+    /// - Warning: Test cases are not yet part of the JSON schema.
+    var _testCase: EncodedTestCase?
+
+    init?(encoding event: borrowing Event, in eventContext: borrowing Event.Context, messages: borrowing [Event.HumanReadableOutputRecorder.Message]) {
+      if let test = eventContext.test {
+        sourceLocation = test.sourceLocation
+      }
+      switch event.kind {
+      case .runStarted:
+        kind = .runStarted
+      case .testStarted:
+        kind = .testStarted
+      case .testCaseStarted:
+        kind = .testCaseStarted
+      case let .issueRecorded(issue):
+        if issue.isKnown {
+          kind = .knownIssueRecorded
+        } else {
+          kind = .issueRecorded
+        }
+        sourceLocation = issue.sourceLocation
+      case .testCaseEnded:
+        kind = .testCaseEnded
+      case .testEnded:
+        kind = .testEnded
+      case .testSkipped:
+        kind = .testSkipped
+      case .runEnded:
+        kind = .runEnded
+      default:
+        return nil
+      }
+      timestamp = Double(event.instant.suspending)
+      timestampSince1970 = Double(event.instant.wall)
+      self.messages = messages.map(EncodedMessage.init)
+      testID = event.testID.map(EncodedTest.ID.init)
+      _testCase = eventContext.testCase.map(EncodedTestCase.init)
+    }
+  }
+}
+
+// MARK: - Codable
+
+extension ABIv0.EncodedEvent: Codable {}
+extension ABIv0.EncodedEvent.Kind: Codable {}

--- a/Sources/Testing/EntryPoints/ABIv0/Encoded/ABIv0.EncodedInstant.swift
+++ b/Sources/Testing/EntryPoints/ABIv0/Encoded/ABIv0.EncodedInstant.swift
@@ -1,0 +1,36 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+extension ABIv0 {
+  /// A type implementing the JSON encoding of ``Test/Clock/Instant`` for the
+  /// ABI entry point and event stream output.
+  ///
+  /// This type is not part of the public interface of the testing library. It
+  /// assists in converting values to JSON; clients that consume this JSON are
+  /// expected to write their own decoders.
+  struct EncodedInstant: Sendable {
+    /// The number of seconds since the system-defined suspending epoch.
+    ///
+    /// For more information, see [`SuspendingClock`](https://developer.apple.com/documentation/swift/suspendingclock).
+    var absolute: Double
+
+    /// The number of seconds since the UNIX epoch (1970-01-01 00:00:00 UT).
+    var since1970: Double
+
+    init(encoding instant: borrowing Test.Clock.Instant) {
+      absolute = Double(instant.suspending)
+      since1970 = Double(instant.wall)
+    }
+  }
+}
+
+// MARK: - Codable
+
+extension ABIv0.EncodedInstant: Codable {}

--- a/Sources/Testing/EntryPoints/ABIv0/Encoded/ABIv0.EncodedIssue.swift
+++ b/Sources/Testing/EntryPoints/ABIv0/Encoded/ABIv0.EncodedIssue.swift
@@ -1,0 +1,34 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+extension ABIv0 {
+  /// A type implementing the JSON encoding of ``Issue`` for the ABI entry point
+  /// and event stream output.
+  ///
+  /// This type is not part of the public interface of the testing library. It
+  /// assists in converting values to JSON; clients that consume this JSON are
+  /// expected to write their own decoders.
+  struct EncodedIssue: Sendable {
+    /// Whether or not this issue is known to occur.
+    var isKnown: Bool
+
+    /// The location in source where this issue occurred, if available.
+    var sourceLocation: SourceLocation?
+
+    init(encoding issue: borrowing Issue) {
+      isKnown = issue.isKnown
+      sourceLocation = issue.sourceLocation
+    }
+  }
+}
+
+// MARK: - Codable
+
+extension ABIv0.EncodedIssue: Codable {}

--- a/Sources/Testing/EntryPoints/ABIv0/Encoded/ABIv0.EncodedMessage.swift
+++ b/Sources/Testing/EntryPoints/ABIv0/Encoded/ABIv0.EncodedMessage.swift
@@ -1,0 +1,78 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+extension ABIv0 {
+  /// A type implementing the JSON encoding of
+  /// ``Event/HumanReadableOutputRecorder/Message`` for the ABI entry point and
+  /// event stream output.
+  ///
+  /// This type is not part of the public interface of the testing library. It
+  /// assists in converting values to JSON; clients that consume this JSON are
+  /// expected to write their own decoders.
+  struct EncodedMessage: Sendable {
+    /// A type implementing the JSON encoding of ``Event/Symbol`` for the ABI
+    /// entry point and event stream output.
+    ///
+    /// For descriptions of individual cases, see ``Event/Symbol``.
+    enum Symbol: String, Sendable {
+      case `default`
+      case skip
+      case pass
+      case passWithKnownIssue
+      case fail
+      case difference
+      case warning
+      case details
+
+      init(encoding symbol: Event.Symbol) {
+        self = switch symbol {
+        case .default:
+            .default
+        case .skip:
+            .skip
+        case let .pass(knownIssueCount):
+          if knownIssueCount > 0 {
+            .passWithKnownIssue
+          } else {
+            .pass
+          }
+        case .fail:
+            .fail
+        case .difference:
+            .difference
+        case .warning:
+            .warning
+        case .details:
+            .details
+        }
+      }
+    }
+
+    /// The symbol associated with this message.
+    var symbol: Symbol
+
+    /// The human-readable, unformatted text associated with this message.
+    var text: String
+
+    /// The human-readable, Markdown-formatted text associated with this
+    /// message, if any.
+    var markdown: String?
+
+    init(encoding message: borrowing Event.HumanReadableOutputRecorder.Message) {
+      symbol = Symbol(encoding: message.symbol ?? .default)
+      text = message.conciseStringValue ?? message.stringValue
+    }
+  }
+}
+
+// MARK: - Codable
+
+extension ABIv0.EncodedMessage: Codable {}
+extension ABIv0.EncodedMessage.Symbol: Codable {}

--- a/Sources/Testing/EntryPoints/ABIv0/Encoded/ABIv0.EncodedMessage.swift
+++ b/Sources/Testing/EntryPoints/ABIv0/Encoded/ABIv0.EncodedMessage.swift
@@ -34,9 +34,9 @@ extension ABIv0 {
       init(encoding symbol: Event.Symbol) {
         self = switch symbol {
         case .default:
-            .default
+          .default
         case .skip:
-            .skip
+          .skip
         case let .pass(knownIssueCount):
           if knownIssueCount > 0 {
             .passWithKnownIssue
@@ -44,13 +44,13 @@ extension ABIv0 {
             .pass
           }
         case .fail:
-            .fail
+          .fail
         case .difference:
-            .difference
+          .difference
         case .warning:
-            .warning
+          .warning
         case .details:
-            .details
+          .details
         }
       }
     }
@@ -60,10 +60,6 @@ extension ABIv0 {
 
     /// The human-readable, unformatted text associated with this message.
     var text: String
-
-    /// The human-readable, Markdown-formatted text associated with this
-    /// message, if any.
-    var markdown: String?
 
     init(encoding message: borrowing Event.HumanReadableOutputRecorder.Message) {
       symbol = Symbol(encoding: message.symbol ?? .default)

--- a/Sources/Testing/EntryPoints/ABIv0/Encoded/ABIv0.EncodedTest.swift
+++ b/Sources/Testing/EntryPoints/ABIv0/Encoded/ABIv0.EncodedTest.swift
@@ -25,9 +25,6 @@ extension ABIv0 {
 
       /// A test function.
       case function
-
-      /// A parameterized test function.
-      case parameterizedFunction
     }
 
     /// The kind of test.
@@ -70,21 +67,27 @@ extension ABIv0 {
     /// - Warning: Test cases are not yet part of the JSON schema.
     var _testCases: [EncodedTestCase]?
 
+    /// Whether or not the test is parameterized.
+    ///
+    /// If this instance represents a test _suite_, the value of this property
+    /// is `nil`.
+    var isParameterized: Bool?
+
     init(encoding test: borrowing Test) {
       if test.isSuite {
         kind = .suite
-      } else if test.isParameterized {
-        kind = .parameterizedFunction
       } else {
         kind = .function
+        let testIsParameterized = test.isParameterized
+        isParameterized = testIsParameterized
+        if testIsParameterized {
+          _testCases = test.testCases?.map(EncodedTestCase.init(encoding:))
+        }
       }
       name = test.name
       displayName = test.displayName
       sourceLocation = test.sourceLocation
       id = ID(encoding: test.id)
-      if test.isParameterized {
-        _testCases = test.testCases?.map(EncodedTestCase.init(encoding:))
-      }
     }
   }
 }

--- a/Sources/Testing/EntryPoints/ABIv0/Encoded/ABIv0.EncodedTest.swift
+++ b/Sources/Testing/EntryPoints/ABIv0/Encoded/ABIv0.EncodedTest.swift
@@ -1,0 +1,122 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+extension ABIv0 {
+  /// A type implementing the JSON encoding of ``Test`` for the ABI entry point
+  /// and event stream output.
+  ///
+  /// The properties and members of this type are documented in ABI/JSON.md.
+  ///
+  /// This type is not part of the public interface of the testing library. It
+  /// assists in converting values to JSON; clients that consume this JSON are
+  /// expected to write their own decoders.
+  struct EncodedTest: Sendable {
+    /// An enumeration describing the various kinds of test.
+    enum Kind: String, Sendable {
+      /// A test suite.
+      case suite
+
+      /// A test function.
+      case function
+
+      /// A parameterized test function.
+      case parameterizedFunction
+    }
+
+    /// The kind of test.
+    var kind: Kind
+
+    /// The programmatic name of the test, such as its corresponding Swift
+    /// function or type name.
+    var name: String
+
+    /// The developer-supplied human-readable name of the test.
+    var displayName: String?
+
+    /// The source location of this test.
+    var sourceLocation: SourceLocation
+
+    /// A type implementing the JSON encoding of ``Test/ID`` for the ABI entry
+    /// point and event stream output.
+    struct ID: Codable {
+      /// The string value representing the corresponding test ID.
+      var stringValue: String
+
+      init(encoding testID: borrowing Test.ID) {
+        stringValue = String(describing: copy testID)
+      }
+
+      func encode(to encoder: any Encoder) throws {
+        try stringValue.encode(to: encoder)
+      }
+
+      init(from decoder: any Decoder) throws {
+        stringValue = try String(from: decoder)
+      }
+    }
+
+    /// The unique identifier of this test.
+    var id: ID
+
+    /// The test cases in this test, if it is a parameterized test function.
+    ///
+    /// - Warning: Test cases are not yet part of the JSON schema.
+    var _testCases: [EncodedTestCase]?
+
+    init(encoding test: borrowing Test) {
+      if test.isSuite {
+        kind = .suite
+      } else if test.isParameterized {
+        kind = .parameterizedFunction
+      } else {
+        kind = .function
+      }
+      name = test.name
+      displayName = test.displayName
+      sourceLocation = test.sourceLocation
+      id = ID(encoding: test.id)
+      if test.isParameterized {
+        _testCases = test.testCases?.map(EncodedTestCase.init(encoding:))
+      }
+    }
+  }
+}
+
+extension ABIv0 {
+  /// A type implementing the JSON encoding of ``Test/Case`` for the ABI entry
+  /// point and event stream output.
+  ///
+  /// The properties and members of this type are documented in ABI/JSON.md.
+  ///
+  /// This type is not part of the public interface of the testing library. It
+  /// assists in converting values to JSON; clients that consume this JSON are
+  /// expected to write their own decoders.
+  ///
+  /// - Warning: Test cases are not yet part of the JSON schema.
+  struct EncodedTestCase: Sendable {
+    var id: String
+    var displayName: String
+
+    init(encoding testCase: borrowing Test.Case) {
+      // TODO: define an encodable form of Test.Case.ID
+      id = String(describing: testCase.id)
+      displayName = testCase.arguments.lazy
+        .map(\.value)
+        .map(String.init(describingForTest:))
+        .joined(separator: ", ")
+    }
+  }
+}
+
+// MARK: - Codable
+
+extension ABIv0.EncodedTest: Codable {}
+extension ABIv0.EncodedTest.Kind: Codable {}
+extension ABIv0.EncodedTestCase: Codable {}

--- a/Sources/Testing/Events/Event.swift
+++ b/Sources/Testing/Events/Event.swift
@@ -15,8 +15,11 @@ public struct Event: Sendable {
   public enum Kind: Sendable {
     /// A test run started.
     ///
+    /// - Parameters:
+    ///   - plan: The test plan of the run that started.
+    ///
     /// This event is the first event posted after ``Runner/run()`` is called.
-    case runStarted
+    indirect case runStarted(_ plan: Runner.Plan)
 
     /// An iteration of the test run started.
     ///

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -27,6 +27,11 @@ extension Event {
 
       /// The human-readable message.
       var stringValue: String
+
+      /// A concise version of ``stringValue``, if available.
+      ///
+      /// Not all messages include a concise string.
+      var conciseStringValue: String?
     }
 
     /// A type that contains mutable context for
@@ -388,12 +393,14 @@ extension Event.HumanReadableOutputRecorder {
       let primaryMessage: Message = if parameterCount == 0 {
         Message(
           symbol: symbol,
-          stringValue: "\(_capitalizedTitle(for: test)) \(testName) recorded a\(known) issue\(atSourceLocation): \(issue.kind)"
+          stringValue: "\(_capitalizedTitle(for: test)) \(testName) recorded a\(known) issue\(atSourceLocation): \(issue.kind)",
+          conciseStringValue: String(describing: issue.kind)
         )
       } else {
         Message(
           symbol: symbol,
-          stringValue: "\(_capitalizedTitle(for: test)) \(testName) recorded a\(known) issue with \(parameterCount.counting("argument")) \(labeledArguments)\(atSourceLocation): \(issue.kind)"
+          stringValue: "\(_capitalizedTitle(for: test)) \(testName) recorded a\(known) issue with \(parameterCount.counting("argument")) \(labeledArguments)\(atSourceLocation): \(issue.kind)",
+          conciseStringValue: String(describing: issue.kind)
         )
       }
       return CollectionOfOne(primaryMessage) + additionalMessages

--- a/Sources/Testing/Events/TimeValue.swift
+++ b/Sources/Testing/Events/TimeValue.swift
@@ -117,3 +117,19 @@ extension timespec {
     self.init(tv_sec: .init(timeValue.seconds), tv_nsec: .init(timeValue.attoseconds / 1_000_000_000))
   }
 }
+
+extension FloatingPoint {
+  /// Initialize this floating-point value with the total number of seconds
+  /// (including the subsecond part) represented by an instance of
+  /// ``TimeValue``.
+  ///
+  /// - Parameters:
+  ///   - timeValue: The instance of ``TimeValue`` to convert.
+  ///
+  /// The resulting value may have less precision than `timeValue` as most
+  /// floating-point types are unable to represent a time value's
+  /// ``TimeValue/attoseconds`` property exactly.
+  init(_ timeValue: TimeValue) {
+    self = Self(timeValue.seconds) + (Self(timeValue.attoseconds) / (1_000_000_000_000_000_000 as Self))
+  }
+}

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -321,7 +321,7 @@ extension Runner {
     }
 
     await Configuration.withCurrent(runner.configuration) {
-      Event.post(.runStarted, for: nil, testCase: nil, configuration: runner.configuration)
+      Event.post(.runStarted(runner.plan), for: nil, testCase: nil, configuration: runner.configuration)
       defer {
         Event.post(.runEnded, for: nil, testCase: nil, configuration: runner.configuration)
       }

--- a/Sources/Testing/Support/JSON.swift
+++ b/Sources/Testing/Support/JSON.swift
@@ -29,6 +29,10 @@ enum JSON {
 
     // Keys must be sorted to ensure deterministic matching of encoded data.
     encoder.outputFormatting.insert(.sortedKeys)
+    if Environment.flag(named: "SWT_PRETTY_PRINT_JSON") == true {
+      encoder.outputFormatting.insert(.prettyPrinted)
+      encoder.outputFormatting.insert(.withoutEscapingSlashes)
+    }
 
     // Set user info keys that clients want to use during encoding.
     encoder.userInfo.merge(userInfo, uniquingKeysWith: { _, rhs in rhs})

--- a/Tests/TestingTests/ABIEntryPointTests.swift
+++ b/Tests/TestingTests/ABIEntryPointTests.swift
@@ -36,6 +36,7 @@ struct ABIEntryPointTests {
     // Construct arguments and convert them to JSON.
     var arguments = __CommandLineArguments_v0()
     arguments.filter = ["NonExistentTestThatMatchesNothingHopefully"]
+    arguments.experimentalEventStreamVersion = 0
     let argumentsJSON = try JSON.withEncoding(of: arguments) { argumentsJSON in
       let result = UnsafeMutableRawBufferPointer.allocate(byteCount: argumentsJSON.count, alignment: 1)
       _ = memcpy(result.baseAddress!, argumentsJSON.baseAddress!, argumentsJSON.count)
@@ -46,9 +47,9 @@ struct ABIEntryPointTests {
     }
 
     // Call the entry point function.
-    let result = await abiEntryPoint.pointee(.init(argumentsJSON)) { eventAndContextJSON in
-      let eventAndContext = try! JSON.decode(EventAndContextSnapshot.self, from: eventAndContextJSON)
-      _ = (eventAndContext.event, eventAndContext.eventContext)
+    let result = await abiEntryPoint.pointee(.init(argumentsJSON)) { recordJSON in
+      let record = try! JSON.decode(ABIv0.Record.self, from: recordJSON)
+      _ = record.version
     }
 
     // Validate expectations.

--- a/Tests/TestingTests/EventTests.swift
+++ b/Tests/TestingTests/EventTests.swift
@@ -44,7 +44,7 @@ struct EventTests {
                 sourceLocation: nil)
             )
           ),
-          Event.Kind.runStarted,
+          Event.Kind.runStarted(Runner.Plan(steps: [])),
           Event.Kind.runEnded,
           Event.Kind.testCaseStarted,
           Event.Kind.testCaseEnded,


### PR DESCRIPTION
This PR defines a JSON schema for events output from swift-testing via either `--experimental-event-stream-output` or `abiEntryPoint_v0()`. The JSON schema needs to be formally reviewed separately.

We are already writing an experimental JSON stream using "snapshot" types and we don't want to break folks experimenting with it before we have a final JSON schema, so for now that remains the default. To opt into the new schema, pass `--experimental-event-stream-version 0` (note that this argument is not forwarded from `swift test`. See https://github.com/apple/swift-package-manager/pull/7534.)

Resolves #368.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
