### PR TITLE
Always set the XCTest bundle path on Darwin when running exit tests.

### DIFF
--- a/Sources/_TestingInternals/include/Includes.h
+++ b/Sources/_TestingInternals/include/Includes.h
@@ -95,6 +95,10 @@
 #include <wasi/libc-environ.h>
 #endif
 
+#if __has_include(<libgen.h>)
+#include <libgen.h>
+#endif
+
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX


### PR DESCRIPTION
Xcode is a complicated beast and there are code paths that lead to us running a test hosted by XCTest that isn't discoverable by the existing exit test implementation. This PR makes that implementation more robust in these scenarios and fixes spurious exit test failures that were resulting.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
