### PR TITLE
Avoid specialization of `unsafeBitCast(_:to:)` when getting an error's backtrace.

### DIFF
--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -220,7 +220,7 @@ extension Backtrace {
   ///   existential containers with different addresses.
   @inline(never)
   init?(forFirstThrowOf error: any Error) {
-    let errorID = ObjectIdentifier(unsafeBitCast(error, to: AnyObject.self))
+    let errorID = ObjectIdentifier(unsafeBitCast(error as any Error, to: AnyObject.self))
     let entry = Self._errorMappingCache.withLock { cache in
       cache[errorID]
     }


### PR DESCRIPTION
It appears the Swift compiler has recently started specializing `unsafeBitCast(_:to:)` more aggressively than before, resulting in a call to that function in `Backtrace.init(forFirstThrowOf:)` crashing because the size of the input error (expected to be an existential box of type `NSError` or `SwiftError`, i.e. actually an object) doesn't match the size of `AnyObject`.

This PR explicitly asks the compiler not to specialize `unsafeBitCast(_:to:)` quite so precisely, preserving the intended semantics.

(This method is already known to contain non-zero quantities of "wat.")

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
