### PR TITLE
Proofread pass of the articles

### DIFF
--- a/Sources/Testing/Testing.docc/AddingComments.md
+++ b/Sources/Testing/Testing.docc/AddingComments.md
@@ -14,11 +14,11 @@ Add comments to provide useful information about tests.
 
 ## Overview
 
-It is often useful to add comments to code in order:
+It's often useful to add comments to code to:
 
-- to provide context or background information about the code's purpose;
-- to explain how complex code implemented; or
-- to include details which may be helpful when diagnosing issues.
+- Provide context or background information about the code's purpose
+- Explain how complex code implemented
+- Include details which may be helpful when diagnosing issues
 
 Test code is no different and can benefit from explanatory code comments, but
 often test issues are shown in places where the source code of the test is
@@ -44,7 +44,7 @@ immediately before its `@Test` or `@Suite` attribute:
 }
 ```
 
-The comment `"// Assumes the standard lunch menu includes a taco"` will be added
+The comment, `// Assumes the standard lunch menu includes a taco`, are added
 to the test.
 
 The following language comment styles are supported:
@@ -61,7 +61,7 @@ The following language comment styles are supported:
 Test comments which are automatically added from source code comments preserve
 their original formatting, including any prefixes like `//` or `/**`. This
 is because the whitespace and formatting of comments can be meaningful in some
-circumstances or aid in understanding the comment—for example, when a comment
+circumstances or aid in understanding the comment; for example, when a comment
 includes an example code snippet or diagram.
 
 <!-- FIXME: Uncomment this section if/when the `.comment(...)` trait is promoted
@@ -88,10 +88,10 @@ func lunchMenu() {
 
 ## Use test comments effectively
 
-As in normal code, comments on tests are generally most useful when:
+As in normal code, comments on tests are generally most useful when they:
 
-- they add information that isn't obvious from reading the code; or
-- they provide useful information about the operation or motivation of a test.
+- Add information that isn't obvious from reading the code
+- Provide useful information about the operation or motivation of a test
 
 If a test is related to a bug or issue, consider using the ``Bug`` trait instead
-of comments. For more information, review <doc:AssociatingBugs>.
+of comments. For more information, see <doc:AssociatingBugs>.

--- a/Sources/Testing/Testing.docc/AddingTags.md
+++ b/Sources/Testing/Testing.docc/AddingTags.md
@@ -16,8 +16,8 @@ Use tags to provide semantic information for organization, filtering, and custom
 
 A complex package or project may contain hundreds or thousands of tests and
 suites. Some subset of those tests may share some common facet, such as being
-"critical" or "flaky". The testing library includes a type of trait called
-"tags" that can be added to tests to group and categorize them.
+*critical* or *flaky*. The testing library includes a type of trait called
+*tags* that you can add to group and categorize tests.
 
 Tags are different from test suites: test suites impose structure on test
 functions at the source level, while tags provide semantic information for a
@@ -31,7 +31,7 @@ a sequence of tags as its argument, and those tags are then applied to the
 corresponding test at runtime. If any tags are applied to a test suite, then all
 tests in that suite inherit those tags.
 
-The testing library does not assign any semantic meaning to any tags, nor does
+The testing library doesn't assign any semantic meaning to any tags, nor does
 the presence or absence of tags affect how the testing library runs tests.
 
 Tags themselves are instances of ``Tag`` and can be expressed as string
@@ -52,7 +52,7 @@ If two tags with the same name (`legallyRequired` in the above example) are
 declared in different files, modules, or other contexts, the testing library
 treats them as equivalent.
 
-If it is important for a tag to be distinguished from similar tags declared
+If it's important for a tag to be distinguished from similar tags declared
 elsewhere in a package or project (or its dependencies), use
  [reverse-DNS naming](https://en.wikipedia.org/wiki/Reverse_domain_name_notation)
 to create a unique Swift symbol name for your tag:
@@ -82,9 +82,9 @@ The following example is unsupported:
 
 ```swift
 extension Tag {
-  @Tag static var legallyRequired: Self // ✅ OK: declaring a new tag
+  @Tag static var legallyRequired: Self // ✅ OK: Declaring a new tag
 
-  static var requiredByLaw: Self { // ❌ ERROR: this tag name will not be
+  static var requiredByLaw: Self { // ❌ ERROR: This tag name will not be
                                    // recognized at runtime
     legallyRequired
   }
@@ -97,17 +97,17 @@ declaration), it cannot be applied to test functions or test suites. The
 following declarations are unsupported:
 
 ```swift
-@Tag let needsKetchup: Self // ❌ ERROR: tags must be declared in an extension
+@Tag let needsKetchup: Self // ❌ ERROR: Tags must be declared in an extension
                             // to Tag
 struct Food {
-  @Tag var needsMustard: Self // ❌ ERROR: tags must be declared in an extension
+  @Tag var needsMustard: Self // ❌ ERROR: Tags must be declared in an extension
                               // to Tag
 }
 ```
 
 ## Built-in tags
 
-The testing library predefines the following symbolic tags that can be used in
+The testing library predefines the following symbolic tags that you can use in
 any test target and applied to any test:
 
 - ``Tag/red``
@@ -117,36 +117,36 @@ any test target and applied to any test:
 - ``Tag/blue``
 - ``Tag/purple``
 
-The testing library does not assign any semantic meaning to these tags, nor does
+The testing library doesn't assign any semantic meaning to these tags, nor does
 the presence or absence of these tags affect how the testing library runs tests.
 
 ## Customize a tag's appearance
 
-By default, a tag does not appear in a test's output when the test is run. It is
+By default, a tag doesn't appear in a test's output when the test is run. It's
 possible to assign colors to tags defined in a package so that when the test is
 run, the tag is visible in its output.
 
 To add colors to tags, create a directory in your home directory named
-`".swift-testing"` and add a file named `"tag-colors.json"` to it. This file
-should contain a JSON object (a dictionary) whose keys are strings representing
+`.swift-testing` and add a file named `tag-colors.json` to it. This file
+should contain a JSON object (a dictionary) whose keys are strings that represent
 tags and whose values represent tag colors.
 
-- Note: On Windows, create the `".swift-testing"` directory in the
-  `"AppData\Local"` directory inside your home directory instead of directly
+- Note: On Windows, create the `.swift-testing` directory in the
+  `AppData\Local` directory inside your home directory instead of directly
   inside it.
 
 Tag colors can be represented using several formats:
 
-- The strings `"red"`, `"orange"`, `"yellow"`, `"green"`, `"blue"`, or
-  `"purple"`, representing corresponding predefined instances of ``Tag``, i.e.
+- The strings `red`, `orange`, `yellow`, `green`, `blue`, or
+  `purple`, represent corresponding predefined instances of ``Tag``, like
   ``Tag/red``, ``Tag/orange``, ``Tag/yellow``, ``Tag/green``, ``Tag/blue``, and
-  ``Tag/purple``;
-- A string of the form `"#RRGGBB"`, containing a hexadecimal representation of
-  the color in a device-independent RGB color space; or
-- The `null` literal value, representing "no color."
+  ``Tag/purple``.
+- A string of the form `#RRGGBB`, containing a hexadecimal representation of
+  the color in a device-independent RGB color space.
+- The `null` literal value, which represents no color.
 
-For example, to set the color of the tag `"critical"` to orange and the color of
-the tag `.legallyRequired` to teal, the contents of `"tag-colors.json"` can
+For example, to set the color of the `critical` tag to orange and the color of
+the `.legallyRequired` tag to teal, the contents of `tag-colors.json` can
 be set to:
 
 ```json

--- a/Sources/Testing/Testing.docc/AssociatingBugs.md
+++ b/Sources/Testing/Testing.docc/AssociatingBugs.md
@@ -15,8 +15,8 @@ Associate bugs uncovered or verified by tests.
 ## Overview
 
 Tests allow developers to prove that the code they write is working as expected.
-If code is not working correctly, bug trackers are often used to track the work
-necessary to fix the underlying problem. It is often useful to associate
+If code isn't working correctly, bug trackers are often used to track the work
+necessary to fix the underlying problem. It's often useful to associate
 specific bugs with tests that reproduce them or verify they are fixed.
 
 - Note: "Bugs" as described in this document may also be referred to as
@@ -75,16 +75,16 @@ The testing library defines several kinds of common bug/test relationship:
 
 | Relationship | Use when… |
 |-|-|
-| `.uncoveredBug` | … a test run failed, uncovering the bug in question. |
-| `.reproducesBug` | … a bug was previously filed and the test was written to demonstrate it. |
-| `.verifiesFix` | … a bug has been fixed and the test shows that it no longer reproduces. |
-| `.failingBecauseOfBug` | … a test was previously passing, but now an unrelated bug is causing it to fail. |
-| `.unspecified` | … no other case accurately describes the relationship. |
+| `.uncoveredBug` | A test run failed, uncovering the bug in question. |
+| `.reproducesBug` | A bug was previously filed and the test was written to demonstrate it. |
+| `.verifiesFix` | A bug has been fixed and the test shows that it no longer reproduces. |
+| `.failingBecauseOfBug` | A test was previously passing, but now an unrelated bug is causing it to fail. |
+| `.unspecified` | No other case accurately describes the relationship. |
 
-<!-- Keep `.unspecified` as the last row above in order to imply it is a
+<!-- Keep `.unspecified` as the last row above to imply it is a
 fallback. -->
 
-## Adding comments to associated bugs
+## Add comments to associated bugs
 
 A bug identifier may be insufficient to uniquely and clearly identify a bug
 associated with a test. Bug trackers universally provide a "title" field for

--- a/Sources/Testing/Testing.docc/BugIdentifiers.md
+++ b/Sources/Testing/Testing.docc/BugIdentifiers.md
@@ -10,7 +10,7 @@ See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 -->
 
-How the testing library interprets bug identifiers provided by developers.
+Examine how the testing library interprets bug identifiers provided by developers.
 
 ## Overview
 
@@ -21,7 +21,7 @@ formats are associated with some common bug-tracking systems.
   "issues." To avoid confusion with the ``Issue`` type in the testing library,
   this document consistently refers to them as "bugs."
 
-## Recognized formats
+### Recognized formats
 
 - If the bug identifier begins with `"rdar:"`, it is assumed to represent a bug
   filed with Apple's Radar system.
@@ -29,9 +29,9 @@ formats are associated with some common bug-tracking systems.
   [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt), it is assumed to represent
   an issue tracked at that URL.
 - If the bug identifier begins with `"FB"` and the rest of it can be parsed as
-  an unsigned integer, it is assumed to represent a bug filed with the
+  an unsigned integer, it's assumed to represent a bug filed with the
   [Apple Feedback Assistant](https://feedbackassistant.apple.com).
-- If the bug identifier can be parsed as an unsigned integer, it is assumed to
+- If the bug identifier can be parsed as an unsigned integer, it's assumed to
   represent an issue with that numeric identifier in an unspecified bug-tracking
   system.
 - All other bug identifiers are considered invalid and will cause the compiler
@@ -46,13 +46,13 @@ handling to detect:
   the same repository as the test.
 -->
 
-## Examples
+### Examples
 
-| Trait Function | Valid | Inferred Bug-Tracking System |
+| Trait function | Valid | Inferred bug-tracking system |
 |-|:-:|-|
 | `.bug(12345)` | Yes | None |
 | `.bug("12345")` | Yes | None |
-| `.bug("Things don't work")` | **No** | None |
+| `.bug("Things don't work")` | No | None |
 | `.bug("rdar:12345")` | Yes | Apple Radar |
 | `.bug("https://github.com/apple/swift/pull/12345")` | Yes | [GitHub Issues for the Swift project](https://github.com/apple/swift/issues) |
 | `.bug("https://bugs.webkit.org/show_bug.cgi?id=12345")` | Yes | [WebKit Bugzilla](https://bugs.webkit.org/) |

--- a/Sources/Testing/Testing.docc/DefiningTests.md
+++ b/Sources/Testing/Testing.docc/DefiningTests.md
@@ -20,7 +20,7 @@ This article assumes that the package or project being tested has already been
 configured with a test target. For help configuring a package to use the testing
 library, see <doc:TemporaryGettingStarted>.
 
-## Import the testing library
+### Import the testing library
 
 To import the testing library, add the following to the Swift source file that
 contains the test:
@@ -30,12 +30,12 @@ import Testing
 ```
 
 - Note: Only import the testing library into a test target. Importing the
-  testing library into an application, library, or binary target is not
-  supported or recommended. Test functions are not stripped from binaries when
+  testing library into an application, library, or binary target isn't
+  supported or recommended. Test functions aren't stripped from binaries when
   building for release, so logic and fixtures of a test may be visible to anyone
   who inspects a build product that contains a test function.
 
-## Declare a test function
+### Declare a test function
 
 To declare a test function, write a Swift function declaration that doesn't
 take any arguments, then prefix its name with the `@Test` attribute:
@@ -51,11 +51,11 @@ containing test functions is automatically a _test suite_ and can be optionally
 annotated with the `@Suite` attribute. For more information about suites, see
 <doc:OrganizingTests>.
 
-Note that, while this function is a valid test function, it does not actually
+Note that, while this function is a valid test function, it doesn't actually
 perform any action or test any code. To check for expected values and outcomes
 in test functions, add [expectations](doc:Expectations) to the test function.
 
-## Customize a test's name
+### Customize a test's name
 
 To customize a test function's name as presented in an IDE or at the command
 line, supply a string literal as an argument to the `@Test` attribute:
@@ -67,7 +67,7 @@ line, supply a string literal as an argument to the `@Test` attribute:
 To further customize the appearance and behavior of a test function, use
  [traits](doc:Traits) such as ``Trait/tags(_:)-505n9``.
 
-## Writing concurrent or throwing tests
+### Write concurrent or throwing tests
 
 As with other Swift functions, test functions can be marked `async` and `throws`
 to annotate them as concurrent or throwing, respectively. If a test is only safe
@@ -78,7 +78,7 @@ the process), it can be annotated `@MainActor`:
 @Test @MainActor func foodTruckExists() async throws { ... }
 ```
 
-## Limit the availability of a test
+### Limit the availability of a test
 
 If a test function can only run on newer versions of an operating system or of
 the Swift language, use the `@available` attribute when declaring it. Use the
@@ -87,6 +87,6 @@ a test is unable to run due to limited availability:
 
 ```swift
 @available(macOS 11.0, *)
-@available(swift, introduced: 8.0, message: "Requires Swift 8.0 features to run")
+@available(swift, introduced: 5.0, message: "Requires Swift 5.0 features to run")
 @Test func foodTruckExists() { ... }
 ```

--- a/Sources/Testing/Testing.docc/EnablingAndDisabling.md
+++ b/Sources/Testing/Testing.docc/EnablingAndDisabling.md
@@ -3,18 +3,18 @@
 <!--
 This source file is part of the Swift.org open source project
 
-Copyright (c) 2023 Apple Inc. and the Swift project authors
+Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 -->
 
-Conditionally enable or disable individual tests before they run.
+Enable or disable individual tests before they run.
 
 ## Overview
 
-Often, a test will only be applicable in specific circumstances. For instance,
+Often, a test is only applicable in specific circumstances. For instance,
 you might want to write a test that only runs on devices with particular
 hardware capabilities, or performs locale-dependent operations. The testing
 library allows you to add traits to your tests that cause runners to
@@ -22,7 +22,7 @@ automatically skip them if conditions like these are not met.
 
 - Note: A condition may be evaluated multiple times during testing.
 
-## Disable a test
+### Disable a test
 
 If you need to disable a test unconditionally, use the
 ``Trait/disabled(_:fileID:filePath:line:column:)`` function. Given the following
@@ -42,7 +42,7 @@ func sellsBurritos() async throws { ... }
 
 The test will now always be skipped.
 
-It is also possible to add a comment to the trait to present in the output from
+It's also possible to add a comment to the trait to present in the output from
 the runner when it skips the test:
 
 ```swift
@@ -50,7 +50,7 @@ the runner when it skips the test:
 func sellsBurritos() async throws { ... }
 ```
 
-## Conditionally enable or disable a test
+### Enable or disable a test conditionally
 
 Sometimes, it makes sense to enable a test only when a certain condition is met. Consider
 the following test function:
@@ -60,9 +60,8 @@ the following test function:
 func isCold() async throws { ... }
 ```
 
-If it is currently winter, then presumably ice cream will not be available for
-sale and this test will fail. It therefore makes sense to only enable it if it
-is currently summer. You can conditionally enable a test with
+If it's currently winter, then presumably ice cream won't be available for
+sale and this test will fail. It therefore makes sense to only enable it if it's currently summer. You can conditionally enable a test with
 ``Trait/enabled(if:_:fileID:filePath:line:column:)``:
 
 ```swift
@@ -70,7 +69,7 @@ is currently summer. You can conditionally enable a test with
 func isCold() async throws { ... }
 ```
 
-It is also possible to conditionally _disable_ a test and to combine multiple
+It's also possible to conditionally _disable_ a test and to combine multiple
 conditions:
 
 ```swift
@@ -101,7 +100,7 @@ If a test has multiple conditions applied to it, they must _all_ pass for it to
 run. Otherwise, the test notes the first condition to fail as the reason the test
 is skipped.
 
-## Handle complex conditions
+### Handle complex conditions
 
 If a condition is complex, consider factoring it out into a helper function to
 improve readability:

--- a/Sources/Testing/Testing.docc/LimitingExecutionTime.md
+++ b/Sources/Testing/Testing.docc/LimitingExecutionTime.md
@@ -3,7 +3,7 @@
 <!--
 This source file is part of the Swift.org open source project
 
-Copyright (c) 2023 Apple Inc. and the Swift project authors
+Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
@@ -19,8 +19,7 @@ resources to complete, may rely on downloaded data from a server, or may
 otherwise be dependent on external factors.
 
 If a test may hang indefinitely or may consume too many system resources to
-complete effectively, consider setting a time limit for it so that it will
-be marked as failing if it runs for an excessive amount of time. Use the
+complete effectively, consider setting a time limit for it so that it's marked as failing if it runs for an excessive amount of time. Use the
 ``Trait/timeLimit(_:)`` trait as an upper bound:
 
 ```swift
@@ -34,13 +33,13 @@ func serve100CustomersInOneHour() async {
 }
 ```
 
-If the above test function takes longer than 60 &times; 60 seconds (i.e. one
-hour) to execute, the task in which it is running will be
+If the above test function takes longer than an
+hour (60 x 60 seconds) to execute, the task in which it's running is
 [cancelled](https://developer.apple.com/documentation/swift/task/cancel())
-and the test will fail with an issue of kind
+and the test fails with an issue of kind
 ``Issue/Kind-swift.enum/timeLimitExceeded(timeLimitComponents:)``.
 
-- Note: if multiple time limit traits apply to a test, the shortest time limit
+- Note: If multiple time limit traits apply to a test, the shortest time limit
   is used.
 
 The testing library may adjust the specified time limit for performance reasons
@@ -51,11 +50,11 @@ limit traits.
 
 ### Time limits applied to test suites
 
-When a time limit is applied to a test suite, it is recursively applied to all
+When a time limit is applied to a test suite, it's recursively applied to all
 test functions and child test suites within that suite.
 
 ### Time limits applied to parameterized tests
 
-When a time limit is applied to a parameterized test function, it is applied to
+When a time limit is applied to a parameterized test function, it's applied to
 each invocation _separately_ so that if only some arguments cause failures, then
-successful arguments are not incorrectly marked as failing too.
+successful arguments aren't incorrectly marked as failing too.

--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -3,7 +3,7 @@
 <!--
 This source file is part of the Swift.org open source project
 
-Copyright (c) 2023 Apple Inc. and the Swift project authors
+Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
@@ -18,8 +18,8 @@ Migrate an existing test method or test class written using XCTest.
 ## Overview
 
 The testing library provides much of the same functionality of XCTest, but uses
-its own syntax to declare test functions and types. This document covers the
-process of converting XCTest-based content to use the testing library instead.
+its own syntax to declare test functions and types. Here, you'll learn how to
+convert XCTest-based content to use the testing library instead.
 
 ### Add the testing library as a dependency
 
@@ -53,18 +53,18 @@ source file contains mixed test content.
 
 ### Convert test classes
 
-XCTest groups related sets of test methods in test classes: classes that inherit
+XCTest groups related sets of test methods in test classes that inherit
 from the [`XCTestCase`](https://developer.apple.com/documentation/xctest/xctestcase)
-class provided by the XCTest framework. The testing library does not require
+class provided by the [XCTest](https://developer.apple.com/documentation/xctest) framework. The testing library doesn't require
 that test functions be instance members of types. Instead, they can be _free_ or
 _global_ functions, or can be `static` or `class` members of a type.
 
 If you want to group your test functions together, you can do so by placing them
 in a Swift type. The testing library refers to such a type as a _suite_. These
-types do _not_ need to be classes, and they do not inherit from `XCTestCase`.
+types do _not_ need to be classes, and they don't inherit from `XCTestCase`.
 
 To convert a subclass of `XCTestCase` to a suite, remove the `XCTestCase`
-conformance. It is also generally recommended that a Swift structure or actor be
+conformance. It's also generally recommended that a Swift structure or actor be
 used instead of a class because it allows the Swift compiler to better-enforce
 concurrency safety:
 
@@ -174,7 +174,7 @@ implement `deinit`:
 The testing library represents individual tests as functions, similar to how
 they are represented in XCTest. However, the syntax for declaring a test
 function is different. In XCTest, a test method must be a member of a test class
-and its name must start with `test`. The testing library does not require a test
+and its name must start with `test`. The testing library doesn't require a test
 function to have any particular name. Instead, it identifies a test function by
 the presence of the `@Test` attribute:
 
@@ -200,7 +200,7 @@ the presence of the `@Test` attribute:
 }
 
 As with XCTest, the testing library allows test functions to be marked `async`
-and/or `throws` and to be isolated to a global actor (for example, by using the
+or `throws`, or `async`-`throws`, and to be isolated to a global actor (for example, by using the
 `@MainActor` attribute.)
 
 - Note: XCTest runs synchronous test methods on the main actor by default, while
@@ -219,8 +219,8 @@ These functions are collectively referred to as
 [`XCTAssert()`](https://developer.apple.com/documentation/xctest/1500669-xctassert).
 The testing library has two replacements, ``expect(_:_:sourceLocation:)`` and
 ``require(_:_:sourceLocation:)-5l63q``. They both behave similarly to
-`XCTAssert()` except that ``require(_:_:sourceLocation:)-5l63q`` will throw an
-error if its condition is not met:
+`XCTAssert()` except that ``require(_:_:sourceLocation:)-5l63q`` throws an
+error if its condition isn't met:
 
 @Row {
   @Column {
@@ -334,8 +334,6 @@ function. To record an unconditional issue using the testing library, use the
   }
 }
 
------
-
 The following table includes a list of the various `XCTAssert()` functions and
 their equivalents in the testing library:
 
@@ -372,7 +370,7 @@ property to `false` to cause a test to stop running after a failure occurs.
 XCTest stops an affected test by throwing an Objective-C exception at the
 time the failure occurs.
 
-- Note: `continueAfterFailure` is not fully supported when using the
+- Note: `continueAfterFailure` isn't fully supported when using the
   [swift-corelibs-xctest](https://github.com/apple/swift-corelibs-xctest)
   library on non-Apple platforms.
 
@@ -380,7 +378,7 @@ The behavior of an exception thrown through a Swift stack frame is undefined. If
 an exception is thrown through an `async` Swift function, it typically causes
 the process to terminate abnormally, preventing other tests from running.
 
-The testing library does not use exceptions to stop test functions. Instead, use
+The testing library doesn't use exceptions to stop test functions. Instead, use
 the ``require(_:_:sourceLocation:)-5l63q`` macro, which throws a Swift error on
 failure:
 
@@ -419,7 +417,7 @@ the failed test method or test function.
 ### Validate asynchronous behaviors
 
 XCTest has a class, [`XCTestExpectation`](https://developer.apple.com/documentation/xctest/xctestexpectation),
-that represents some asynchronous condition. A developer creates an instance of
+that represents some asynchronous condition. You create an instance of
 this class (or a subclass like [`XCTKeyPathExpectation`](https://developer.apple.com/documentation/xctest/xctkeypathexpectation))
 using an initializer or a convenience method on `XCTestCase`. When the condition
 represented by an expectation occurs, the developer _fulfills_ the expectation.
@@ -428,9 +426,9 @@ instance of [`XCTWaiter`](https://developer.apple.com/documentation/xctest/xctwa
 or using a convenience method on `XCTestCase`.
 
 Wherever possible, prefer to use Swift concurrency to validate asynchronous
-conditions. For example, if it is necessary to determine the result of an
+conditions. For example, if it's necessary to determine the result of an
 asynchronous Swift function, it can be awaited with `await`. For a function that
-takes a completion handler but which does not use `await`, a Swift
+takes a completion handler but which doesn't use `await`, a Swift
 [continuation](https://developer.apple.com/documentation/swift/withcheckedcontinuation(function:_:))
 can be used to convert the call into an `async`-compatible one.
 
@@ -440,11 +438,10 @@ functionality called _confirmations_ which can be used to implement these tests.
 Instances of ``Confirmation`` are created and used within the scope of the
 function ``confirmation(_:expectedCount:fileID:filePath:line:column:_:)``.
 
-Confirmations function similarly to XCTest's expectations, however they do not
+Confirmations function similarly to the expectations of XCTest; however, they don't
 block or suspend the caller while waiting for a condition to be fulfilled.
 Instead, the requirement is expected to be _confirmed_ (the equivalent of
-_fulfilling_ an expectation) before `confirmation()` returns, and an issue is
-recorded otherwise:
+_fulfilling_ an expectation) before `confirmation()` returns, and records an issue otherwise:
 
 @Row {
   @Column {
@@ -532,7 +529,7 @@ test function with an instance of this trait type to control whether it runs:
 A test may have a known issue that sometimes or always prevents it from passing.
 When written using XCTest, such tests can call
 [`XCTExpectFailure(_:options:failingBlock:)`](https://developer.apple.com/documentation/xctest/3727246-xctexpectfailure)
-to tell XCTest and its infrastructure that the issue should not cause the test
+to tell XCTest and its infrastructure that the issue shouldn't cause the test
 to fail. The testing library has an equivalent function with synchronous and
 asynchronous variants:
 
@@ -574,8 +571,8 @@ issue:
 }
 
 - Note: The XCTest function [`XCTExpectFailure(_:options:)`](https://developer.apple.com/documentation/xctest/3727245-xctexpectfailure),
-  which does not take a closure and which affects the remainder of the test,
-  does not have a direct equivalent in the testing library. To mark an entire
+  which doesn't take a closure and which affects the remainder of the test,
+  doesn't have a direct equivalent in the testing library. To mark an entire
   test as having a known issue, wrap its body in a call to `withKnownIssue()`. 
 
 If a test may fail intermittently, the call to
@@ -624,10 +621,10 @@ Additional options can be specified when calling `XCTExpectFailure()`:
 
 - [`isEnabled`](https://developer.apple.com/documentation/xctest/xctexpectedfailure/options/3726085-isenabled)
   can be set to `false` to skip known-issue matching (for instance, if a
-  particular issue only occurs under certain conditions); and
+  particular issue only occurs under certain conditions)
 - [`issueMatcher`](https://developer.apple.com/documentation/xctest/xctexpectedfailure/options/3726086-issuematcher)
   can be set to a closure to allow marking only certain issues as known and to
-  allow other issues to be recorded as test failures.
+  allow other issues to be recorded as test failures
 
 The testing library includes overloads of `withKnownIssue()` that take
 additional arguments with similar behavior:
@@ -635,7 +632,7 @@ additional arguments with similar behavior:
 - ``withKnownIssue(_:isIntermittent:fileID:filePath:line:column:_:when:matching:)-68e5g``
 - ``withKnownIssue(_:isIntermittent:fileID:filePath:line:column:_:when:matching:)-7azqg``
 
-To conditionally enable known-issue matching and/or to match only certain kinds
+To conditionally enable known-issue matching or to match only certain kinds
 of issues:
 
 @Row {

--- a/Sources/Testing/Testing.docc/OrganizingTests.md
+++ b/Sources/Testing/Testing.docc/OrganizingTests.md
@@ -3,7 +3,7 @@
 <!--
 This source file is part of the Swift.org open source project
 
-Copyright (c) 2023 Apple Inc. and the Swift project authors
+Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
@@ -17,18 +17,18 @@ Organize tests into test suites.
 When working with a large selection of test functions, it can be helpful to
 organize them into test suites.
 
-A test function can be added to a test suite in one of several ways:
+A test function can be added to a test suite in one of two ways:
 
-@Comment { 0. By placing it in the same file as other test functions; }
-1. By placing it in a Swift type; or
-2. By placing it in a Swift type and annotating that type with the `@Suite`
+@Comment{ * By placing it in the same file as other test functions. }
+* By placing it in a Swift type.
+* By placing it in a Swift type and annotating that type with the `@Suite`
    attribute.
 
-The `@Suite` attribute is not required for the testing library to recognize that
+The `@Suite` attribute isn't required for the testing library to recognize that
 a type contains test functions, but adding it allows customization of a test
 suite's appearance in the IDE and at the command line. If a trait such as
 ``Trait/tags(_:)-505n9`` or ``Trait/disabled(_:fileID:filePath:line:column:)``
-is applied to a test suite, it is automatically inherited by the tests contained
+is applied to a test suite, it's automatically inherited by the tests contained
 in the suite.
 
 In addition to containing test functions and any other members that a Swift type
@@ -36,10 +36,10 @@ might contain, test suite types can also contain additional test suites nested
 within them. To add a nested test suite type, simply declare an additional type
 within the scope of the outer test suite type.
 
-By default, tests contained within a suite will run in parallel with each other.
+By default, tests contained within a suite run in parallel with each other.
 For more information about test parallelization, see <doc:Parallelization>.
 
-## Customize a suite's name
+### Customize a suite's name
 
 To customize a test suite's name, supply a string literal as an argument to the
 `@Suite` attribute:
@@ -56,7 +56,7 @@ To further customize the appearance and behavior of a test function, use
 ## Test functions in test suite types
 
 If a type contains a test function declared as an instance method (that is,
-without either the `static` or `class` keyword), the testing library will call
+without either the `static` or `class` keyword), the testing library calls
 that test function at runtime by initializing an instance of the type, then
 calling the test function on that instance. If a test suite type contains
 multiple test functions declared as instance methods, each one is called on a
@@ -82,21 +82,21 @@ Are equivalent to:
 }
 ```
 
-## Constraints on test suite types
+### Constraints on test suite types
 
-If a type is used as a test suite, it is subject to some constraints that are
+When using a type as a test suite, it's subject to some constraints that are
 not otherwise applied to Swift types.
 
-### An initializer may be required
+#### An initializer may be required
 
 If a type contains test functions declared as instance methods, it must be
 possible to initialize an instance of the type with a zero-argument initializer.
 The initializer may be any combination of:
 
-- implicit or explicit;
-- synchronous or asynchronous;
-- throwing or non-throwing; and
-- `private`, `fileprivate`, `internal`, `package`, or `public`.
+- implicit or explicit
+- synchronous or asynchronous
+- throwing or non-throwing
+- `private`, `fileprivate`, `internal`, `package`, or `public`
 
 For example:
 
@@ -104,25 +104,25 @@ For example:
 @Suite struct FoodTruckTests {
   var batteryLevel = 100
 
-  @Test func foodTruckExists() { ... } // ✅ OK: type has implicit init()
+  @Test func foodTruckExists() { ... } // ✅ OK: The type has an implicit init().
 }
 
 @Suite struct CashRegisterTests {
   private init(cashOnHand: Decimal = 0.0) async throws { ... }
 
-  @Test func calculateSalesTax() { ... } // ✅ OK: type has callable init()
+  @Test func calculateSalesTax() { ... } // ✅ OK: The type has a callable init().
 }
 
 struct MenuTests {
   var foods: [Food]
   var prices: [Food: Decimal]
 
-  @Test static func specialOfTheDay() { ... } // ✅ OK: function is static
-  @Test func orderAllFoods() { ... } // ❌ ERROR: suite type requires init()
+  @Test static func specialOfTheDay() { ... } // ✅ OK: The function is static.
+  @Test func orderAllFoods() { ... } // ❌ ERROR: The suite type requires init().
 }
 ```
 
-The compiler will emit an error when presented with a test suite that does not
+The compiler emits an error when presented with a test suite that doesn't
 meet this requirement.
 
 ### Test suite types must always be available
@@ -132,29 +132,29 @@ availability at runtime, a test suite type (and any types that contain it) must
 _not_ be annotated with the `@available` attribute:
 
 ```swift
-@Suite struct FoodTruckTests { ... } // ✅ OK: type is always available
+@Suite struct FoodTruckTests { ... } // ✅ OK: The type is always available.
 
-@available(macOS 11.0, *) // ❌ ERROR: suite type must always be available
+@available(macOS 11.0, *) // ❌ ERROR: The suite type must always be available.
 @Suite struct CashRegisterTests { ... }
 
-@available(macOS 11.0, *) struct MenuItemTests { // ❌ ERROR: suite type's
+@available(macOS 11.0, *) struct MenuItemTests { // ❌ ERROR: The suite type's
                                                  // containing type must always
-                                                 // be available too
+                                                 // be available too.
   @Suite struct BurgerTests { ... }
 }
 ```
 
-The compiler will emit an error when presented with a test suite that does not
+The compiler emits an error when presented with a test suite that doesn't
 meet this requirement.
 
-### Classes must be final
+#### Classes must be final
 
-The testing library does not currently support inheritance between test suite
-types. If a class is used as a test suite type, it may inherit from another
+The testing library doesn't support inheritance between test suite
+types. When using a class as a test suite type, it may inherit from another
 class, but it must be declared `final`:
 
 ```swift
-@Suite final class FoodTruckTests { ... } // ✅ OK: class is final
-actor CashRegisterTests: NSObject { ... } // ✅ OK: actors are implicitly final
-class MenuItemTests { ... } // ❌ ERROR: this class is not final
+@Suite final class FoodTruckTests { ... } // ✅ OK: The class is final.
+actor CashRegisterTests: NSObject { ... } // ✅ OK: The actors are implicitly final.
+class MenuItemTests { ... } // ❌ ERROR: This class isn't final.
 ```

--- a/Sources/Testing/Testing.docc/ParameterizedTesting.md
+++ b/Sources/Testing/Testing.docc/ParameterizedTesting.md
@@ -3,7 +3,7 @@
 <!--
 This source file is part of the Swift.org open source project
 
-Copyright (c) 2023 Apple Inc. and the Swift project authors
+Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
@@ -21,11 +21,11 @@ the elements of those collections being forwarded to a test function. An
 invocation of a test function with a particular set of argument values is called
 a test _case_.
 
-By default, the test cases of a test function will run in parallel with each
+By default, the test cases of a test function run in parallel with each
 other. For more information about test parallelization, see
 <doc:Parallelization>.
 
-## Parameterize over an array of values
+### Parameterize over an array of values
 
 It is very common to want to run a test _n_ times over an array containing the
 values that should be tested. Consider the following test function:
@@ -60,13 +60,13 @@ func foodAvailable(_ food: Food) async throws {
 }
 ```
 
-When a collection is passed to the `@Test` attribute for parameterization, the
+When passing a collection to the `@Test` attribute for parameterization, the
 testing library passes each element in the collection, one at a time, to the
 test function as its first (and only) argument. Then, if the test fails for one
 or more inputs, the corresponding diagnostics can clearly indicate which inputs
-need to be examined.
+to examine.
 
-## Parameterize over the cases of an enumeration
+### Parameterize over the cases of an enumeration
 
 The previous example includes a hard-coded list of `Food` cases to test. If `Food`
 is an enumeration that conforms to `CaseIterable`, you can instead write:
@@ -83,10 +83,10 @@ func foodAvailable(_ food: Food) async throws {
 }
 ```
 
-This way, if a new case is added to the `Food` enumeration, it is
+This way, if a new case is added to the `Food` enumeration, it's
 automatically tested by this function.
 
-## Parameterize over a range of integers
+### Parameterize over a range of integers
 
 It is possible to parameterize a test function over a closed range of integers:
 
@@ -101,9 +101,9 @@ func makeLargeOrder(count: Int) async throws {
 - Note: Very large ranges such as `0 ..< .max` may take an excessive amount of
   time to test, or may never complete due to resource constraints.
 
-## Test with more than one collection
+### Test with more than one collection
 
-It is possible to test more than one collection. Consider the following test
+It's possible to test more than one collection. Consider the following test
 function:
 
 ```swift
@@ -119,7 +119,7 @@ function, elements from the second collection are passed as the second argument,
 and so forth.
 
 Assuming there are five cases in the `Food` enumeration, this test function
-will, when run, be invoked 5 × 100 = 500 times with every possible combination
+will, when run, be invoked 500 times (5 x 100) with every possible combination
 of food and order size. These combinations are referred to as the collections'
 [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product).
 
@@ -137,31 +137,31 @@ func makeLargeOrder(of food: Food, count: Int) async throws {
 The zipped sequence will be "destructured" into two arguments automatically,
 then passed to the test function for evaluation.
 
-This revised test function will be invoked once for each tuple in the zipped
+This revised test function is invoked once for each tuple in the zipped
 sequence, for a total of five invocations instead of 500 invocations. In other
-words, this test function will be passed the inputs `(.burger, 1)`,
+words, this test function is passed the inputs `(.burger, 1)`,
 `(.iceCream, 2)`, ..., `(.kebab, 5)` instead of `(.burger, 1)`, `(.burger, 2)`,
-`(.burger, 3)`, ... `(.kebab, 99)`, `(.kebab, 100)`.
+`(.burger, 3)`, ..., `(.kebab, 99)`, `(.kebab, 100)`.
 
-## Run selected test cases
+### Run selected test cases
 
 If a parameterized test meets certain requirements, the testing library allows
-users to run specific test cases it contains. This can be useful when a test
+people to run specific test cases it contains. This can be useful when a test
 has many cases but only some are failing since it enables re-running and
 debugging the failing cases in isolation.
 
 To support running selected test cases, it must be possible to deterministically
-match the test case's arguments. When a user attempts to run selected test cases
+match the test case's arguments. When someone attempts to run selected test cases
 of a parameterized test function, the testing library evaluates each argument of
 the tests' cases for conformance to one of several known protocols, and if all
 arguments of a test case conform to one of those protocols, that test case can
 be run selectively. The following lists the known protocols, in precedence order
 (highest to lowest):
 
-1. ``CustomTestArgumentEncodable``.
-1. `RawRepresentable`, where `RawValue` conforms to `Encodable`.
-1. `Encodable`.
-1. `Identifiable`, where `ID` conforms to `Encodable`.
+1. ``CustomTestArgumentEncodable``
+1. `RawRepresentable`, where `RawValue` conforms to `Encodable`
+1. `Encodable`
+1. `Identifiable`, where `ID` conforms to `Encodable`
 
 If any argument of a test case doesn't meet one of the above requirements, then
 the overall test case cannot be run selectively.


### PR DESCRIPTION
Made a proofreading pass through the articles.

### Motivation:

To verify there are no typos.

### Modifications:

Largely, made edits to correct tense and turn text like "it is" or "does not" into contractions ("it's" and "doesn't", respectively).

### Result:

Clean up pass for initial release.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
