### PR TITLE
Fix a typo on the JSON ABI document.

### DIFF
--- a/Documentation/ABI/JSON.md
+++ b/Documentation/ABI/JSON.md
@@ -210,8 +210,8 @@ sufficient information to display the event in a human-readable format.
   "text": <string>, ; the human-readable text of this message
 }
 
-<message-symbol> ::= "default" | "skip" | "pass" | "passWithKnownIssue" | "fail"
-  "difference" | "warning" | "details"
+<message-symbol> ::= "default" | "skip" | "pass" | "passWithKnownIssue" |
+  "fail" | "difference" | "warning" | "details"
 ```
 
 <!--


### PR DESCRIPTION
This PR fixes a missing `|` in JSON.md.

Resolves #445.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
