### PR TITLE
Lower predefined color tags to experimental SPI.

### DIFF
--- a/Sources/Testing/Testing.docc/AddingTags.md
+++ b/Sources/Testing/Testing.docc/AddingTags.md
@@ -105,6 +105,9 @@ struct Food {
 }
 ```
 
+<!--
+HIDDEN: tag colors are experimental SPI.
+
 ## Built-in tags
 
 The testing library predefines the following symbolic tags that can be used in
@@ -155,3 +158,4 @@ be set to:
   ".legallyRequired": "#66FFCC"
 }
 ```
+-->

--- a/Sources/Testing/Traits/Tags/Tag+Predefined.swift
+++ b/Sources/Testing/Traits/Tags/Tag+Predefined.swift
@@ -10,6 +10,7 @@
 
 // MARK: Primary colors
 
+@_spi(Experimental)
 extension Tag {
   /// A tag representing the color red.
   public static var red: Self {

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ForToolsIntegrationOnly) import Testing
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
 @Test(/* name unspecified */ .hidden)
 @Sendable func freeSyncFunction() {}


### PR DESCRIPTION
This PR lowers `Tag.red`, `Tag.orange`, etc. to experimental SPI pending a formal review of tag colors as a general feature.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
