### PR TITLE
Work around rdar://128091794.

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
@@ -15,7 +15,7 @@ extension Event {
   /// The format of the output is not meant to be machine-readable and is
   /// subject to change. For machine-readable output, use ``JUnitXMLRecorder``.
   @_spi(ForToolsIntegrationOnly)
-  public struct ConsoleOutputRecorder: Sendable, ~Copyable {
+  public struct ConsoleOutputRecorder: Sendable/*, ~Copyable*/ {
     /// A type describing options to use when writing events to a stream.
     public struct Options: Sendable {
       /// Use [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code)

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -18,7 +18,7 @@ extension Event {
   /// The format of the output is not meant to be machine-readable and is
   /// subject to change. For machine-readable output, use ``JUnitXMLRecorder``.
   @_spi(ForToolsIntegrationOnly)
-  public struct HumanReadableOutputRecorder: Sendable /*, ~Copyable*/ {
+  public struct HumanReadableOutputRecorder: Sendable/*, ~Copyable*/ {
     /// A type describing a human-readable message produced by an instance of
     /// ``Event/HumanReadableOutputRecorder``.
     public struct Message: Sendable {

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -18,7 +18,7 @@ extension Event {
   /// The format of the output is not meant to be machine-readable and is
   /// subject to change. For machine-readable output, use ``JUnitXMLRecorder``.
   @_spi(ForToolsIntegrationOnly)
-  public struct HumanReadableOutputRecorder: Sendable, ~Copyable {
+  public struct HumanReadableOutputRecorder: Sendable /*, ~Copyable*/ {
     /// A type describing a human-readable message produced by an instance of
     /// ``Event/HumanReadableOutputRecorder``.
     public struct Message: Sendable {

--- a/Sources/Testing/Events/Recorder/Event.JUnitXMLRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.JUnitXMLRecorder.swift
@@ -12,7 +12,7 @@ extension Event {
   /// A type which handles ``Event`` instances and outputs representations of
   /// them as JUnit-compatible XML.
   @_spi(ForToolsIntegrationOnly)
-  public struct JUnitXMLRecorder: Sendable, ~Copyable {
+  public struct JUnitXMLRecorder: Sendable/*, ~Copyable*/ {
     /// The write function for this event recorder.
     var write: @Sendable (String) -> Void
 


### PR DESCRIPTION
This PR attempts to work around the compiler regression tracked in the aforementioned Apple radar.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
