### PR TITLE
Avoid infinite recursion when snapshotting objects which may have cyclic references

### DIFF
--- a/Sources/Testing/SourceAttribution/Expression.swift
+++ b/Sources/Testing/SourceAttribution/Expression.swift
@@ -217,8 +217,9 @@ public struct __Expression: Sendable {
       var objectIdentifierTeRemove: ObjectIdentifier?
       var shouldIncludeChildren = true
       if mirror.displayStyle == .class, type(of: subject) is AnyObject.Type {
-        let objectIdentifier = ObjectIdentifier(subject as AnyObject)
-        let oldValue = seenObjects.updateValue(subject as AnyObject, forKey: objectIdentifier)
+        let object = subject as AnyObject
+        let objectIdentifier = ObjectIdentifier(object)
+        let oldValue = seenObjects.updateValue(object, forKey: objectIdentifier)
         if oldValue != nil {
           shouldIncludeChildren = false
         }

--- a/Sources/Testing/SourceAttribution/Expression.swift
+++ b/Sources/Testing/SourceAttribution/Expression.swift
@@ -174,7 +174,7 @@ public struct __Expression: Sendable {
     ///   - subject: The subject this instance should describe.
     init(reflecting subject: Any) {
       var objectIDs: Set<ObjectIdentifier> = []
-      self.init(reflecting: subject, label: nil, objectIDs: &objectIDs)!
+      self.init(_reflecting: subject, label: nil, objectIDs: &objectIDs)!
     }
 
     /// Initialize an instance of this type describing the specified subject and
@@ -193,7 +193,7 @@ public struct __Expression: Sendable {
     ///   already been seen while recursing. Otherwise, an initialized instance
     ///   reflecting `subject`.
     private init?(
-        reflecting subject: Any,
+        _reflecting subject: Any,
         label: String?,
         objectIDs: inout Set<ObjectIdentifier>
     ) {
@@ -216,11 +216,10 @@ public struct __Expression: Sendable {
       // checks the metatype of the subject using `type(of:)`, which is
       // inexpensive.
       if mirror.displayStyle == .class, type(of: subject) is AnyObject.Type {
-        let objectIdentifier = ObjectIdentifier(subject as AnyObject)
-        if objectIDs.contains(objectIdentifier) {
+        let result = objectIDs.insert(ObjectIdentifier(subject as AnyObject))
+        if !result.inserted {
           return nil
         }
-        objectIDs.insert(objectIdentifier)
       }
 
       description = String(describingForTest: subject)
@@ -239,7 +238,7 @@ public struct __Expression: Sendable {
 
       if !mirror.children.isEmpty || isCollection {
         self.children = mirror.children.compactMap { child in
-          Self(reflecting: child.value, label: child.label, objectIDs: &objectIDs)
+          Self(_reflecting: child.value, label: child.label, objectIDs: &objectIDs)
         }
       }
     }

--- a/Tests/TestingTests/Expression.ValueTests.swift
+++ b/Tests/TestingTests/Expression.ValueTests.swift
@@ -1,0 +1,92 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable @_spi(ForToolsIntegrationOnly) import Testing
+
+@Suite("Expression.Value Tests")
+struct Expression_ValueTests {
+
+  @Test("Value reflecting a simple struct with one property")
+  func simpleStruct() throws {
+    struct Foo {
+      var x: Int = 123
+    }
+
+    let foo = Foo()
+
+    let value = Expression.Value(reflecting: foo)
+    let children = try #require(value.children)
+    try #require(children.count == 1)
+
+    let child = try #require(children.first)
+    #expect(child.label == "x")
+    #expect(child.typeInfo == TypeInfo(describing: Int.self))
+    #expect(String(describing: child) == "123")
+    #expect(child.children == nil)
+  }
+
+  @Test("Value reflecting an object with a cyclic reference to itself")
+  func recursiveObjectReference() throws {
+    class RecursiveItem {
+      weak var anotherItem: RecursiveItem?
+      let boolValue = false
+    }
+
+    let recursiveItem = RecursiveItem()
+    recursiveItem.anotherItem = recursiveItem
+
+    let value = Expression.Value(reflecting: recursiveItem)
+    let children = try #require(value.children)
+    try #require(children.count == 2)
+
+    let firstChild = try #require(children.first)
+    #expect(firstChild.label == "anotherItem")
+
+    let lastChild = try #require(children.last)
+    #expect(lastChild.label == "boolValue")
+    #expect(String(describing: lastChild) == "false")
+  }
+
+  @Test("Value reflecting an object with a reference to another object which has a cyclic back-reference the first")
+  func cyclicBackReference() throws {
+    class One {
+      var two: Two?
+    }
+    class Two {
+      weak var one: One?
+    }
+
+    let one = One()
+    let two = Two()
+    one.two = two
+    two.one = one
+
+    let value = Expression.Value(reflecting: one)
+    let children = try #require(value.children)
+    try #require(children.count == 1)
+
+    let twoChild = try #require(children.first)
+    #expect(twoChild.label == "two")
+    #expect(twoChild.typeInfo == TypeInfo(describing: Two?.self))
+    let twoChildChildren = try #require(twoChild.children)
+    try #require(twoChildChildren.count == 1)
+    let twoChildChildrenOptionalChild = try #require(twoChildChildren.first)
+    #expect(twoChildChildrenOptionalChild.label == "some")
+    let twoChildChildrenOptionalChildren = try #require(twoChildChildrenOptionalChild.children)
+    try #require(twoChildChildrenOptionalChildren.count == 1)
+
+    let oneChild = try #require(twoChildChildrenOptionalChildren.first)
+    #expect(oneChild.label == "one")
+    #expect(oneChild.typeInfo == TypeInfo(describing: One?.self))
+    let oneChildChildren = try #require(oneChild.children)
+    #expect(oneChildChildren.isEmpty)
+  }
+
+}


### PR DESCRIPTION
This fixes an issue which can cause a crash due to infinite recursion when taking snapshots of values which have cyclic or recursive object references.

### Modifications:

- Begin keeping track of the objects seen while recursively snapshotting child values, and stop recursion if we encounter a previously-seen object. The logic is carefully constructed to limit the overhead involved in managing this data and limiting it to only apply to object types. See the code comment for details.
- Added a new unit test suite validating this fix, as well as the general behavior.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Resolves rdar://124726503
