### PR TITLE
Remove `Sendable` constraint on the type of `Test.testCases`.

### DIFF
--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -113,7 +113,7 @@ public struct Test: Sendable {
   /// combination of parameterized inputs. For non-parameterized tests, a single
   /// test case is synthesized. For test suite types (as opposed to test
   /// functions), the value of this property is `nil`.
-  var testCases: (some Sequence<Test.Case> & Sendable)? {
+  var testCases: (some Sequence<Test.Case>)? {
     testCasesState.map { testCasesState in
       guard case let .evaluated(testCases) = testCasesState else {
         // Callers are expected to first attempt to evaluate a test's cases by


### PR DESCRIPTION
This change makes the type of `Test.testCases` just `(some Sequence<Test.Case>)?` instead of
`(some Sequence<Test.Case> & Sendable)?`. We don't need to send the sequence anywhere, so the extra requirement is not needed.

Resolves #439.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
