### PR TITLE
Warn about the use of `.serialized` with non-parameterized test functions

### DIFF
--- a/Sources/TestingMacros/Support/AttributeDiscovery.swift
+++ b/Sources/TestingMacros/Support/AttributeDiscovery.swift
@@ -154,11 +154,13 @@ struct AttributeInfo {
     if let declaration = declaration.asProtocol((any WithAttributesSyntax).self) {
       traits += createAvailabilityTraitExprs(for: declaration, in: context)
     }
-    diagnoseIssuesWithTraits(in: traits, addedTo: attribute, in: context)
 
     // Use the start of the test attribute's name as the canonical source
     // location of the test.
     sourceLocation = createSourceLocationExpr(of: attribute.attributeName, context: context)
+
+    // After this instance is fully initialized, diagnose known issues.
+    diagnoseIssuesWithTraits(in: context)
   }
 
   /// Convert this instance to a series of arguments suitable for passing to a

--- a/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
@@ -139,7 +139,7 @@ private func _diagnoseIssuesWithBugTrait(_ traitExpr: FunctionCallExprSyntax, ad
 ///
 /// - Parameters:
 ///   - traitExpr: The `.serialized` expression.
-///   - attribute: The `@Test` or `@Suite` attribute.
+///   - attributeInfo: The `@Test` or `@Suite` attribute.
 ///   - context: The macro context in which the expression is being parsed.
 private func _diagnoseIssuesWithParallelizationTrait(_ traitExpr: MemberAccessExprSyntax, addedTo attributeInfo: AttributeInfo, in context: some MacroExpansionContext) {
   guard attributeInfo.attribute.attributeName.isNamed("Test", inModuleNamed: "Testing") else {

--- a/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
@@ -38,8 +38,8 @@ extension AttributeInfo {
         }
       } else if let memberAccessExpr = traitExpr.as(MemberAccessExprSyntax.self) {
         switch memberAccessExpr.tokens(viewMode: .fixedUp).map(\.textWithoutBackticks).joined() {
-        case ".serialized", "SerializationTrait.serialized", "Testing.SerializationTrait.serialized":
-          _diagnoseIssuesWithSerializedTrait(memberAccessExpr, addedTo: self, in: context)
+        case ".serialized", "ParallelizationTrait.serialized", "Testing.ParallelizationTrait.serialized":
+          _diagnoseIssuesWithParallelizationTrait(memberAccessExpr, addedTo: self, in: context)
         default:
           // This is not a trait we can parse.
           break
@@ -141,7 +141,7 @@ private func _diagnoseIssuesWithBugTrait(_ traitExpr: FunctionCallExprSyntax, ad
 ///   - traitExpr: The `.serialized` expression.
 ///   - attribute: The `@Test` or `@Suite` attribute.
 ///   - context: The macro context in which the expression is being parsed.
-private func _diagnoseIssuesWithSerializedTrait(_ traitExpr: MemberAccessExprSyntax, addedTo attributeInfo: AttributeInfo, in context: some MacroExpansionContext) {
+private func _diagnoseIssuesWithParallelizationTrait(_ traitExpr: MemberAccessExprSyntax, addedTo attributeInfo: AttributeInfo, in context: some MacroExpansionContext) {
   guard attributeInfo.attribute.attributeName.isNamed("Test", inModuleNamed: "Testing") else {
     // We aren't diagnosing any issues on suites.
     return

--- a/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
@@ -53,7 +53,7 @@ extension AttributeInfo {
 ///
 /// - Parameters:
 ///   - traitExpr: The `.tags()` expression.
-///   - attribute: The `@Test` or `@Suite` attribute.
+///   - attributeInfo: The `@Test` or `@Suite` attribute.
 ///   - context: The macro context in which the expression is being parsed.
 private func _diagnoseIssuesWithTagsTrait(_ traitExpr: FunctionCallExprSyntax, addedTo attributeInfo: AttributeInfo, in context: some MacroExpansionContext) {
   // Find tags that are in an unsupported format (only .member and "literal"

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -581,6 +581,22 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
     )
   }
 
+  /// Create a diagnostic message stating that a trait has no effect on a given
+  /// attribute (assumed to be a non-parameterized `@Test` attribute.)
+  ///
+  /// - Parameters:
+  ///   - traitExpr: The unsupported trait expression.
+  ///   - attribute: The `@Test` or `@Suite` attribute.
+  ///
+  /// - Returns: A diagnostic message.
+  static func traitHasNoEffect(_ traitExpr: some ExprSyntaxProtocol, in attribute: AttributeSyntax) -> Self {
+    Self(
+      syntax: Syntax(traitExpr),
+      message: "Trait '\(traitExpr.trimmed)' has no effect when used with a non-parameterized test function",
+      severity: .warning
+    )
+  }
+
   /// Create a diagnostic messages stating that the expression passed to
   /// `#require()` is ambiguous.
   ///

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -176,6 +176,10 @@ struct TestDeclarationMacroTests {
         "The result of this function will be discarded during testing",
       "@Test func f() -> (Int, Int) {}":
         "The result of this function will be discarded during testing",
+
+      // .serialized on a non-parameterized test function
+      "@Test(.serialized) func f() {}":
+        "Trait '.serialized' has no effect when used with a non-parameterized test function",
     ]
   )
   func apiMisuseWarnings(input: String, expectedMessage: String) throws {


### PR DESCRIPTION
This PR adds a compile-time diagnostic if `.serialized` is used with `@Test` for a test function that is not parameterized. Such uses are nonsensical, because a non-parameterized test function has nothing to serialize against. The trait operates "inward", meaning that applying it to a _suite_ affects the tests in that suite, and applying it to a _parameterized test function_ applies to the test cases of that function.

For example:

```swift
@Test(.serialized) // ⚠️ Warning: Trait '.serialized' has no effect when used
                   // with a non-parameterized test function
func f() { /* ... */ }
```

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
