### PR TITLE
Fix a misuse of `.bug()` in documentation.

### DIFF
--- a/Sources/Testing/Testing.docc/EnablingAndDisabling.md
+++ b/Sources/Testing/Testing.docc/EnablingAndDisabling.md
@@ -90,7 +90,7 @@ bug report, you can use the ``Trait/bug(_:_:)-2u8j9`` or
   "Ice cream is cold",
   .enabled(if: Season.current == .summer),
   .disabled("We ran out of sprinkles"),
-  .bug("12345")
+  .bug(id: "12345")
 )
 func isCold() async throws { ... }
 ```


### PR DESCRIPTION
Fixes a typo in an example using `.bug()`.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
