### PR TITLE
Silence warnings about `String.init(validatingUTF8:)` on Swift 6.

### DIFF
--- a/Sources/Testing/Support/Additions/CommandLineAdditions.swift
+++ b/Sources/Testing/Support/Additions/CommandLineAdditions.swift
@@ -21,7 +21,7 @@ extension CommandLine {
   static func arguments() -> [String] {
     UnsafeBufferPointer(start: unsafeArgv, count: Int(argc)).lazy
       .compactMap { $0 }
-      .compactMap { String(validatingUTF8: $0) }
+      .compactMap { String(validatingUTF8CString: $0) }
   }
 
   /// The path to the current process' executable.

--- a/Sources/Testing/Support/Additions/StringAdditions.swift
+++ b/Sources/Testing/Support/Additions/StringAdditions.swift
@@ -1,0 +1,21 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+private import _TestingInternals
+
+extension String {
+  init?(validatingUTF8CString cString: UnsafePointer<CChar>) {
+#if compiler(>=5.11)
+    self.init(validatingCString: cString)
+#else
+    self.init(validatingUTF8: cString)
+#endif
+  }
+}

--- a/Sources/Testing/Support/Environment.swift
+++ b/Sources/Testing/Support/Environment.swift
@@ -57,7 +57,7 @@ enum Environment {
         break
       }
 
-      if let row = String(validatingUTF8: rowp),
+      if let row = String(validatingUTF8CString: rowp),
          let (key, value) = _splitEnvironmentVariable(row) {
         result[key] = value
       }
@@ -164,14 +164,14 @@ enum Environment {
         if let equals = strchr(rowp, CInt(UInt8(ascii: "="))) {
           let keyLength = UnsafeRawPointer(equals) - UnsafeRawPointer(rowp)
           if 0 == strncmp(rowp, name, keyLength) {
-            return String(validatingUTF8: equals + 1)
+            return String(validatingUTF8CString: equals + 1)
           }
         }
       }
       return nil
     }
 #elseif SWT_TARGET_OS_APPLE || os(Linux) || os(WASI)
-    getenv(name).flatMap { String(validatingUTF8: $0) }
+    getenv(name).flatMap { String(validatingUTF8CString: $0) }
 #elseif os(Windows)
     name.withCString(encodedAs: UTF16.self) { name in
       func getVariable(maxCount: Int) -> String? {

--- a/Sources/Testing/Support/Versions.swift
+++ b/Sources/Testing/Support/Versions.swift
@@ -36,12 +36,12 @@ let operatingSystemVersion: String = {
   if 0 == uname(&name) {
     let release = withUnsafeBytes(of: name.release) { release in
       release.withMemoryRebound(to: CChar.self) { release in
-        String(validatingUTF8: release.baseAddress!) ?? ""
+        String(validatingUTF8CString: release.baseAddress!) ?? ""
       }
     }
     let version = withUnsafeBytes(of: name.version) { version in
       version.withMemoryRebound(to: CChar.self) { version in
-        String(validatingUTF8: version.baseAddress!) ?? ""
+        String(validatingUTF8CString: version.baseAddress!) ?? ""
       }
     }
     switch (release, version) {
@@ -157,7 +157,7 @@ func sysctlbyname(_ name: String, as _: String.Type) -> String? {
     if 0 == sysctlbyname(name, nil, &szValue, nil, 0) {
       return withUnsafeTemporaryAllocation(of: CChar.self, capacity: szValue) { buffer in
         if 0 == sysctlbyname(name, buffer.baseAddress!, &szValue, nil, 0) {
-          return String(validatingUTF8: buffer.baseAddress!)
+          return String(validatingUTF8CString: buffer.baseAddress!)
         }
         return nil
       }

--- a/Sources/Testing/Traits/Tags/Tag.Color+Loading.swift
+++ b/Sources/Testing/Traits/Tags/Tag.Color+Loading.swift
@@ -22,7 +22,7 @@ private var _homeDirectoryPath: String? {
   return if let homeVariable = Environment.variable(named: "HOME") {
     homeVariable
   } else if let pwd = getpwuid(geteuid()) {
-    String(validatingUTF8: pwd.pointee.pw_dir)
+    String(validatingUTF8CString: pwd.pointee.pw_dir)
   } else {
     nil
   }


### PR DESCRIPTION
Swift 6 deprecates `String.init(validatingUTF8:)` and replaces it with the identical `String.init(validatingCString:)`. This change adopts the new API when compiling with Swift 6.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
