### PR TITLE
Avoid Regex API availability check when no filter or skip flags have been passed

### DIFF
--- a/Sources/Testing/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/EntryPoints/EntryPoint.swift
@@ -158,10 +158,10 @@ public struct __CommandLineArguments_v0: Sendable {
   public var experimentalEventStreamOutput: String?
 
   /// The value(s) of the `--filter` argument.
-  public var filter: [String] = []
+  public var filter: [String]?
 
   /// The value(s) of the `--skip` argument.
-  public var skip: [String] = []
+  public var skip: [String]?
 
   /// The value of the `--repetitions` argument.
   public var repetitions: Int?
@@ -289,8 +289,8 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
 
   // Filtering
   var filters = [Configuration.TestFilter]()
-  func testFilter(forRegularExpressions regexes: [String], label: String, membership: Configuration.TestFilter.Membership) throws -> Configuration.TestFilter {
-    guard !regexes.isEmpty else {
+  func testFilter(forRegularExpressions regexes: [String]?, label: String, membership: Configuration.TestFilter.Membership) throws -> Configuration.TestFilter {
+    guard let regexes, !regexes.isEmpty else {
       // Return early if empty, even though the `reduce` logic below can handle
       // this case, in order to avoid the `#available` guard.
       return .unfiltered

--- a/Sources/Testing/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/EntryPoints/EntryPoint.swift
@@ -158,10 +158,10 @@ public struct __CommandLineArguments_v0: Sendable {
   public var experimentalEventStreamOutput: String?
 
   /// The value(s) of the `--filter` argument.
-  public var filter: [String]?
+  public var filter: [String] = []
 
   /// The value(s) of the `--skip` argument.
-  public var skip: [String]?
+  public var skip: [String] = []
 
   /// The value of the `--repetitions` argument.
   public var repetitions: Int?
@@ -289,8 +289,10 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
 
   // Filtering
   var filters = [Configuration.TestFilter]()
-  func testFilter(forRegularExpressions regexes: [String]?, label: String, membership: Configuration.TestFilter.Membership) throws -> Configuration.TestFilter {
-    guard let regexes else {
+  func testFilter(forRegularExpressions regexes: [String], label: String, membership: Configuration.TestFilter.Membership) throws -> Configuration.TestFilter {
+    guard !regexes.isEmpty else {
+      // Return early if empty, even though the `reduce` logic below can handle
+      // this case, in order to avoid the `#available` guard.
       return .unfiltered
     }
 


### PR DESCRIPTION
Fix several test failures in `SwiftPMTests` when running on older Apple OS versions before `Regex` was added, which is due to unnecessarily checking whether that API is available. One example:

```text
✘ Test "No --filter or --skip argument" recorded an issue at SwiftPMTests.swift:40:4: Caught error: The `--filter' option is not supported on this OS version.
```

In tests which do not involve `--filter` or `--skip` arguments, this check is unnecessary and can be avoided altogether.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
