### PR TITLE
Throw errors from the ABI entry point instead of crashing.

### DIFF
--- a/Sources/Testing/EntryPoints/ABIEntryPoint.swift
+++ b/Sources/Testing/EntryPoints/ABIEntryPoint.swift
@@ -22,6 +22,9 @@
 /// - Returns: The result of invoking the testing library. The type of this
 ///   value is subject to change.
 ///
+/// - Throws: Any error that occurred prior to running tests. Errors that are
+///   thrown while tests are running are handled by the testing library.
+///
 /// This function examines the command-line arguments to the current process
 /// and then invokes available tests in the current process.
 ///
@@ -31,7 +34,7 @@
 public typealias ABIEntryPoint_v0 = @Sendable (
   _ argumentsJSON: UnsafeRawBufferPointer?,
   _ recordHandler: @escaping @Sendable (_ recordJSON: UnsafeRawBufferPointer) -> Void
-) async -> CInt
+) async throws -> CInt
 
 /// Get the entry point to the testing library used by tools that want to remain
 /// version-agnostic regarding the testing library.
@@ -58,11 +61,11 @@ public typealias ABIEntryPoint_v0 = @Sendable (
 public func copyABIEntryPoint_v0() -> UnsafeMutableRawPointer {
   let result = UnsafeMutablePointer<ABIEntryPoint_v0>.allocate(capacity: 1)
   result.initialize { argumentsJSON, recordHandler in
-    let args = try! argumentsJSON.map { argumentsJSON in
+    let args = try argumentsJSON.map { argumentsJSON in
       try JSON.decode(__CommandLineArguments_v0.self, from: argumentsJSON)
     }
 
-    let eventHandler = try! eventHandlerForStreamingEvents(version: args?.experimentalEventStreamVersion, forwardingTo: recordHandler)
+    let eventHandler = try eventHandlerForStreamingEvents(version: args?.experimentalEventStreamVersion, forwardingTo: recordHandler)
     return await entryPoint(passing: args, eventHandler: eventHandler)
   }
   return .init(result)

--- a/Tests/TestingTests/ABIEntryPointTests.swift
+++ b/Tests/TestingTests/ABIEntryPointTests.swift
@@ -53,7 +53,7 @@ struct ABIEntryPointTests {
     }
 
     // Call the entry point function.
-    let result = await abiEntryPoint.pointee(.init(argumentsJSON)) { recordJSON in
+    let result = try await abiEntryPoint.pointee(.init(argumentsJSON)) { recordJSON in
       let record = try! JSON.decode(ABIv0.Record.self, from: recordJSON)
       _ = record.version
     }


### PR DESCRIPTION
This PR changes the signature of the ABI entry point function to be throwing. Any existing early adopters will need to add `try` to their calls to it (not to the function that yields the Swift entry point, but to the yielded Swift entry point.)

Callers that are uninterested in errors that occur during setup can use `try!` or `try?` as appropriate.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
