### PR TITLE
Explicitly add visionOS availability to tests that check availability (Take 2)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -145,7 +145,7 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .enableExperimentalFeature("AvailabilityMacro=_regexAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0"),
       .enableExperimentalFeature("AvailabilityMacro=_swiftVersionAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0"),
 
-      .enableExperimentalFeature("AvailabilityMacro=_distantFuture:macOS 99.0, iOS 99.0, watchOS 99.0, tvOS 99.0"),
+      .enableExperimentalFeature("AvailabilityMacro=_distantFuture:macOS 99.0, iOS 99.0, watchOS 99.0, tvOS 99.0, visionOS 99.0"),
     ]
   }
 }

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -402,11 +402,11 @@ struct EventRecorderTests {
   func unavailablePigeon() {}
 
   @Test("Future Grouse", .hidden)
-  @available(macOS 999.0, iOS 999.0, watchOS 999.0, tvOS 999.0, *)
+  @available(macOS 999.0, iOS 999.0, watchOS 999.0, tvOS 999.0, visionOS 999.0, *)
   func futureGrouse() {}
 
   @Test("Future Goose", .hidden)
-  @available(macOS 999, iOS 999, watchOS 999, tvOS 999, *)
+  @available(macOS 999, iOS 999, watchOS 999, tvOS 999, visionOS 999.0, *)
   func futureGoose() {}
 
   @Test("Future Mouse", .hidden)

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -615,7 +615,7 @@ final class RunnerTests: XCTestCase {
 
 #if SWT_TARGET_OS_APPLE
     @Test(.hidden)
-    @available(macOS 999.0, iOS 999.0, watchOS 999.0, tvOS 999.0, *)
+    @available(macOS 999.0, iOS 999.0, watchOS 999.0, tvOS 999.0, visionOS 999.0, *)
     func futureAvailable() {}
 
     @Test(.hidden)
@@ -623,12 +623,13 @@ final class RunnerTests: XCTestCase {
     @available(iOS, introduced: 999.0)
     @available(watchOS, introduced: 999.0)
     @available(tvOS, introduced: 999.0)
+    @available(visionOS, introduced: 999.0)
     func futureAvailableLongForm() {}
 
     @Suite(.hidden)
     struct U {
       @Test(.hidden)
-      @available(macOS 999.0, iOS 999.0, watchOS 999.0, tvOS 999.0, *)
+      @available(macOS 999.0, iOS 999.0, watchOS 999.0, tvOS 999.0, visionOS 999.0, *)
       func f() {}
 
       @Test(.hidden)
@@ -643,6 +644,7 @@ final class RunnerTests: XCTestCase {
       @available(iOS, introduced: 999.0)
       @available(watchOS, introduced: 999.0)
       @available(tvOS, introduced: 999.0)
+      @available(visionOS, introduced: 999.0)
       func f() {}
     }
 #endif
@@ -677,6 +679,7 @@ final class RunnerTests: XCTestCase {
     @available(iOS, introduced: 1.0, obsoleted: 999.0)
     @available(watchOS, introduced: 1.0, obsoleted: 999.0)
     @available(tvOS, introduced: 1.0, obsoleted: 999.0)
+    @available(visionOS, introduced: 1.0, obsoleted: 999.0)
     func obsoleted() {}
   }
 
@@ -702,6 +705,7 @@ final class RunnerTests: XCTestCase {
     @available(iOS, introduced: 999.0, message: "Expected Message")
     @available(watchOS, introduced: 999.0, message: "Expected Message")
     @available(tvOS, introduced: 999.0, message: "Expected Message")
+    @available(visionOS, introduced: 999.0, message: "Expected Message")
     func futureAvailableLongForm() {}
 #endif
   }
@@ -839,6 +843,7 @@ final class RunnerTests: XCTestCase {
     @available(iOS, deprecated: 1.0)
     @available(watchOS, deprecated: 1.0)
     @available(tvOS, deprecated: 1.0)
+    @available(visionOS, deprecated: 1.0)
     func deprecatedAppleCallee() {}
 
     @Test(.hidden)
@@ -846,6 +851,7 @@ final class RunnerTests: XCTestCase {
     @available(iOS, deprecated: 1.0)
     @available(watchOS, deprecated: 1.0)
     @available(tvOS, deprecated: 1.0)
+    @available(visionOS, deprecated: 1.0)
     func deprecatedApple() {
       deprecatedAppleCallee()
     }


### PR DESCRIPTION
Re-attempt the change from https://github.com/apple/swift-testing/pull/424 now that we require a Swift 6 toolchain to building the package.