### PR TITLE
Ensure default property values for `__CommandLineArguments_v0` are all `nil`.

### DIFF
--- a/Sources/Testing/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/EntryPoints/EntryPoint.swift
@@ -32,7 +32,7 @@ func entryPoint(passing args: consuming __CommandLineArguments_v0?, eventHandler
 
   do {
     let args = try args ?? parseCommandLineArguments(from: CommandLine.arguments)
-    if args.listTests ?? true {
+    if args.listTests ?? false {
       for testID in await listTestsForEntryPoint(Test.all) {
 #if SWT_TARGET_OS_APPLE && !SWT_NO_FILE_IO
         try? FileHandle.stdout.write("\(testID)\n")
@@ -153,19 +153,19 @@ public struct __CommandLineArguments_v0: Sendable {
   public init() {}
 
   /// The value of the `--list-tests` argument.
-  public var listTests: Bool? = false
+  public var listTests: Bool?
 
   /// The value of the `--parallel` or `--no-parallel` argument.
-  public var parallel: Bool? = true
+  public var parallel: Bool?
 
   /// The value of the `--verbose` argument.
-  public var verbose: Bool? = false
+  public var verbose: Bool?
 
   /// The value of the `--very-verbose` argument.
-  public var veryVerbose: Bool? = false
+  public var veryVerbose: Bool?
 
   /// The value of the `--quiet` argument.
-  public var quiet: Bool? = false
+  public var quiet: Bool?
 
   /// Storage for the ``verbosity`` property.
   private var _verbosity: Int?
@@ -226,7 +226,7 @@ public struct __CommandLineArguments_v0: Sendable {
   ///
   /// - Warning: The behavior of this property will change when the ABI version
   ///   0 JSON schema is finalized.
-  public var experimentalEventStreamVersion: Int? = nil
+  public var experimentalEventStreamVersion: Int?
 
   /// The value(s) of the `--filter` argument.
   public var filter: [String]?

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -174,16 +174,18 @@ struct SwiftPMTests {
     defer {
       _ = remove(temporaryFilePath)
     }
-    let fileHandle = try FileHandle(forWritingAtPath: temporaryFilePath)
-    try fileHandle.write(
-      """
-      {
-        "verbosity": 50,
-        "filter": ["hello", "world"],
-        "parallel": false
-      }
-      """
-    )
+    do {
+      let fileHandle = try FileHandle(forWritingAtPath: temporaryFilePath)
+      try fileHandle.write(
+        """
+        {
+          "verbosity": 50,
+          "filter": ["hello", "world"],
+          "parallel": false
+        }
+        """
+      )
+    }
     let args = try parseCommandLineArguments(from: ["PATH", "--experimental-configuration-path", temporaryFilePath])
     #expect(args.verbose == nil)
     #expect(args.quiet == nil)

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -167,6 +167,32 @@ struct SwiftPMTests {
   }
 
 #if canImport(Foundation)
+  @Test("--experimental-configuration-path argument")
+  func configurationPath() async throws {
+    let tempDirPath = try temporaryDirectory()
+    let temporaryFilePath = appendPathComponent("\(UInt64.random(in: 0 ..< .max))", to: tempDirPath)
+    defer {
+      _ = remove(temporaryFilePath)
+    }
+    let fileHandle = try FileHandle(forWritingAtPath: temporaryFilePath)
+    try fileHandle.write(
+      """
+      {
+        "verbosity": 50,
+        "filter": ["hello", "world"],
+        "parallel": false
+      }
+      """
+    )
+    let args = try parseCommandLineArguments(from: ["PATH", "--experimental-configuration-path", temporaryFilePath])
+    #expect(args.verbose == nil)
+    #expect(args.quiet == nil)
+    #expect(args.verbosity == 50)
+    #expect(args.filter == ["hello", "world"])
+    #expect(args.skip == nil)
+    #expect(args.parallel == false)
+  }
+
   func decodeABIv0RecordStream(fromFileAtPath path: String) throws -> [ABIv0.Record] {
     try FileHandle(forReadingAtPath: path).readToEnd()
       .split(separator: 10) // "\n"


### PR DESCRIPTION
We should default to `nil` (i.e. "unspecified") for command-line argument values that aren't specified. This ensures consistent default behaviour whether specifying command-line arguments individually or specifying `--experimental-configuration-path` (or a combination thereof).

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
