### PR TITLE
Delete the workaround for `CommandLine.arguments` being concurrency-unsafe.

### DIFF
--- a/Sources/Testing/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/EntryPoints/EntryPoint.swift
@@ -31,7 +31,7 @@ func entryPoint(passing args: consuming __CommandLineArguments_v0?, eventHandler
   let exitCode = Locked(rawValue: EXIT_SUCCESS)
 
   do {
-    let args = try args ?? parseCommandLineArguments(from: CommandLine.arguments())
+    let args = try args ?? parseCommandLineArguments(from: CommandLine.arguments)
     if args.listTests ?? true {
       for testID in await listTestsForEntryPoint(Test.all) {
 #if SWT_TARGET_OS_APPLE && !SWT_NO_FILE_IO

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -240,7 +240,7 @@ extension ExitTest {
     let childArguments: [String] = {
       var result = [String]()
       lazy var xctestTargetPath = Environment.variable(named: "XCTestBundlePath")
-        ?? CommandLine.arguments().dropFirst().last
+        ?? CommandLine.arguments.dropFirst().last
 #if SWT_TARGET_OS_APPLE
       // If the running executable appears to be the XCTest runner executable in
       // Xcode, figure out the path to the running XCTest bundle. If we can find

--- a/Sources/Testing/Support/Additions/CommandLineAdditions.swift
+++ b/Sources/Testing/Support/Additions/CommandLineAdditions.swift
@@ -15,19 +15,6 @@ private import _TestingInternals
 #endif
 
 extension CommandLine {
-  /// Get the command-line arguments passed to this process.
-  ///
-  /// - Returns: An array of command-line arguments.
-  ///
-  /// This function works around a bug in the Swift standard library that causes
-  /// the built-in `CommandLine.arguments` property to not be concurrency-safe.
-  /// ([swift-#66213](https://github.com/apple/swift/issues/66213))
-  static func arguments() -> [String] {
-    UnsafeBufferPointer(start: unsafeArgv, count: Int(argc)).lazy
-      .compactMap { $0 }
-      .compactMap { String(validatingUTF8CString: $0) }
-  }
-
   /// The path to the current process' executable.
   static var executablePath: String {
     get throws {

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -26,7 +26,7 @@ struct SwiftPMTests {
   func commandLineArguments() {
     // We can't meaningfully check the actual values of this process' arguments,
     // but we can check that the arguments() function has a non-empty result.
-    #expect(!CommandLine.arguments().isEmpty)
+    #expect(!CommandLine.arguments.isEmpty)
   }
 
   @Test("--parallel/--no-parallel argument")


### PR DESCRIPTION
The Swift 6 standard library fixes `CommandLine.arguments` being unsafe to use in concurrent code, so our workaround is no longer needed.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
