### PR TITLE
Revert "Work around miscompilation of entry point function on Windows…

### DIFF
--- a/Sources/Testing/EntryPoints/ABIEntryPoint.swift
+++ b/Sources/Testing/EntryPoints/ABIEntryPoint.swift
@@ -58,12 +58,12 @@ public typealias ABIEntryPoint_v0 = @Sendable (
 public func copyABIEntryPoint_v0() -> UnsafeMutableRawPointer {
   let result = UnsafeMutablePointer<ABIEntryPoint_v0>.allocate(capacity: 1)
   result.initialize { argumentsJSON, recordHandler in
-    let args = try! argumentsJSON.map { argumentsJSON in
+    var args = try! argumentsJSON.map { argumentsJSON in
       try JSON.decode(__CommandLineArguments_v0.self, from: argumentsJSON)
     }
 
     let eventHandler = try! eventHandlerForStreamingEvents(version: args?.experimentalEventStreamVersion, forwardingTo: recordHandler)
-    return await entryPoint(passing: args, eventHandler: eventHandler)
+    return await entryPoint(passing: &args, eventHandler: eventHandler)
   }
   return .init(result)
 }

--- a/Sources/Testing/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/EntryPoints/EntryPoint.swift
@@ -16,12 +16,17 @@ private import _TestingInternals
 ///   - args: A previously-parsed command-line arguments structure to interpret.
 ///     If `nil`, a new instance is created from the command-line arguments to
 ///     the current process.
-///   - eventHandler: An event handler
-func entryPoint(passing args: consuming __CommandLineArguments_v0?, eventHandler: Event.Handler?) async -> CInt {
+///   - eventHandler: An event handler.
+///
+/// - Bug: This function takes `args` as a pointer in order to work around a
+///   code generation bug when using the Swift 5.10 toolchain on Windows. This
+///   function should be updated to take `args` directly when Swift 5.10
+///   support is removed.
+func entryPoint(passing args: UnsafePointer<__CommandLineArguments_v0?>, eventHandler: Event.Handler?) async -> CInt {
   let exitCode = Locked(rawValue: EXIT_SUCCESS)
 
   do {
-    let args = try args ?? parseCommandLineArguments(from: CommandLine.arguments())
+    let args = try args.pointee ?? parseCommandLineArguments(from: CommandLine.arguments())
     if args.listTests {
       for testID in await listTestsForEntryPoint(Test.all) {
 #if SWT_TARGET_OS_APPLE && !SWT_NO_FILE_IO

--- a/Sources/Testing/EntryPoints/SwiftPMEntryPoint.swift
+++ b/Sources/Testing/EntryPoints/SwiftPMEntryPoint.swift
@@ -26,7 +26,8 @@ private import _TestingInternals
 /// - Warning: This function is used by Swift Package Manager. Do not call it
 ///   directly.
 @_disfavoredOverload public func __swiftPMEntryPoint(passing args: __CommandLineArguments_v0? = nil) async -> CInt {
-  await entryPoint(passing: args, eventHandler: nil)
+  var args = args
+  await entryPoint(passing: &args, eventHandler: nil)
 }
 
 /// The entry point to the testing library used by Swift Package Manager.

--- a/Sources/Testing/EntryPoints/XCTestScaffold.swift
+++ b/Sources/Testing/EntryPoints/XCTestScaffold.swift
@@ -146,8 +146,9 @@ public enum XCTestScaffold: Sendable {
       functionName[...]
     }
     args.xcTestCaseHostIdentifier = "\(typeName)/\(functionName)"
+    var argsCopy: __CommandLineArguments_v0? = args
 
-    _ = await entryPoint(passing: args) { event, _ in
+    _ = await entryPoint(passing: &argsCopy) { event, _ in
       guard case let .issueRecorded(issue) = event.kind else {
         return
       }


### PR DESCRIPTION
… with Swift 5.10 (Take 2). (#382)"

This reverts commit 2516cdb43a3f84195eea3eeec26ebdd4ab06fb9c.

Works around rdar://128091794.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
