### PR TITLE
Stop proactively inserting redundant `@frozen` annotations in various macro expansions.

### DIFF
--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -350,7 +350,7 @@ extension ExitTestConditionMacro {
     let enumName = context.makeUniqueName("__🟠$exit_test_body__")
     let enumDecl: DeclSyntax = """
     @available(*, deprecated, message: "This type is an implementation detail of the testing library. Do not use it directly.")
-    @frozen enum \(enumName): Testing.__ExitTestContainer {
+    enum \(enumName): Testing.__ExitTestContainer {
       static var __sourceLocation: Testing.SourceLocation {
         \(createSourceLocationExpr(of: macro, context: context))
       }

--- a/Sources/TestingMacros/SuiteDeclarationMacro.swift
+++ b/Sources/TestingMacros/SuiteDeclarationMacro.swift
@@ -132,7 +132,7 @@ public struct SuiteDeclarationMacro: MemberMacro, PeerMacro, Sendable {
     result.append(
       """
       @available(*, deprecated, message: "This type is an implementation detail of the testing library. Do not use it directly.")
-      @frozen enum \(enumName): Testing.__TestContainer {
+      enum \(enumName): Testing.__TestContainer {
         static var __tests: [Testing.Test] {
           get async {[
             .__type(

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -509,7 +509,7 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
     result.append(
       """
       @available(*, deprecated, message: "This type is an implementation detail of the testing library. Do not use it directly.")
-      @frozen enum \(enumName): Testing.__TestContainer {
+      enum \(enumName): Testing.__TestContainer {
         static var __tests: [Testing.Test] {
           get async {
             \(raw: testsBody)


### PR DESCRIPTION
Resolves #444.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
