### PR TITLE
Allow `nil` comments to be passed to `#expect()` or `#require()`.

### DIFF
--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -138,17 +138,24 @@ extension ConditionMacro {
       }
 
       // Capture any comments as well (either in source or as a macro argument.)
-      checkArguments.append(Argument(
-        label: "comments",
-        expression: ArrayExprSyntax {
-          for commentTraitExpr in createCommentTraitExprs(for: macro) {
-            ArrayElementSyntax(expression: commentTraitExpr)
-          }
-          if let commentIndex {
-            ArrayElementSyntax(expression: macroArguments[commentIndex].expression.trimmed)
-          }
+      let commentsArrayExpr = ArrayExprSyntax {
+        for commentTraitExpr in createCommentTraitExprs(for: macro) {
+          ArrayElementSyntax(expression: commentTraitExpr)
         }
-      ))
+        if let commentIndex {
+          ArrayElementSyntax(expression: macroArguments[commentIndex].expression.trimmed)
+        }
+      }
+      if commentIndex != nil {
+        // The developer supplied a comment argument. It might be nil, so
+        // explicitly filter out nil values from the resulting comment array.
+        checkArguments.append(Argument(
+          label: "comments",
+          expression: #"(\#(commentsArrayExpr) as [Comment?]).compactMap(\.self)"#
+        ))
+      } else {
+        checkArguments.append(Argument(label: "comments", expression: commentsArrayExpr))
+      }
 
       checkArguments.append(Argument(label: "isRequired", expression: BooleanLiteralExprSyntax(isThrowing)))
 

--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -146,9 +146,10 @@ extension ConditionMacro {
           ArrayElementSyntax(expression: macroArguments[commentIndex].expression.trimmed)
         }
       }
-      if commentIndex != nil {
-        // The developer supplied a comment argument. It might be nil, so
-        // explicitly filter out nil values from the resulting comment array.
+      if let commentIndex, !macroArguments[commentIndex].expression.is(StringLiteralExprSyntax.self) {
+        // The developer supplied a comment argument that isn't a string
+        // literal. It might be nil, so explicitly filter out nil values from
+        // the resulting comment array.
         checkArguments.append(Argument(
           label: "comments",
           expression: #"(\#(commentsArrayExpr) as [Comment?]).compactMap(\.self)"#

--- a/Tests/TestingTests/Traits/CommentTests.swift
+++ b/Tests/TestingTests/Traits/CommentTests.swift
@@ -52,6 +52,11 @@ struct CommentTests {
     #expect(inner2Type.comments == ["// L"])
 #endif
   }
+
+  @Test("Explicitly nil comment")
+  func explicitlyNilComment() {
+    #expect(true as Bool, nil as Comment?)
+  }
 }
 
 // MARK: - Fixtures


### PR DESCRIPTION
This PR allows `nil` to be passed to the expectation macros as their documented signatures allow.

Resolves #485.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
