### PR TITLE
Remove a few unintended Foundation dependencies from our unit tests.

### DIFF
--- a/Tests/TestingTests/ABIEntryPointTests.swift
+++ b/Tests/TestingTests/ABIEntryPointTests.swift
@@ -38,7 +38,7 @@ struct ABIEntryPointTests {
     arguments.filter = ["NonExistentTestThatMatchesNothingHopefully"]
     let argumentsJSON = try JSON.withEncoding(of: arguments) { argumentsJSON in
       let result = UnsafeMutableRawBufferPointer.allocate(byteCount: argumentsJSON.count, alignment: 1)
-      argumentsJSON.copyBytes(to: result)
+      _ = memcpy(result.baseAddress, argumentsJSON.baseAddress, argumentsJSON.count)
       return result
     }
     defer {

--- a/Tests/TestingTests/ABIEntryPointTests.swift
+++ b/Tests/TestingTests/ABIEntryPointTests.swift
@@ -38,7 +38,7 @@ struct ABIEntryPointTests {
     arguments.filter = ["NonExistentTestThatMatchesNothingHopefully"]
     let argumentsJSON = try JSON.withEncoding(of: arguments) { argumentsJSON in
       let result = UnsafeMutableRawBufferPointer.allocate(byteCount: argumentsJSON.count, alignment: 1)
-      _ = memcpy(result.baseAddress, argumentsJSON.baseAddress, argumentsJSON.count)
+      _ = memcpy(result.baseAddress!, argumentsJSON.baseAddress!, argumentsJSON.count)
       return result
     }
     defer {

--- a/Tests/TestingTests/Test.Case.Argument.IDTests.swift
+++ b/Tests/TestingTests/Test.Case.Argument.IDTests.swift
@@ -23,7 +23,7 @@ struct Test_Case_Argument_IDTests {
     #expect(testCase.arguments.count == 1)
     let argument = try #require(testCase.arguments.first)
     let argumentID = try #require(argument.id)
-    #expect(String(bytes: argumentID.bytes, encoding: .utf8) == "123")
+    #expect(String(decoding: argumentID.bytes, as: UTF8.self) == "123")
   }
 
   @Test("One CustomTestArgumentEncodable parameter")
@@ -56,7 +56,7 @@ struct Test_Case_Argument_IDTests {
     #expect(testCase.arguments.count == 1)
     let argument = try #require(testCase.arguments.first)
     let argumentID = try #require(argument.id)
-    #expect(String(bytes: argumentID.bytes, encoding: .utf8) == #""abc""#)
+    #expect(String(decoding: argumentID.bytes, as: UTF8.self) == #""abc""#)
   }
 
   @Test("One RawRepresentable parameter")
@@ -70,7 +70,7 @@ struct Test_Case_Argument_IDTests {
     #expect(testCase.arguments.count == 1)
     let argument = try #require(testCase.arguments.first)
     let argumentID = try #require(argument.id)
-    #expect(String(bytes: argumentID.bytes, encoding: .utf8) == #""abc""#)
+    #expect(String(decoding: argumentID.bytes, as: UTF8.self) == #""abc""#)
   }
 }
 


### PR DESCRIPTION
This PR removes uses of Foundation's `String.Encoding.utf8` and `DataProtocol.copyBytes(to:)`. These dependencies on Foundation are not needed nor are they intentional.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
