### PR TITLE
Enable 'InferSendableFromCaptures' upcoming feature and resolve new build failures

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -118,6 +118,7 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .unsafeFlags(["-require-explicit-sendable"]),
       .enableExperimentalFeature("StrictConcurrency"),
       .enableUpcomingFeature("ExistentialAny"),
+      .enableUpcomingFeature("InferSendableFromCaptures"),
 
       .enableExperimentalFeature("AccessLevelOnImport"),
       .enableUpcomingFeature("InternalImportsByDefault"),

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -118,6 +118,7 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .unsafeFlags(["-require-explicit-sendable"]),
       .enableExperimentalFeature("StrictConcurrency"),
       .enableUpcomingFeature("ExistentialAny"),
+      .enableUpcomingFeature("InferSendableFromCaptures"),
 
       .enableExperimentalFeature("AccessLevelOnImport"),
       .enableUpcomingFeature("InternalImportsByDefault"),

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -118,7 +118,6 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .unsafeFlags(["-require-explicit-sendable"]),
       .enableExperimentalFeature("StrictConcurrency"),
       .enableUpcomingFeature("ExistentialAny"),
-      .enableUpcomingFeature("InferSendableFromCaptures"),
 
       .enableExperimentalFeature("AccessLevelOnImport"),
       .enableUpcomingFeature("InternalImportsByDefault"),

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -165,8 +165,8 @@ struct TestsWithStaticMemberAccessBySelfKeyword {
   @Test(.hidden, arguments: Self.f(max: 100))
   func g(i: Int) {}
 
-  @Test(.hidden, arguments: [UncheckedSendable(rawValue: Self.f(max:))])
-  func h(i: UncheckedSendable<(Int) -> Range<Int>>) {}
+  @Test(.hidden, arguments: [Self.f(max:)])
+  func h(i: @Sendable (Int) -> Range<Int>) {}
 
   struct Nested {
     static let x = 0 ..< 100


### PR DESCRIPTION
Enable the `InferSendableFromCaptures` upcoming feature and resolve new build failures. This is a feature enabled by default in Swift 6 per [SE-0418](https://github.com/apple/swift-evolution/blob/main/proposals/0418-inferring-sendable-for-methods.md), and attempting to build in Swift 6 language mode has revealed a build failure which this resolves.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Resolves rdar://128079937