### PR TITLE
Don't use `memcpy()` in a unit test.

### DIFF
--- a/Tests/TestingTests/ABIEntryPointTests.swift
+++ b/Tests/TestingTests/ABIEntryPointTests.swift
@@ -40,7 +40,7 @@ struct ABIEntryPointTests {
     arguments.verbosity = .min
     let argumentsJSON = try JSON.withEncoding(of: arguments) { argumentsJSON in
       let result = UnsafeMutableRawBufferPointer.allocate(byteCount: argumentsJSON.count, alignment: 1)
-      _ = memcpy(result.baseAddress!, argumentsJSON.baseAddress!, argumentsJSON.count)
+      result.copyMemory(from: argumentsJSON)
       return result
     }
     defer {


### PR DESCRIPTION
This PR changes from `memcpy()` to the Swiftier `UnsafeMutableRawBufferPointer.copyMemory(from:)`.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
