### PR TITLE
Support forcing color output

### DIFF
--- a/Sources/Testing/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/EntryPoints/EntryPoint.swift
@@ -439,7 +439,9 @@ extension Event.ConsoleOutputRecorder.Options {
     var result = Self()
 
     result.useANSIEscapeCodes = _fileHandleSupportsANSIEscapeCodes(fileHandle)
-    if result.useANSIEscapeCodes {
+
+    // Respect the FORCE_COLOR environment variable. SEE: https://www.force-color.org
+    if result.useANSIEscapeCodes || Environment.variable(named: "FORCE_COLOR")?.isEmpty == false {
       if let noColor = Environment.variable(named: "NO_COLOR"), !noColor.isEmpty {
         // Respect the NO_COLOR environment variable. SEE: https://www.no-color.org
         result.ansiColorBitDepth = 1


### PR DESCRIPTION
Add support for the `FORCE_COLOR` environment variable. It is possible to run in an environment that does not look like either a TTY or a named pipe and still want ANSI escape codes emitted. The `NO_COLOR` environment variable takes precedence.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

