### PR TITLE
Fix miscompile with inferred base expression of member access expression.

### DIFF
--- a/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
+++ b/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
@@ -393,12 +393,20 @@ private func _parseCondition(from expr: FunctionCallExprSyntax, for macro: some 
     // closure body since it is unused.
     let parameterList = forwardedArguments.isEmpty ? "_ in" : ""
     conditionArguments.append(Argument(expression: "()"))
+
+    // If memberAccessExpr is not nil here, that means it had a nil base
+    // expression (i.e. the base is inferred.)
+    var dot: TokenSyntax?
+    if memberAccessExpr != nil {
+      dot = .periodToken()
+    }
+
     conditionArguments.append(
       Argument(
         label: "calling",
         expression: """
         { \(raw: parameterList)
-          \(functionName.trimmed)(\(LabeledExprListSyntax(indexedArguments)))
+          \(dot)\(functionName.trimmed)(\(LabeledExprListSyntax(indexedArguments)))
         }
         """
       )

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -239,6 +239,7 @@ final class IssueTests: XCTestCase {
     }
 
     await Test {
+      _ = try #require(.memberAccessWithInferredBase(1))
       _ = try #require(TypeWithMemberFunctions.j(1))
     }.run(configuration: configuration)
 
@@ -1528,5 +1529,13 @@ struct IssueCodingTests {
 
     #expect(String(describing: issueSnapshot) == String(describing: issue))
     #expect(String(reflecting: issueSnapshot) == String(reflecting: issue))
+  }
+}
+
+// MARK: - Fixtures
+
+extension Optional {
+  fileprivate static func memberAccessWithInferredBase(_ this: Self) -> Self {
+    this
   }
 }


### PR DESCRIPTION
This PR fixes a bug where an inferred base expression in a member function call (`.foo()` instead of `T.foo()`) would be expanded incorrectly in `#expect()` and `#require()` as if it were a free function call.

For example:

```swift
extension Bool {
  static func truth() -> Bool {
    true
  }
}

@Test func f() {
  #expect(.truth())
}
```

Resolves #487.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
