### PR TITLE
Exclude CMakeLists.txt from package targets.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,6 +43,7 @@ let package = Package(
         "_TestingInternals",
         "TestingMacros",
       ],
+      exclude: ["CMakeLists.txt"],
       cxxSettings: .packageSettings,
       swiftSettings: .packageSettings
     ),
@@ -65,6 +66,7 @@ let package = Package(
         .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
         .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
       ],
+      exclude: ["CMakeLists.txt"],
       swiftSettings: .packageSettings + [
         // The only target which needs the ability to import this macro
         // implementation target's module is its unit test target. Users of the
@@ -80,6 +82,7 @@ let package = Package(
     // by other targets above, not directly included in product libraries.
     .target(
       name: "_TestingInternals",
+      exclude: ["CMakeLists.txt"],
       cxxSettings: .packageSettings
     ),
 

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -43,6 +43,7 @@ let package = Package(
         "_TestingInternals",
         "TestingMacros",
       ],
+      exclude: ["CMakeLists.txt"],
       cxxSettings: .packageSettings,
       swiftSettings: .packageSettings
     ),
@@ -65,6 +66,7 @@ let package = Package(
         .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
         .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
       ],
+      exclude: ["CMakeLists.txt"],
       swiftSettings: .packageSettings + [
         // The only target which needs the ability to import this macro
         // implementation target's module is its unit test target. Users of the
@@ -80,6 +82,7 @@ let package = Package(
     // by other targets above, not directly included in product libraries.
     .target(
       name: "_TestingInternals",
+      exclude: ["CMakeLists.txt"],
       cxxSettings: .packageSettings
     ),
 


### PR DESCRIPTION
This PR silences some warnings from SwiftPM now that we have CMake support since SwiftPM doesn't recognize the CMakeLists.txt files used by CMake.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
