### PR TITLE
Fix some DocC symbol typos

### DIFF
--- a/Sources/Testing/Traits/Bug.swift
+++ b/Sources/Testing/Traits/Bug.swift
@@ -12,8 +12,8 @@
 ///
 /// To add this trait to a test, use one of the following functions:
 ///
-/// - ``Trait/bug(_:_:)-86mmm``
-/// - ``Trait/bug(_:_:)-3hsi5``
+/// - ``Trait/bug(_:_:)-2u8j9``
+/// - ``Trait/bug(_:_:)-7mo2w``
 public struct Bug {
   /// The identifier of this bug in the associated bug-tracking system.
   ///

--- a/Sources/Testing/Traits/Tags/Tag.List.swift
+++ b/Sources/Testing/Traits/Tags/Tag.List.swift
@@ -78,7 +78,7 @@ extension Trait where Self == Tag.List {
   ///
   /// This function is provided as a convenience to allow specifying tags as
   /// string values. To specify a mix of tags identified by symbol (such as
-  /// ``Tag/red``) and tags identified by string value (such as `"important"`),
+  /// `.example`) and tags identified by string value (such as `"important"`),
   /// use two separate calls to this function and pass symbols separately from
   /// string values:
   ///


### PR DESCRIPTION
Fix some DocC symbol typos. Self-reviewing.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
