### PR TITLE
Fix CMake files referencing GetSymbol.cpp -> GetSymbol.swift.

### DIFF
--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -66,6 +66,7 @@ add_library(Testing
   Support/CError.swift
   Support/Environment.swift
   Support/FileHandle.swift
+  Support/GetSymbol.swift
   Support/Graph.swift
   Support/JSON.swift
   Support/Locked.swift

--- a/Sources/_TestingInternals/CMakeLists.txt
+++ b/Sources/_TestingInternals/CMakeLists.txt
@@ -9,7 +9,6 @@
 include(LibraryVersion)
 add_library(_TestingInternals STATIC
   Discovery.cpp
-  GetSymbol.cpp
   WillThrow.cpp)
 target_include_directories(_TestingInternals PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include)


### PR DESCRIPTION
When I rewrote the `dlsym()` wrapper in Swift, I neglected to update our CMake files. Oops!

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
