### PR TITLE
Return the ABI entry point from `swt_copyABIEntryPoint_v0()` normally.

### DIFF
--- a/Sources/Testing/EntryPoints/ABIEntryPoint.swift
+++ b/Sources/Testing/EntryPoints/ABIEntryPoint.swift
@@ -28,7 +28,7 @@
 ///
 /// - Warning: This function's signature and the structure of its JSON inputs
 ///   and outputs have not been finalized yet.
-@_spi(ForToolsIntegrationOnly)
+@_spi(Experimental) @_spi(ForToolsIntegrationOnly)
 public typealias ABIEntryPoint_v0 = @Sendable (
   _ argumentsJSON: UnsafeRawBufferPointer?,
   _ eventHandler: @escaping @Sendable (_ eventAndContextJSON: UnsafeRawBufferPointer) -> Void
@@ -37,12 +37,9 @@ public typealias ABIEntryPoint_v0 = @Sendable (
 /// Get the entry point to the testing library used by tools that want to remain
 /// version-agnostic regarding the testing library.
 ///
-/// - Parameters:
-///   - outEntryPoint: Uninitialized memory large enough to hold an instance of
-///     ``ABIEntryPoint_v0``. On return, a pointer to an instance of that type
-///     representing the ABI-stable entry point to the testing library. The
-///     caller owns this memory and is responsible for deinitializing and
-///     deallocating it when done.
+/// - Returns: A pointer to an instance of that type representing the ABI-stable
+///   entry point to the testing library. The caller owns this memory and is
+///   responsible for deinitializing and deallocating it when done.
 ///
 /// This function can be used by tools that do not link directly to the testing
 /// library and wish to invoke tests in a binary that has been loaded into the
@@ -50,16 +47,17 @@ public typealias ABIEntryPoint_v0 = @Sendable (
 /// `"swt_copyABIEntryPoint_v0"` and can be dynamically looked up at runtime
 /// using `dlsym()` or a platform equivalent.
 ///
-/// The function stored at `outEntryPoint` can be thought of as equivalent to
+/// The returned function can be thought of as equivalent to
 /// `swift test --experimental-event-stream-output` except that, instead of
 /// streaming events to a named pipe or file, it streams them to a callback.
 ///
 /// - Warning: This function's signature and the structure of its JSON inputs
 ///   and outputs have not been finalized yet.
 @_cdecl("swt_copyABIEntryPoint_v0")
-@usableFromInline
-func abiEntryPoint_v0(_ outEntryPoint: UnsafeMutableRawPointer) {
-  outEntryPoint.initializeMemory(as: ABIEntryPoint_v0.self) { argumentsJSON, eventHandler in
+@_spi(Experimental) @_spi(ForToolsIntegrationOnly)
+public func copyABIEntryPoint_v0() -> UnsafeMutableRawPointer {
+  let result = UnsafeMutablePointer<ABIEntryPoint_v0>.allocate(capacity: 1)
+  result.initialize { argumentsJSON, eventHandler in
     let args = try! argumentsJSON.map { argumentsJSON in
       try JSON.decode(__CommandLineArguments_v0.self, from: argumentsJSON)
     }
@@ -67,6 +65,7 @@ func abiEntryPoint_v0(_ outEntryPoint: UnsafeMutableRawPointer) {
     let eventHandler = eventHandlerForStreamingEvents_v0(to: eventHandler)
     return await entryPoint(passing: args, eventHandler: eventHandler)
   }
+  return .init(result)
 }
 #endif
 

--- a/Tests/TestingTests/ABIEntryPointTests.swift
+++ b/Tests/TestingTests/ABIEntryPointTests.swift
@@ -15,21 +15,19 @@ private import TestingInternals
 @Suite("ABI entry point tests")
 struct ABIEntryPointTests {
   @Test func v0() async throws {
-    // Get the ABI entry point.
-#if os(Linux)
-    // The standard Linux linker does not allow exporting symbols from
+#if !os(Linux)
+    // Get the ABI entry point by dynamically looking it up at runtime.
+    //
+    // NOTE: The standard Linux linker does not allow exporting symbols from
     // executables, so dlsym() does not let us find this function on that
     // platform when built as an executable rather than a dynamic library.
-    let copyABIEntryPoint = abiEntryPoint_v0
-#else
-    let copyABIEntryPoint = try #require(
+    let copyABIEntryPoint_v0 = try #require(
       swt_getFunctionWithName(nil, "swt_copyABIEntryPoint_v0").map {
-        unsafeBitCast($0, to: (@convention(c) (UnsafeMutableRawPointer) -> Void).self)
+        unsafeBitCast($0, to: (@convention(c) () -> UnsafeMutableRawPointer).self)
       }
     )
 #endif
-    let abiEntryPoint = UnsafeMutablePointer<ABIEntryPoint_v0>.allocate(capacity: 1)
-    copyABIEntryPoint(abiEntryPoint)
+    let abiEntryPoint = copyABIEntryPoint_v0().assumingMemoryBound(to: ABIEntryPoint_v0.self)
     defer {
       abiEntryPoint.deinitialize(count: 1)
       abiEntryPoint.deallocate()


### PR DESCRIPTION
This PR changes the calling convention of `swt_copyABIEntryPoint_v0()` to return a pointer to the ABI entry point rather than passing it back through an out-parameter. The previous signature was an attempt to allow using `withUnsafeTemporaryAllocation()` (to avoid a heap allocation) but that's a premature optimization and makes the function harder to use.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
