### PR TITLE
Add Swift 6 post-merge jobs to the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ concurrency, and parameterize test functions across wide ranges of inputs.
 The table below describes the current level of support that `swift-testing` has
 for various platforms:
 
-| **Platform** | **CI Status (5.10)** | **CI Status (main)** | **Support Status** |
-|-|:-:|:-:|-|
-| **macOS** | [![Build Status](https://ci.swift.org/buildStatus/icon?job=swift-testing-main-swift-5.10-macos)](https://ci.swift.org/job/swift-testing-main-swift-5.10-macos/) | [![Build Status](https://ci.swift.org/buildStatus/icon?job=swift-testing-main-swift-main-macos)](https://ci.swift.org/view/Swift%20Packages/job/swift-testing-main-swift-main-macos/) | Supported |
-| **iOS** | | | Supported |
-| **watchOS** | | | Supported |
-| **tvOS** | | | Supported |
-| **Ubuntu 22.04** | [![Build Status](https://ci.swift.org/buildStatus/icon?job=swift-testing-main-swift-5.10-linux)](https://ci.swift.org/job/swift-testing-main-swift-5.10-linux/) | [![Build Status](https://ci.swift.org/buildStatus/icon?job=swift-testing-main-swift-main-linux)](https://ci.swift.org/view/Swift%20Packages/job/swift-testing-main-swift-main-linux/) | Supported |
-| **Windows** | [![Build Status](https://ci-external.swift.org/buildStatus/icon?job=swift-testing-main-swift-5.10-windows)](https://ci-external.swift.org/job/swift-testing-main-swift-5.10-windows/) | [![Build Status](https://ci-external.swift.org/buildStatus/icon?job=swift-testing-main-swift-main-windows)](https://ci-external.swift.org/job/swift-testing-main-swift-main-windows/) | Supported |
+| **Platform** | **CI Status (5.10)** | **CI Status (6.0)** | **CI Status (main)** | **Support Status** |
+|---|:-:|:-:|:-:|---|
+| **macOS** | [![Build Status](https://ci.swift.org/buildStatus/icon?job=swift-testing-main-swift-5.10-macos)](https://ci.swift.org/job/swift-testing-main-swift-5.10-macos/) | [![Build Status](https://ci.swift.org/buildStatus/icon?job=swift-testing-main-swift-6.0-macos)](https://ci.swift.org/job/swift-testing-main-swift-6.0-macos/) | [![Build Status](https://ci.swift.org/buildStatus/icon?job=swift-testing-main-swift-main-macos)](https://ci.swift.org/view/Swift%20Packages/job/swift-testing-main-swift-main-macos/) | Supported |
+| **iOS** | | | | Supported |
+| **watchOS** | | | | Supported |
+| **tvOS** | | | | Supported |
+| **Ubuntu 22.04** | [![Build Status](https://ci.swift.org/buildStatus/icon?job=swift-testing-main-swift-5.10-linux)](https://ci.swift.org/job/swift-testing-main-swift-5.10-linux/) | [![Build Status](https://ci.swift.org/buildStatus/icon?job=swift-testing-main-swift-6.0-linux)](https://ci.swift.org/job/swift-testing-main-swift-6.0-linux/) | [![Build Status](https://ci.swift.org/buildStatus/icon?job=swift-testing-main-swift-main-linux)](https://ci.swift.org/view/Swift%20Packages/job/swift-testing-main-swift-main-linux/) | Supported |
+| **Windows** | [![Build Status](https://ci-external.swift.org/buildStatus/icon?job=swift-testing-main-swift-5.10-windows)](https://ci-external.swift.org/job/swift-testing-main-swift-5.10-windows/) | | [![Build Status](https://ci-external.swift.org/buildStatus/icon?job=swift-testing-main-swift-main-windows)](https://ci-external.swift.org/job/swift-testing-main-swift-main-windows/) | Supported |
 
 ## Documentation
 


### PR DESCRIPTION
This PR adds new columns to the readme for Swift 6.0 jobs running on macOS and Linux. (Windows to be added as soon as feasible.)

<img width="761" alt="Screenshot 2024-05-15 at 2 05 04 PM" src="https://github.com/apple/swift-testing/assets/4145863/5568caf0-f4c7-4a59-95e5-035d24c4c071">

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
