### PR TITLE
Store a collection of patterns to match against in Configuration.TestFilter instead of chaining multiple pattern-matcher filters

### DIFF
--- a/Sources/Testing/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/EntryPoints/EntryPoint.swift
@@ -429,9 +429,7 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
     guard #available(_regexAPI, *) else {
       throw _EntryPointError.featureUnavailable("The `\(label)' option is not supported on this OS version.")
     }
-    return try regexes.lazy
-      .map { try Configuration.TestFilter(membership: membership, matching: $0) }
-      .reduce(into: .unfiltered) { $0.combine(with: $1, using: .or) }
+    return try Configuration.TestFilter(membership: membership, matchingAnyOf: regexes)
   }
   filters.append(try testFilter(forRegularExpressions: args.filter, label: "--filter", membership: .including))
   filters.append(try testFilter(forRegularExpressions: args.skip, label: "--skip", membership: .excluding))


### PR DESCRIPTION
This fixes a crash which can occur if there are many filter or skip arguments passed to the testing library's entry point.

In this situation, before this fix, one `Configuration.TestFilter` was created for each filter or skip argument and they were chained together to form a tree using `combining(with:using:)`. Then, they were applied to a test graph recursively. If this tree was deep due to having many filter or skip arguments chained together, the recursion could exceed the stack and cause a crash.

The fix is to change `Configuration.TestFilter.Kind.pattern` so that it can store multiple patterns to match against instead of just one. This makes it more aligned with the other cases in its enum, which also store collections, and prevents the crash since it typically results in much shallower filter trees.

### Result:

Crash is resolved, validated by a new unit test.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
