### PR TITLE
Some minor housekeeping.

### DIFF
--- a/Sources/Testing/EntryPoints/XCTestScaffold.swift
+++ b/Sources/Testing/EntryPoints/XCTestScaffold.swift
@@ -31,6 +31,7 @@ extension XCTSourceCodeContext {
     self.init(callStackAddresses: addresses, location: sourceLocation)
   }
 }
+
 extension XCTIssue {
   init(_ issue: Issue, processLaunchedByXcode: Bool) {
     var error = issue.error

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -245,7 +245,6 @@ extension ExitTest {
       // If the running executable appears to be the XCTest runner executable in
       // Xcode, figure out the path to the running XCTest bundle. If we can find
       // it, then we can re-run the host XCTestCase instance.
-      // TODO: use basename_r() instead of parsing the path.
       var isHostedByXCTest = false
       if let executablePath = try? childProcessExecutablePath.get() {
         executablePath.withCString { childProcessExecutablePath in

--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -258,7 +258,7 @@ extension FileHandle {
 
     try withUnsafeCFILEHandle { file in
       try withUnsafeTemporaryAllocation(byteCount: 1024, alignment: 1) { buffer in
-        while true {
+        repeat {
           let countRead = fread(buffer.baseAddress, 1, buffer.count, file)
           if 0 != ferror(file) {
             throw CError(rawValue: swt_errno())
@@ -267,10 +267,7 @@ extension FileHandle {
             let endIndex = buffer.index(buffer.startIndex, offsetBy: countRead)
             result.append(contentsOf: buffer[..<endIndex])
           }
-          if 0 != feof(file) {
-            break
-          }
-        }
+        } while 0 == feof(file)
       }
     }
 

--- a/Sources/_TestingInternals/include/Stubs.h
+++ b/Sources/_TestingInternals/include/Stubs.h
@@ -116,7 +116,7 @@ static pid_t swt_siginfo_t_si_pid(const siginfo_t *siginfo) {
 /// platforms and cannot be imported directly into Swift. It is renamed back to
 /// `siginfo_t.si_status` in Swift.
 SWT_SWIFT_NAME(getter:siginfo_t.si_status(self:))
-static pid_t swt_siginfo_t_si_status(const siginfo_t *siginfo) {
+static int swt_siginfo_t_si_status(const siginfo_t *siginfo) {
   return siginfo->si_status;
 }
 #endif


### PR DESCRIPTION
This PR does some minor housekeeping/cleanup. Other than style changes, it avoids stomping on the filter/skip arguments from a configuration JSON blob in the ABI entry point and it avoids copying every JSON blob in the event stream unless they actually contain newlines (which is unexpected.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
