### PR TITLE
[cmake] Fix inconsistently imported warning.

### DIFF
--- a/Sources/Testing/Support/GetSymbol.swift
+++ b/Sources/Testing/Support/GetSymbol.swift
@@ -8,7 +8,11 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if SWT_BUILDING_WITH_CMAKE
+@_implementationOnly import _TestingInternals
+#else
 internal import _TestingInternals
+#endif
 
 #if !SWT_NO_DYNAMIC_LINKING
 


### PR DESCRIPTION
Quick fix for:
```
swift-testing\Sources\Testing\Support\GetSymbol.swift:11:17: warning: '_TestingInternals' inconsistently imported as implementation-only
```

### Motivation:

We made importing `_TestingInternals` conditional on build type to minimize chances of direct usage by third-parties. While verifying other recent changes, I noticed this import had been added without the proper conditional.

```
[15/16] Building Swift object swift/Testing.swiftmodule Sources/Tes...t.obj Sources/Testing/CMakeFiles/Testing.dir/Traits/Trait.swift.obj
swift-testing\Sources\Testing\Support\GetSymbol.swift:11:17: warning: '_TestingInternals' inconsistently imported as implementation-only
 9 │ //
10 │
11 │ internal import _TestingInternals
   │                 ╰─ warning: '_TestingInternals' inconsistently imported as implementation-only
12 │
13 │ #if !SWT_NO_DYNAMIC_LINKING

swift-testing\Sources\Testing\EntryPoints\EntryPoint.swift:12:29: note: imported as implementation-only here
 10 │
 11 │ #if SWT_BUILDING_WITH_CMAKE
 12 │ @_implementationOnly import _TestingInternals
    │                             ╰─ note: imported as implementation-only here
 13 │ #else
 14 │ private import _TestingInternals
```

### Modifications:

Update import to use `@_implementationOnly` when building w/CMake.

### Result:

Warning is gone.

### Checklist:

- [X] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [X] If public symbols are renamed or modified, DocC references should be updated.
