### PR TITLE
Fix Tag example in documentation.

### DIFF
--- a/Sources/Testing/Testing.docc/AddingTags.md
+++ b/Sources/Testing/Testing.docc/AddingTags.md
@@ -66,7 +66,7 @@ extension Tag.com_example_foodtruck {
   @Tag static var extraSpecial: Tag
 }
 
-@Test
+@Test(
   "Extra Special Sauce recipe is secret",
   .tags(.com_example_foodtruck.extraSpecial)
 )

--- a/Sources/Testing/Testing.docc/AddingTags.md
+++ b/Sources/Testing/Testing.docc/AddingTags.md
@@ -63,7 +63,7 @@ extension Tag {
 }
 
 extension Tag.com_example_foodtruck {
-  @Tag static var extraSpecial: Self
+  @Tag static var extraSpecial: Tag
 }
 
 @Test


### PR DESCRIPTION
Attribute Tag must by applied to type Tag and not type Tag.com_example_foodtruck.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
