### PR TITLE
Resolve a build failure in a test target

### DIFF
--- a/Tests/TestingTests/Test.SnapshotTests.swift
+++ b/Tests/TestingTests/Test.SnapshotTests.swift
@@ -127,5 +127,5 @@ struct Test_SnapshotTests {
 }
 
 extension Tag {
-  @Tag fileprivate static let testTag: Self
+  @Tag fileprivate static var testTag: Self
 }


### PR DESCRIPTION
Change a `let` to `var` to work around a build failure on current Swift 6.0 toolchains

Resolves #443.