### PR TITLE
Rename `.serial` to `.serialized`.

### DIFF
--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -22,12 +22,12 @@ extension Runner {
         /// ``Configuration/isParallelizationEnabled`` property of the
         /// configuration passed during initialization has a value of `true`.
         ///
-        /// Traits such as ``Trait/serial`` applied to individual tests may
+        /// Traits such as ``Trait/serialized`` applied to individual tests may
         /// affect whether or not that test is parallelized.
         ///
         /// ## See Also
         ///
-        /// - ``SerialTrait``
+        /// - ``ParallelizationTrait``
         public var isParallelizationEnabled: Bool
       }
 

--- a/Sources/Testing/Testing.docc/Parallelization.md
+++ b/Sources/Testing/Testing.docc/Parallelization.md
@@ -20,23 +20,23 @@ run in the same process. The number of tests that run concurrently is controlled
 by the Swift runtime.
 
 <!--
-HIDDEN: .serial is experimental SPI pending feature review.
+HIDDEN: .serialized is experimental SPI pending feature review.
 
 ## Disabling parallelization
 
 Parallelization can be disabled on a per-function or per-suite basis using the
-``Trait/serial`` trait:
+``Trait/serialized`` trait:
 
 ```swift
-@Test(.serial, arguments: Food.allCases) func prepare(food: Food) {
+@Test(.serialized, arguments: Food.allCases) func prepare(food: Food) {
   // This function will be invoked serially, once per food, because it has the
-  // .serial trait.
+  // .serialized trait.
 }
 
-@Suite(.serial) struct FoodTruckTests {
+@Suite(.serialized) struct FoodTruckTests {
   @Test(arguments: Condiment.allCases) func refill(condiment: Condiment) {
     // This function will be invoked serially, once per condiment, because the
-    // containing suite has the .serial trait.
+    // containing suite has the .serialized trait.
   }
 
   @Test func startEngine() async throws {
@@ -62,6 +62,6 @@ disabled (by, for example, passing `--no-parallel` to the `swift test` command.)
 
 ## Topics
 
-- ``Trait/serial``
-- ``SerialTrait``
+- ``Trait/serialized``
+- ``ParallelizationTrait``
 -->

--- a/Sources/Testing/Testing.docc/Traits.md
+++ b/Sources/Testing/Testing.docc/Traits.md
@@ -34,9 +34,9 @@ behavior of test functions.
 - ``Trait/timeLimit(_:)``
 
 <!--
-HIDDEN: .serial is experimental SPI pending feature review.
+HIDDEN: .serialized is experimental SPI pending feature review.
 ### Running tests serially or in parallel
-- ``SerialTrait``
+- ``ParallelizationTrait``
  -->
 
 ### Annotating tests

--- a/Sources/Testing/Traits/ParallelizationTrait.swift
+++ b/Sources/Testing/Traits/ParallelizationTrait.swift
@@ -25,9 +25,9 @@
 /// globally disabled (by, for example, passing `--no-parallel` to the
 /// `swift test` command.)
 ///
-/// To add this trait to a test, use ``Trait/serial``.
+/// To add this trait to a test, use ``Trait/serialized``.
 @_spi(Experimental)
-public struct SerialTrait: TestTrait, SuiteTrait {
+public struct ParallelizationTrait: TestTrait, SuiteTrait {
   public var isRecursive: Bool {
     true
   }
@@ -36,7 +36,7 @@ public struct SerialTrait: TestTrait, SuiteTrait {
 // MARK: - SPIAwareTrait
 
 @_spi(ForToolsIntegrationOnly)
-extension SerialTrait: SPIAwareTrait {
+extension ParallelizationTrait: SPIAwareTrait {
   public func prepare(for test: Test, action: inout Runner.Plan.Action) async throws {
     if case var .run(options) = action {
       options.isParallelizationEnabled = false
@@ -48,13 +48,13 @@ extension SerialTrait: SPIAwareTrait {
 // MARK: -
 
 @_spi(Experimental)
-extension Trait where Self == SerialTrait {
+extension Trait where Self == ParallelizationTrait {
   /// A trait that serializes the test to which it is applied.
   ///
   /// ## See Also
   ///
-  /// - ``SerialTrait``
-  public static var serial: Self {
+  /// - ``ParallelizationTrait``
+  public static var serialized: Self {
     Self()
   }
 }

--- a/Tests/TestingTests/Support/EnvironmentTests.swift
+++ b/Tests/TestingTests/Support/EnvironmentTests.swift
@@ -11,7 +11,7 @@
 @testable @_spi(Experimental) import Testing
 private import TestingInternals
 
-@Suite("Environment Tests", .serial)
+@Suite("Environment Tests", .serialized)
 struct EnvironmentTests {
   var name = "SWT_ENVIRONMENT_VARIABLE_FOR_TESTING"
 

--- a/Tests/TestingTests/Traits/ParallelizationTraitTests.swift
+++ b/Tests/TestingTests/Traits/ParallelizationTraitTests.swift
@@ -10,7 +10,7 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
-@Suite("Serial Trait Tests", .tags("trait"))
+@Suite("Parallelization Trait Tests", .tags("trait"))
 struct ParallelizationTraitTests {
   @Test(".serialized trait is recursively applied")
   func serializedTrait() async {

--- a/Tests/TestingTests/Traits/ParallelizationTraitTests.swift
+++ b/Tests/TestingTests/Traits/ParallelizationTraitTests.swift
@@ -11,9 +11,9 @@
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
 @Suite("Serial Trait Tests", .tags("trait"))
-struct SerialTraitTests {
-  @Test(".serial trait is recursively applied")
-  func serialTrait() async {
+struct ParallelizationTraitTests {
+  @Test(".serialized trait is recursively applied")
+  func serializedTrait() async {
     var configuration = Configuration()
     configuration.isParallelizationEnabled = true
     let plan = await Runner.Plan(selecting: OuterSuite.self, configuration: configuration)
@@ -22,7 +22,7 @@ struct SerialTraitTests {
     }
   }
 
-  @Test(".serial trait serializes parameterized test")
+  @Test(".serialized trait serializes parameterized test")
   func serializesParameterizedTestFunction() async {
     var configuration = Configuration()
     configuration.isParallelizationEnabled = true
@@ -56,7 +56,7 @@ struct SerialTraitTests {
 
 // MARK: - Fixtures
 
-@Suite(.hidden, .serial)
+@Suite(.hidden, .serialized)
 private struct OuterSuite {
   /* This @Suite intentionally left blank */ struct IntermediateSuite {
     @Suite(.hidden)


### PR DESCRIPTION
Pending an API review thread on the forums, we've decided to rename this trait to `.serialized`.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
