### PR TITLE
Refactor type enumeration loop.

### DIFF
--- a/Sources/TestingInternals/Discovery.cpp
+++ b/Sources/TestingInternals/Discovery.cpp
@@ -11,6 +11,7 @@
 #include "Discovery.h"
 
 #include <atomic>
+#include <cstring>
 #include <iterator>
 #include <type_traits>
 #include <vector>
@@ -351,7 +352,7 @@ void swt_enumerateTypesWithNamesContaining(const char *nameSubstring, void *cont
       // Check that the type's name passes. This will be more expensive than the
       // checks above, but should be cheaper than realizing the metadata.
       const char *typeName = contextDescriptor->getName();
-      bool nameOK = typeName && nullptr != strstr(typeName, nameSubstring);
+      bool nameOK = typeName && nullptr != std::strstr(typeName, nameSubstring);
       if (!nameOK) {
         continue;
       }

--- a/Sources/TestingInternals/Discovery.cpp
+++ b/Sources/TestingInternals/Discovery.cpp
@@ -328,13 +328,13 @@ static void enumerateTypeMetadataSections(const SectionEnumerator& body) {}
 
 #pragma mark -
 
-void swt_enumerateTypes(void *context, SWTTypeEnumerator body, SWTTypeNameFilter nameFilter) {
+void swt_enumerateTypesWithNamesContaining(const char *nameSubstring, void *context, SWTTypeEnumerator body) {
   enumerateTypeMetadataSections([=] (const void *section, size_t size) {
     auto records = reinterpret_cast<const SWTTypeMetadataRecord *>(section);
     size_t recordCount = size / sizeof(SWTTypeMetadataRecord);
 
-    bool keepGoing = true;
-    for (size_t i = 0; i < recordCount && keepGoing; i++) {
+    bool stop = false;
+    for (size_t i = 0; i < recordCount && !stop; i++) {
       const auto& record = records[i];
 
       auto contextDescriptor = record.getContextDescriptor();
@@ -348,19 +348,16 @@ void swt_enumerateTypes(void *context, SWTTypeEnumerator body, SWTTypeNameFilter
         continue;
       }
 
-      // If the caller supplied a name filtering function, check that the type's
-      // name passes. This will be more expensive than the checks above, but
-      // should be cheaper than realizing the metadata.
-      if (nameFilter) {
-        const char *typeName = contextDescriptor->getName();
-        bool nameOK = typeName && (* nameFilter)(typeName, context);
-        if (!nameOK) {
-          continue;
-        }
+      // Check that the type's name passes. This will be more expensive than the
+      // checks above, but should be cheaper than realizing the metadata.
+      const char *typeName = contextDescriptor->getName();
+      bool nameOK = typeName && nullptr != strstr(typeName, nameSubstring);
+      if (!nameOK) {
+        continue;
       }
 
       if (void *typeMetadata = contextDescriptor->getMetadata()) {
-        keepGoing = body(typeMetadata, context);
+        body(typeMetadata, &stop, context);
       }
     }
   });

--- a/Sources/TestingInternals/include/Discovery.h
+++ b/Sources/TestingInternals/include/Discovery.h
@@ -17,45 +17,28 @@
 
 SWT_ASSUME_NONNULL_BEGIN
 
-/// The type of callback that is called by `swt_enumerateTypes()`.
+/// The type of callback called by `swt_enumerateTypes()`.
 ///
 /// - Parameters:
 ///   - typeMetadata: A type metadata pointer that can be bitcast to `Any.Type`.
+///   - stop: A pointer to a boolean variable indicating whether type
+///     enumeration should stop after the function returns. Set `*stop` to
+///     `true` to stop type enumeration.
 ///   - context: An arbitrary pointer passed by the caller to
 ///     `swt_enumerateTypes()`.
-///
-/// - Returns: Whether or not to continue enumeration.
-typedef bool (* SWTTypeEnumerator)(void *typeMetadata, void *_Null_unspecified context);
-
-/// The type name filter that is called by `swt_enumerateTypes()`.
-///
-/// - Parameters:
-///   - typeName: The name of the type being considered, as a C string.
-///   - context: An arbitrary pointer passed by the caller to
-///     `swt_enumerateTypes()`.
-///
-/// - Returns: Whether or not the type named by `typeName` should be passed to
-///   the corresponding enumerator function.
-typedef bool (* SWTTypeNameFilter)(const char *typeName, void *_Null_unspecified context);
+typedef void (* SWTTypeEnumerator)(void *typeMetadata, bool *stop, void *_Null_unspecified context);
 
 /// Enumerate all types known to Swift found in the current process.
 ///
 /// - Parameters:
-///   - nameFilter: If not `nullptr`, a filtering function that checks if a type
-///     name is valid before realizing the type.
-///   - body: A function to invoke. `context` is passed to it along with a
-///     type metadata pointer (which can be bitcast to `Any.Type`.)
+///   - nameSubstring: A string which the names of matching classes all contain.
 ///   - context: An arbitrary pointer to pass to `body`.
-///
-/// This function may enumerate the same type more than once (for instance, if
-/// it is present in an image's metadata table multiple times, or if it is an
-/// Objective-C class implemented in Swift.) Callers are responsible for
-/// deduping type metadata pointers passed to `body`.
-SWT_EXTERN void swt_enumerateTypes(
+///   - body: A function to invoke, once per matching type.
+SWT_EXTERN void swt_enumerateTypesWithNamesContaining(
+  const char *nameSubstring,
   void *_Null_unspecified context,
-  SWTTypeEnumerator body,
-  SWTTypeNameFilter _Nullable nameFilter
-) SWT_SWIFT_NAME(swt_enumerateTypes(_:_:withNamesMatching:));
+  SWTTypeEnumerator body
+) SWT_SWIFT_NAME(swt_enumerateTypes(withNamesContaining:_:_:));
 
 SWT_ASSUME_NONNULL_END
 


### PR DESCRIPTION
This PR reworks `swt_enumerateTypes()` and adds a Swift wrapper so that less boilerplate is needed at call sites. Since we're always using it to look for types with a particular substring in their names, I've dropped the name-matcher callback and replaced it with a simple "give me a substring to look for"-type argument.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
