### PR TITLE
During test discovery, ignore Swift types in the Darwin/dyld shared cache.

### DIFF
--- a/Sources/TestingInternals/Discovery.cpp
+++ b/Sources/TestingInternals/Discovery.cpp
@@ -29,6 +29,12 @@
 #include <os/lock.h>
 
 #if !__has_include(<mach-o/dyld_priv.h>)
+/// Get the range of addresses in the shared cache.
+///
+/// The Swift runtime uses this function on Apple platforms to optimize protocol
+/// conformance lookups. The testing library uses it to optimize test discovery.
+///
+/// - Note: This function is not public API on Darwin.
 SWT_IMPORT_FROM_STDLIB const void *_dyld_get_shared_cache_range(size_t *length);
 #endif
 #endif

--- a/Sources/TestingInternals/Discovery.cpp
+++ b/Sources/TestingInternals/Discovery.cpp
@@ -21,9 +21,16 @@
 #elif defined(__APPLE__)
 #include <dispatch/dispatch.h>
 #include <mach-o/dyld.h>
+#if __has_include(<mach-o/dyld_priv.h>)
+#include <mach-o/dyld_priv.h>
+#endif
 #include <mach-o/getsect.h>
 #include <objc/runtime.h>
 #include <os/lock.h>
+
+#if !__has_include(<mach-o/dyld_priv.h>)
+extern "C" const void *_dyld_get_shared_cache_range(size_t *length);
+#endif
 #endif
 
 /// Enumerate over all Swift type metadata sections in the current process.
@@ -227,14 +234,31 @@ static SWTMachHeaderList getMachHeaders(void) {
   static constinit SWTMachHeaderList *machHeaders = nullptr;
   static constinit os_unfair_lock lock = OS_UNFAIR_LOCK_INIT;
 
+  // The bounds of the dyld shared cache. On platforms that support it (Darwin),
+  // most system images are containined in this range. System images can be
+  // expected not to contain test declarations, so we don't need to walk them.
+  static constinit uintptr_t dyldSharedCacheBegin = 0;
+  static constinit uintptr_t dyldSharedCacheEnd = 0;
+
   static constinit dispatch_once_t once = 0;
   dispatch_once_f(&once, nullptr, [] (void *) {
     machHeaders = reinterpret_cast<SWTMachHeaderList *>(std::malloc(sizeof(SWTMachHeaderList)));
     ::new (machHeaders) SWTMachHeaderList();
     machHeaders->reserve(_dyld_image_count());
 
+    // Get the bounds of the shared cache.
+    size_t dyldSharedCacheLength = 0;
+    dyldSharedCacheBegin = reinterpret_cast<uintptr_t>(_dyld_get_shared_cache_range(&dyldSharedCacheLength));
+    dyldSharedCacheEnd = dyldSharedCacheBegin + dyldSharedCacheLength;
+
     objc_addLoadImageFunc([] (const mach_header *mh) {
       auto mhn = reinterpret_cast<SWTMachHeaderList::value_type>(mh);
+
+      // Ignore this Mach header if it is in the shared cache.
+      auto machHeaderAddress = reinterpret_cast<uintptr_t>(mhn);
+      if (machHeaderAddress >= dyldSharedCacheBegin && machHeaderAddress < dyldSharedCacheEnd) {
+        return;
+      }
 
       // Only store the mach header address if the image contains Swift data.
       // Swift does not support unloading images, but images that do not contain

--- a/Sources/TestingInternals/Discovery.cpp
+++ b/Sources/TestingInternals/Discovery.cpp
@@ -29,7 +29,7 @@
 #include <os/lock.h>
 
 #if !__has_include(<mach-o/dyld_priv.h>)
-extern "C" const void *_dyld_get_shared_cache_range(size_t *length);
+SWT_IMPORT_FROM_STDLIB const void *_dyld_get_shared_cache_range(size_t *length);
 #endif
 #endif
 


### PR DESCRIPTION
This PR modifies the Darwin-specific implementation of runtime type enumeration such that types in Darwin's dyld shared cache are ignored. As of macOS Sonoma, there are approximately 300 images in the shared cache containing approximately 3,000 Swift types, none of which are reasonably expected to represent test declarations.

We don't need to enumerate these types. Skipping them gets us a speedup of approximately 27% (according to my very unscientific measurements.)

Images in the current process (including framework binaries) that come from the shared cache have the `MH_DYLIB_IN_CACHE` bit set in their Mach headers, so we can easily filter them out.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
