### PR TITLE
Fix two DocC symbol references to `#expect(throws:...)`

### DIFF
--- a/Sources/Testing/Testing.docc/testing-for-errors-in-swift-code.md
+++ b/Sources/Testing/Testing.docc/testing-for-errors-in-swift-code.md
@@ -26,7 +26,7 @@ If the code throws an error, then your test fails.
 
 To check that the code under test throws a specific error, or to continue a
 longer test function after the code throws an error, pass that error as the
-first argument of ``expect(throws:_:sourcelocation:performing:)-1xr34``, and
+first argument of ``expect(throws:_:sourceLocation:performing:)-1xr34``, and
 pass a closure that calls the code under test:
 
 ```swift
@@ -65,4 +65,4 @@ the error to `Never`:
 If the closure throws _any_ error, the testing library records an issue.
 If you need the test to stop when the code throws an error, include the
 code inline in the test function instead of wrapping it in an
-``expect(throws:_:sourcelocation:performing:)-1xr34`` block.
+``expect(throws:_:sourceLocation:performing:)-1xr34`` block.


### PR DESCRIPTION
Small fixup to the changes landed in #408 to fix the capitalization of two DocC symbol references:

```
⚠️ Sources/Testing/Testing.docc/testing-for-errors-in-swift-code.md:29:21:
'expect(throws:_:sourcelocation:performing:)-1xr34' doesn't exist at '/Testing/testing-for-errors-in-swift-code'
```

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
