### PR TITLE
Don't emit JSON blobs for test cases if a test function isn't parameterized.

### DIFF
--- a/Sources/Testing/EntryPoints/ABIv0/Encoded/ABIv0.EncodedEvent.swift
+++ b/Sources/Testing/EntryPoints/ABIv0/Encoded/ABIv0.EncodedEvent.swift
@@ -64,11 +64,17 @@ extension ABIv0 {
       case .testStarted:
         kind = .testStarted
       case .testCaseStarted:
+        if eventContext.test?.isParameterized == false {
+          return nil
+        }
         kind = .testCaseStarted
       case let .issueRecorded(recordedIssue):
         kind = .issueRecorded
         issue = EncodedIssue(encoding: recordedIssue)
       case .testCaseEnded:
+        if eventContext.test?.isParameterized == false {
+          return nil
+        }
         kind = .testCaseEnded
       case .testEnded:
         kind = .testEnded
@@ -82,7 +88,9 @@ extension ABIv0 {
       instant = EncodedInstant(encoding: event.instant)
       self.messages = messages.map(EncodedMessage.init)
       testID = event.testID.map(EncodedTest.ID.init)
-      _testCase = eventContext.testCase.map(EncodedTestCase.init)
+      if eventContext.test?.isParameterized == true {
+        _testCase = eventContext.testCase.map(EncodedTestCase.init)
+      }
     }
   }
 }


### PR DESCRIPTION
Internally, Swift Testing models non-parameterized test functions as parameterized over a single input, `()`. This is a very useful abstraction internally, but when it comes to the JSON output for parameterized tests, it can be confusing or surprising to see information about a test case that was synthesized by the library.

This PR suppresses events and metadata for the single test case of a non-parameterized test function.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
