### PR TITLE
Add discussion about parallelization/concurrency and tools integration to vision document draft

### DIFF
--- a/Documentation/Vision.md
+++ b/Documentation/Vision.md
@@ -441,8 +441,9 @@ this means:
 
 ### Tools integration
 
-A well-rounded testing library should be integrated with popular tools in the
-community. This integration should include some essential functionality such as:
+A well-rounded testing library should be integrated with popular tools used by
+the community. This integration should include some essential functionality such
+as:
 
 * Building tests into products which can be be executed.
 * Running all built tests.
@@ -453,8 +454,8 @@ community. This integration should include some essential functionality such as:
 Beyond the essentials, tools may offer other useful features, such as:
 
 * Filtering tests by name, specific traits (e.g. custom tags), or other criteria.
-* Outputting results to a standard format such as [xUnit XML](https://xunit.net/docs/format-xml-v2)
-  for importing into other tools.
+* Outputting results to a standard format such as JUnit XML for importing into
+  other tools.
 * Controlling runtime options such as whether parallel execution is enabled,
   whether failed tests should be reattempted, etc.
 * Relaunching a test executable after an unexpected crash.


### PR DESCRIPTION
In preparation for submitting the swift-testing vision document for wider review (as mentioned in this recent [Forum post](https://forums.swift.org/t/an-update-on-swift-testing-progress-and-stable-release-plans/71455)), this expands the document to include discussion about two important topics:

- Parallelization and concurrency
- Tools integration

These topics are mentioned briefly in the document already, but these additions give a lot more detail about their design considerations.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
