### PR TITLE
Switch doc generation to use 6.0

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -3,5 +3,8 @@ metadata:
   authors: Apple Inc.
 builder:
   configs:
-    - documentation_targets: [Testing]
+    - swift_version: 5.10
+      scheme: Testing
+    - swift_version: 6.0
+      documentation_targets: [Testing]
       scheme: Testing


### PR DESCRIPTION
NB: we always build docs with the latest _release_ version of Swift by default. So once Swift 6 is released this change will be redundant and moreover would pin doc gen to 6.0 even once 6.1 released and should be reverted by then.

Tested to be working ok with our doc gen mechanism:

![CleanShot 2024-06-12 at 14 39 35@2x](https://github.com/apple/swift-testing/assets/65520/07bcefcb-d7a2-4fea-b22d-193bb8198852)
