### PR TITLE
Remove string literal tags.

### DIFF
--- a/Sources/Testing/Testing.docc/AddingTags.md
+++ b/Sources/Testing/Testing.docc/AddingTags.md
@@ -26,8 +26,8 @@ source files, and even test targets.
 
 ## Add a tag
 
-To add a tag to a test, use the ``Trait/tags(_:)-505n9`` trait. This trait takes
-a sequence of tags as its argument, and those tags are then applied to the
+To add a tag to a test, use the ``Trait/tags(_:)`` trait. This trait takes a
+sequence of tags as its argument, and those tags are then applied to the
 corresponding test at runtime. If any tags are applied to a test suite, then all
 tests in that suite inherit those tags.
 

--- a/Sources/Testing/Testing.docc/DefiningTests.md
+++ b/Sources/Testing/Testing.docc/DefiningTests.md
@@ -65,7 +65,7 @@ line, supply a string literal as an argument to the `@Test` attribute:
 ```
 
 To further customize the appearance and behavior of a test function, use
- [traits](doc:Traits) such as ``Trait/tags(_:)-505n9``.
+[traits](doc:Traits) such as ``Trait/tags(_:)``.
 
 ### Write concurrent or throwing tests
 

--- a/Sources/Testing/Testing.docc/OrganizingTests.md
+++ b/Sources/Testing/Testing.docc/OrganizingTests.md
@@ -27,9 +27,9 @@ A test function can be added to a test suite in one of two ways:
 The `@Suite` attribute isn't required for the testing library to recognize that
 a type contains test functions, but adding it allows customization of a test
 suite's appearance in the IDE and at the command line. If a trait such as
-``Trait/tags(_:)-505n9`` or ``Trait/disabled(_:fileID:filePath:line:column:)``
-is applied to a test suite, it's automatically inherited by the tests contained
-in the suite.
+``Trait/tags(_:)`` or ``Trait/disabled(_:fileID:filePath:line:column:)`` is
+applied to a test suite, it's automatically inherited by the tests contained in
+the suite.
 
 In addition to containing test functions and any other members that a Swift type
 might contain, test suite types can also contain additional test suites nested
@@ -51,7 +51,7 @@ To customize a test suite's name, supply a string literal as an argument to the
 ```
 
 To further customize the appearance and behavior of a test function, use
- [traits](doc:Traits) such as ``Trait/tags(_:)-505n9``.
+[traits](doc:Traits) such as ``Trait/tags(_:)``.
 
 ## Test functions in test suite types
 

--- a/Sources/Testing/Testing.docc/Traits/Trait.md
+++ b/Sources/Testing/Testing.docc/Traits/Trait.md
@@ -26,8 +26,7 @@ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
  
 ### Categorizing tests
 
-- ``Trait/tags(_:)-505n9``
-- ``Trait/tags(_:)-yg0i``
+- ``Trait/tags(_:)``
 
 ### Associating bugs
 

--- a/Sources/Testing/Traits/Tags/Tag.List.swift
+++ b/Sources/Testing/Traits/Tags/Tag.List.swift
@@ -11,10 +11,7 @@
 extension Tag {
   /// A type representing one or more tags applied to a test.
   ///
-  /// To add this trait to a test, use one of the following functions:
-  ///
-  /// - ``Trait/tags(_:)-505n9``
-  /// - ``Trait/tags(_:)-yg0i``
+  /// To add this trait to a test, use the ``Trait/tags(_:)`` function.
   public struct List {
     /// The list of tags contained in this instance.
     ///
@@ -65,28 +62,5 @@ extension Trait where Self == Tag.List {
   /// - Returns: An instance of ``Tag/List`` containing the specified tags.
   public static func tags(_ tags: Tag...) -> Self {
     Self(tags: tags)
-  }
-
-  /// Construct a list of tags to apply to a test from a list of string values.
-  ///
-  /// - Parameters:
-  ///   - stringValues: The list of string values to convert to tags and apply
-  ///     to the test.
-  ///
-  /// - Returns: An instance of ``Tag/List`` containing the specified string
-  ///   literals as tags.
-  ///
-  /// This function is provided as a convenience to allow specifying tags as
-  /// string values. To specify a mix of tags identified by symbol (such as
-  /// `.example`) and tags identified by string value (such as `"important"`),
-  /// use two separate calls to this function and pass symbols separately from
-  /// string values:
-  ///
-  /// ```swift
-  /// @Test("Wheels spin", .tags("mechanical"), .tags(.critical))
-  /// func wheelsSpin() {}
-  /// ```
-  public static func tags(_ stringValues: _const String...) -> Self {
-    Self(tags: stringValues.map { Tag(kind: .stringLiteral($0)) })
   }
 }

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -35,7 +35,7 @@
 }
 
 @`Suite`(.hidden) struct `SuiteWithBackticks` {
-  @`Test`(.hidden, .`tags`("tag")) func `testWithBackticks`() {
+  @`Test`(.hidden, .`tags`(.namedConstant)) func `testWithBackticks`() {
     #`expect`(Bool(true))
   }
 }
@@ -78,9 +78,9 @@ struct SendableTests: Sendable {
   @Test(.hidden, arguments: FixtureData.zeroUpTo100)
   static func `reserved1`(`reserved2`: Int) async throws {}
 
-  @Suite(.hidden, .tags("tag-1"))
+  @Suite(.hidden, .tags(.namedConstant))
   struct NestedSendableTests: Sendable {
-    @Test(.hidden, .tags("tag-2"))
+    @Test(.hidden, .tags(.anotherConstant))
     func succeeds() throws {}
 
     @Test(.hidden)

--- a/Tests/TestingTests/PlanTests.swift
+++ b/Tests/TestingTests/PlanTests.swift
@@ -116,7 +116,7 @@ struct PlanTests {
     ]
 
     var configuration = Configuration()
-    var filter = Configuration.TestFilter(includingAnyOf: [Tag("tag-1"), Tag("tag-2")])
+    var filter = Configuration.TestFilter(includingAnyOf: [.namedConstant, .anotherConstant])
     filter.includeHiddenTests = true
     configuration.testFilter = filter
 
@@ -146,7 +146,7 @@ struct PlanTests {
     ]
 
     var configuration = Configuration()
-    var filter = Configuration.TestFilter(includingAllOf: [Tag("tag-1"), Tag("tag-2")])
+    var filter = Configuration.TestFilter(includingAllOf: [.namedConstant, .anotherConstant])
     filter.includeHiddenTests = true
     configuration.testFilter = filter
 
@@ -176,7 +176,7 @@ struct PlanTests {
     ]
 
     var configuration = Configuration()
-    var filter = Configuration.TestFilter(excludingAnyOf: [Tag("tag-1"), Tag("tag-2")])
+    var filter = Configuration.TestFilter(excludingAnyOf: [.namedConstant, .anotherConstant])
     filter.includeHiddenTests = true
     configuration.testFilter = filter
 
@@ -206,7 +206,7 @@ struct PlanTests {
     ]
 
     var configuration = Configuration()
-    var filter = Configuration.TestFilter(excludingAllOf: [Tag("tag-1"), Tag("tag-2")])
+    var filter = Configuration.TestFilter(excludingAllOf: [.namedConstant, .anotherConstant])
     filter.includeHiddenTests = true
     configuration.testFilter = filter
 
@@ -356,7 +356,7 @@ struct PlanTests {
     var configuration = Configuration()
     let selection = [testA.id]
     var testFilter = Configuration.TestFilter(including: selection)
-    testFilter.combine(with: .init(includingAnyOf: [Tag("tag-2")]), using: .or)
+    testFilter.combine(with: .init(includingAnyOf: [.anotherConstant]), using: .or)
     testFilter.includeHiddenTests = true
     configuration.testFilter = testFilter
 

--- a/Tests/TestingTests/Traits/ParallelizationTraitTests.swift
+++ b/Tests/TestingTests/Traits/ParallelizationTraitTests.swift
@@ -10,7 +10,7 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
-@Suite("Parallelization Trait Tests", .tags("trait"))
+@Suite("Parallelization Trait Tests", .tags(.traitRelated))
 struct ParallelizationTraitTests {
   @Test(".serialized trait is recursively applied")
   func serializedTrait() async {


### PR DESCRIPTION
As discussed [in the forums](https://forums.swift.org/t/removal-of-string-literal-tag-definitions/71667), we are removing string literal tags. This PR removes the interfaces for them. It preserves `Tag.Kind` because that may prove to be a useful abstraction in the future, e.g. if we come up with a new kind of tag that isn't a member of `Tag`.

Resolves rdar://125730118.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
