### PR TITLE
Ensure `@Test(arguments:)` macro expansion trims trivia from argument expressions

### DIFF
--- a/Sources/TestingMacros/Support/AttributeDiscovery.swift
+++ b/Sources/TestingMacros/Support/AttributeDiscovery.swift
@@ -190,7 +190,7 @@ struct AttributeInfo {
     if let argumentsIndex = otherArguments.firstIndex(where: { $0.label?.tokenKind == .identifier("arguments") }) {
       for index in argumentsIndex ..< otherArguments.endIndex {
         var argument = otherArguments[index]
-        argument.expression = .init(ClosureExprSyntax { argument.expression })
+        argument.expression = .init(ClosureExprSyntax { argument.expression.trimmed })
         otherArguments[index] = argument
       }
     }

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -201,6 +201,11 @@ struct TestsWithAsyncArguments {
   func g(i: Int, j: Int) {}
 }
 
+@Test(
+  arguments: [0] // Meaningful trivia: This line comment should be omitted during macro expansion
+)
+func parameterizedTestWithTrailingComment(value: Int) {}
+
 @Suite("Miscellaneous tests")
 struct MiscellaneousTests {
   @Test("Free function's name")


### PR DESCRIPTION
This fixes a build error which can arise if the `@Test(arguments:)` attribute applied to a parameterized test function includes trailing trivia such as a `//`-style line comment on the end of the line. For example:

```swift
@Test(
  arguments: [...] // some comment
)
func example(...) { ... }
```

This regressed with my changes in #366 which began surrounding the argument expressions in a closure expression, in order to facilitate lazy evaluation. The fix ensures that the wrapped expression is trimmed, in addition to the outer closure (which was, and still is, trimmed).

### Motivation:

Comments in this position may not be used often, but can be useful to provide context about the role or meaning of a particular collection of arguments passed to a parameterized test. So we'd like to continue supporting this.

### Modifications:

- Trim trivia from the argument expression included in the `@Test` macro expansion code.
- Add test reproducing and validating this scenario.

### Result:

Parameterized test functions with trailing line comments on the `arguments:` line now produce valid macro expansion code and build successfully.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Resolves rdar://128609944
