### PR TITLE
Fix a sendability warning in a test fixture.

### DIFF
--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -155,7 +155,7 @@ actor ActorTests {
 struct TestsWithStaticMemberAccessBySelfKeyword {
   static let x = 0 ..< 100
 
-  static func f(max: Int) -> Range<Int> {
+  @Sendable static func f(max: Int) -> Range<Int> {
     0 ..< max
   }
 
@@ -167,6 +167,13 @@ struct TestsWithStaticMemberAccessBySelfKeyword {
 
   @Test(.hidden, arguments: [Self.f(max:)])
   func h(i: @Sendable (Int) -> Range<Int>) {}
+
+  struct Box<RawValue>: Sendable, RawRepresentable where RawValue: Sendable {
+    var rawValue: RawValue
+  }
+
+  @Test(.hidden, arguments: [Box(rawValue: Self.f(max:))])
+  func j(i: Box<@Sendable (Int) -> Range<Int>>) {}
 
   struct Nested {
     static let x = 0 ..< 100


### PR DESCRIPTION
This PR fixes the aforementioned sendability warning. It adds an additional fixture to ensure we're testing the original case (nested `Self` usage.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
