### PR TITLE
Edits to doc comments in the EntryPoints files

### DIFF
--- a/Sources/Testing/EntryPoints/ABIEntryPoint.swift
+++ b/Sources/Testing/EntryPoints/ABIEntryPoint.swift
@@ -41,7 +41,7 @@ public typealias ABIEntryPoint_v0 = @Sendable (
 ///   ABI-stable entry point to the testing library. The caller owns this memory
 ///   and is responsible for deinitializing and deallocating it when done.
 ///
-/// This function can be used by tools that do not link directly to the testing
+/// This function can be used by tools that don't link directly to the testing
 /// library and wish to invoke tests in a binary that has been loaded into the
 /// current process. The function is emitted into the binary under the name
 /// `"swt_copyABIEntryPoint_v0"` and can be dynamically looked up at runtime

--- a/Sources/Testing/EntryPoints/ABIEntryPoint.swift
+++ b/Sources/Testing/EntryPoints/ABIEntryPoint.swift
@@ -99,7 +99,7 @@ extension EventAndContextSnapshot: Codable {}
 ///
 /// The resulting event handler outputs data as JSON. For each event handled by
 /// the resulting event handler, a JSON object representing it and its
-/// associated context is created and is passed to `eventHandler`. These JSON
+/// associated context is created and passed to `eventHandler`. These JSON
 /// objects are guaranteed not to contain any ASCII newline characters (`"\r"`
 /// or `"\n"`).
 ///

--- a/Sources/Testing/EntryPoints/ABIEntryPoint.swift
+++ b/Sources/Testing/EntryPoints/ABIEntryPoint.swift
@@ -52,7 +52,7 @@ public typealias ABIEntryPoint_v0 = @Sendable (
 /// streaming events to a named pipe or file, it streams them to a callback.
 ///
 /// - Warning: This function's signature and the structure of its JSON inputs
-///   and outputs have not been finalized yet.
+///   and outputs have not been finalized yet.@Comment{ QUERY: Has this been finalized? If so, can we remove the Warning? If not, we should make this a double-slash comment for initial release. }
 @_cdecl("swt_copyABIEntryPoint_v0")
 @_spi(Experimental) @_spi(ForToolsIntegrationOnly)
 public func copyABIEntryPoint_v0() -> UnsafeMutableRawPointer {

--- a/Sources/Testing/EntryPoints/ABIEntryPoint.swift
+++ b/Sources/Testing/EntryPoints/ABIEntryPoint.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -13,10 +13,10 @@
 /// to remain version-agnostic regarding the testing library.
 ///
 /// - Parameters:
-///   - argumentsJSON: A buffer to memory representing the JSON encoding of an
-///     instance of `__CommandLineArguments_v0`. If `nil`, a new instance is
-///     created from the command-line arguments to the current process.
-///   - eventHandler: An event handler to which is passed a buffer to memory
+///   - argumentsJSON: A buffer to memory that represents the JSON encoding of an
+///     instance of `__CommandLineArguments_v0`. If `nil`, and creates a new instance
+///     from the command-line arguments to the current process.
+///   - eventHandler: An event handler that receives a memory buffer
 ///     representing each event and its context, as with ``Event/Handler``, but
 ///     encoded as JSON.
 ///

--- a/Sources/Testing/EntryPoints/ABIEntryPoint.swift
+++ b/Sources/Testing/EntryPoints/ABIEntryPoint.swift
@@ -27,7 +27,7 @@
 /// and then invokes available tests in the current process.
 ///
 /// - Warning: This function's signature and the structure of its JSON inputs
-///   and outputs have not been finalized yet.
+///   and outputs have not been finalized yet.@Comment{ QUERY: Has this been finalized? If so, can we remove the Warning? If not, we should make this a double-slash comment for initial release. }
 @_spi(Experimental) @_spi(ForToolsIntegrationOnly)
 public typealias ABIEntryPoint_v0 = @Sendable (
   _ argumentsJSON: UnsafeRawBufferPointer?,

--- a/Sources/Testing/EntryPoints/ABIEntryPoint.swift
+++ b/Sources/Testing/EntryPoints/ABIEntryPoint.swift
@@ -92,8 +92,8 @@ extension EventAndContextSnapshot: Codable {}
 /// ABI-friendly event handler.
 ///
 /// - Parameters:
-///   - eventHandler: The event handler to forward events to. See
-///     ``ABIEntryPoint_v0`` for more information.
+///   - eventHandler: The event handler to forward events to. For more 
+///     information, see ``ABIEntryPoint_v0``.
 ///
 /// - Returns: An event handler.
 ///

--- a/Sources/Testing/EntryPoints/ABIEntryPoint.swift
+++ b/Sources/Testing/EntryPoints/ABIEntryPoint.swift
@@ -72,12 +72,12 @@ public func copyABIEntryPoint_v0() -> UnsafeMutableRawPointer {
 // MARK: - Experimental event streaming
 
 #if canImport(Foundation) && (!SWT_NO_FILE_IO || !SWT_NO_ABI_ENTRY_POINT)
-/// A type containing an event snapshot and snapshots of the contents of an
+/// A type that contains an event snapshot and snapshots of the contents of an
 /// event context suitable for streaming over JSON.
 ///
-/// This function is not part of the public interface of the testing library.
+/// This function isn't part of the public interface of the testing library.
 /// External adopters are not necessarily written in Swift and are expected to
-/// decode the JSON produced for this type in implementation-specific ways.
+/// decode the JSON produced for this type in implementation-specific ways.@Comment{ QUERY: Should we convert this text into a double-slashed comment? We don't typically talk about "external adopters" in the reference docs. }
 struct EventAndContextSnapshot {
   /// A snapshot of the event.
   var event: Event.Snapshot

--- a/Sources/Testing/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/EntryPoints/EntryPoint.swift
@@ -137,7 +137,7 @@ func listTestsForEntryPoint(_ tests: some Sequence<Test>) -> [String] {
 /// - Warning: This type's definition and JSON-encoded form have not been
 ///   finalized yet.@Comment{ QUERY: Has this been finalized? If so, can we remove the Warning? If not, we should make this a double-slash comment for initial release. }
 ///
-/// - Warning: This type is used by Swift Package Manager. Do not use it
+/// - Warning: This type is used by Swift Package Manager. Don't use it
 ///   directly.
 public struct __CommandLineArguments_v0: Sendable {
   public init() {}
@@ -172,7 +172,7 @@ public struct __CommandLineArguments_v0: Sendable {
   /// The identifier of the `XCTestCase` instance hosting the testing library,
   /// if ``XCTestScaffold`` is being used.
   ///
-  /// This property is not ABI and will be removed with ``XCTestScaffold``.
+  /// This property is not ABI and will be removed with ``XCTestScaffold``.@Comment{ QUERY: Should we remove this line? }
   var xcTestCaseHostIdentifier: String?
 }
 

--- a/Sources/Testing/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/EntryPoints/EntryPoint.swift
@@ -240,7 +240,7 @@ func parseCommandLineArguments(from args: [String]) throws -> __CommandLineArgum
   return result
 }
 
-/// Get an instance of ``Configuration`` given a sequence of command-line
+/// Get an instance of a configuration given a sequence of command-line
 /// arguments passed from Swift Package Manager.
 ///
 /// - Parameters:

--- a/Sources/Testing/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/EntryPoints/EntryPoint.swift
@@ -461,8 +461,8 @@ extension Event.ConsoleOutputRecorder.Options {
       return true
     }
 
-    // If the file handle is a pipe, assume the other end is using it to forward
-    // output from this process to its own stderr file. This is how `swift test`
+    // If the file handle is a pipe, assume the other end uses it to forward
+    // output from this process to its own `stderr` file. This is how `swift test`
     // invokes the testing library, for example.
     if fileHandle.isPipe {
       return true

--- a/Sources/Testing/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/EntryPoints/EntryPoint.swift
@@ -511,7 +511,7 @@ extension Event.ConsoleOutputRecorder.Options {
 
 // MARK: - Error reporting
 
-/// A type describing an error encountered in the entry point.
+/// A type used to describe an error encountered in the entry point.
 private enum _EntryPointError: Error {
   /// A feature is unavailable.
   ///

--- a/Sources/Testing/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/EntryPoints/EntryPoint.swift
@@ -489,8 +489,8 @@ extension Event.ConsoleOutputRecorder.Options {
 #endif
   }
 
-  /// Whether or not the system terminal claims to support true-color ANSI
-  /// escape codes.
+  /// A Boolean value that indicates whether the system terminal claims to 
+  /// support true-color ANSI escape codes.
   private static var _terminalSupportsTrueColorANSIEscapeCodes: Bool {
 #if SWT_TARGET_OS_APPLE || os(Linux)
     if let colortermVariable = Environment.variable(named: "COLORTERM") {

--- a/Sources/Testing/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/EntryPoints/EntryPoint.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -98,7 +98,7 @@ func entryPoint(passing args: consuming __CommandLineArguments_v0?, eventHandler
 /// - Parameters:
 ///   - tests: The tests to list.
 ///
-/// - Returns: An array of strings representing the IDs of `tests`.
+/// - Returns: An array of strings that represents the IDs of `tests`.
 func listTestsForEntryPoint(_ tests: some Sequence<Test>) -> [String] {
   // Filter out hidden tests and test suites. Hidden tests should not generally
   // be presented to the user, and suites (XCTestCase classes) are not included
@@ -131,8 +131,8 @@ func listTestsForEntryPoint(_ tests: some Sequence<Test>) -> [String] {
 
 // MARK: - Command-line arguments and configuration
 
-/// A type describing the command-line arguments passed by Swift Package Manager
-/// to the testing library's entry point.
+/// A type that describes the command-line arguments passed by Swift Package
+/// Manager to the testing library's entry point.
 ///
 /// - Warning: This type's definition and JSON-encoded form have not been
 ///   finalized yet.

--- a/Sources/Testing/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/EntryPoints/EntryPoint.swift
@@ -471,8 +471,8 @@ extension Event.ConsoleOutputRecorder.Options {
     return false
   }
 
-  /// Whether or not the system terminal claims to support 256-color ANSI escape
-  /// codes.
+  /// A Boolean value that indicates whether the system terminal claims to
+  /// support 256-color ANSI escape codes.
   private static var _terminalSupports256ColorANSIEscapeCodes: Bool {
 #if SWT_TARGET_OS_APPLE || os(Linux)
     if let termVariable = Environment.variable(named: "TERM") {

--- a/Sources/Testing/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/EntryPoints/EntryPoint.swift
@@ -348,7 +348,7 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
 ///   - path: The path to which events should be streamed. This file will be
 ///     opened for writing.
 ///
-/// - Throws: Any error that occurs opening `path`. Once `path` is opened,
+/// - Throws: Any error that occurs opening `path`. After opening the `path`,
 ///   errors that may occur writing to it are handled by the resulting event
 ///   handler.
 ///
@@ -361,7 +361,7 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
 /// objects are guaranteed not to contain any ASCII newline characters (`"\r"`
 /// or `"\n"`) themselves.
 ///
-/// The file at `path` can be a regular file, however to allow for streaming a
+/// The file at `path` can be a regular file, however, to allow for streaming a
 /// named pipe is recommended. `mkfifo()` can be used on Darwin and Linux to
 /// create a named pipe; `CreateNamedPipeA()` can be used on Windows.
 ///

--- a/Sources/Testing/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/EntryPoints/EntryPoint.swift
@@ -135,7 +135,7 @@ func listTestsForEntryPoint(_ tests: some Sequence<Test>) -> [String] {
 /// Manager to the testing library's entry point.
 ///
 /// - Warning: This type's definition and JSON-encoded form have not been
-///   finalized yet.
+///   finalized yet.@Comment{ QUERY: Has this been finalized? If so, can we remove the Warning? If not, we should make this a double-slash comment for initial release. }
 ///
 /// - Warning: This type is used by Swift Package Manager. Do not use it
 ///   directly.

--- a/Sources/Testing/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/EntryPoints/EntryPoint.swift
@@ -452,8 +452,8 @@ extension Event.ConsoleOutputRecorder.Options {
     return result
   }
 
-  /// Whether or not the current process's standard error stream is capable of
-  /// accepting and rendering ANSI escape codes.
+  /// A Boolean value that indicates whether the current process's standard 
+  /// error stream is capable of accepting and rendering ANSI escape codes.
   private static func _fileHandleSupportsANSIEscapeCodes(_ fileHandle: borrowing FileHandle) -> Bool {
     // Determine if this file handle appears to write to a Terminal window
     // capable of accepting ANSI escape codes.

--- a/Sources/Testing/EntryPoints/SwiftPMEntryPoint.swift
+++ b/Sources/Testing/EntryPoints/SwiftPMEntryPoint.swift
@@ -42,7 +42,7 @@ private import TestingInternals
 /// of `EXIT_SUCCESS` is used; otherwise, a (possibly platform-specific) value
 /// such as `EXIT_FAILURE` is used instead.
 ///
-/// - Warning: This function is used by Swift Package Manager. Do not call it
+/// - Warning: This function is used by Swift Package Manager. Don't call it
 ///   directly.
 public func __swiftPMEntryPoint(passing args: __CommandLineArguments_v0? = nil) async -> Never {
   let exitCode: CInt = await __swiftPMEntryPoint(passing: args)

--- a/Sources/Testing/EntryPoints/SwiftPMEntryPoint.swift
+++ b/Sources/Testing/EntryPoints/SwiftPMEntryPoint.swift
@@ -23,7 +23,7 @@ private import TestingInternals
 /// This function examines the command-line arguments represented by `args` and
 /// then invokes available tests in the current process.
 ///
-/// - Warning: This function is used by Swift Package Manager. Do not call it
+/// - Warning: This function is used by Swift Package Manager. Don't call it
 ///   directly.
 @_disfavoredOverload public func __swiftPMEntryPoint(passing args: __CommandLineArguments_v0? = nil) async -> CInt {
   await entryPoint(passing: args, eventHandler: nil)

--- a/Sources/Testing/EntryPoints/XCTestScaffold.swift
+++ b/Sources/Testing/EntryPoints/XCTestScaffold.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -70,7 +70,7 @@ extension XCTIssue {
 
 // MARK: -
 
-/// A type providing temporary tools for integrating the testing library and
+/// A type that provides temporary tools for integrating the testing library and
 /// the XCTest framework.
 ///
 /// ## See Also

--- a/Sources/Testing/EntryPoints/XCTestScaffold.swift
+++ b/Sources/Testing/EntryPoints/XCTestScaffold.swift
@@ -89,8 +89,8 @@ public enum XCTestScaffold: Sendable {
   ///   - testCase: An `XCTestCase` instance that hosts tests implemented using
   ///     the testing library.
   ///
-  /// Output from the testing library is written to the standard error stream.
-  /// The format of the output is not meant to be machine-readable and is
+  /// Writes output from the testing library to the standard error stream.
+  /// The format of the output isn't meant to be machine-readable and is
   /// subject to change.
   ///
   /// ### Configuring output


### PR DESCRIPTION
Edits to the documentation comments (`///` lines) in the `.Swift` API source files in the `EntryPoints` directory.

### Motivation:

Editing for style.

### Modifications:

Edits to the text in some `///` comments throughout.

### Result:

Documentation produced from the source files will generate and conform to style.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
