### PR TITLE
[CMake] Set macro build make program

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -8,9 +8,15 @@
 
 # Macros must be built for the build machine, not the host.
 include(ExternalProject)
+if(NOT SwiftTesting_MACRO_MAKE_PROGRAM)
+  set(SwiftTesting_MACRO_MAKE_PROGRAM ${CMAKE_MAKE_PROGRAM})
+endif()
+
 ExternalProject_Add(TestingMacros
   PREFIX "tm"
   SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/TestingMacros"
+  CMAKE_ARGS
+    -DCMAKE_MAKE_PROGRAM=${SwiftTesting_MACRO_MAKE_PROGRAM}
   INSTALL_COMMAND "")
 ExternalProject_Get_Property(TestingMacros BINARY_DIR)
 if(CMAKE_HOST_WIN32)


### PR DESCRIPTION
One may need to be able to set the make program on the macro build. Either they are unable to have `Ninja` on their path, or need to use a different `Ninja` for their macro build.
The behavior of this PR:
 -  default it to the `CMAKE_MAKE_PROGRAM`, which, if unset, will pull the make program the path as CMake does normally. 
 - If it is set but `SwiftTesting_MACRO_MAKE_PROGRAM` is unset, it will default to the specified `CMAKE_MAKE_PROGRAM` that is used for the rest of the build. 
 - Finally, if one needs to use a different make program for the macro build from the rest (using a different cross-compiling toolchain, e.g), they can specify `SwiftTesting_MACRO_MAKE_PROGRAM` explicitly.