### PR TITLE
Avoid linker symbol de-duplication in 'failureBreakpoint()' marker function

### DIFF
--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -259,5 +259,13 @@ extension Issue {
 @inline(never) @_optimize(none)
 @usableFromInline
 func failureBreakpoint() {
-  // Empty.
+  // This function's body cannot be completely empty or else linker symbol
+  // de-duplication will cause its symbol to be consolidated with that of
+  // another, arbitrarily chosen empty function in this module. This linker
+  // behavior can be disabled by passing the `-no_deduplicate` flag described in
+  // ld(1), but that would disable it module-wide and sacrifice optimization
+  // opportunities elsewhere, so instead this function performs some trivial
+  // work to ensure its body is unique.
+  func noOp() {}
+  noOp()
 }

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -264,8 +264,9 @@ func failureBreakpoint() {
   // another, arbitrarily chosen empty function in this module. This linker
   // behavior can be disabled by passing the `-no_deduplicate` flag described in
   // ld(1), but that would disable it module-wide and sacrifice optimization
-  // opportunities elsewhere, so instead this function performs some trivial
-  // work to ensure its body is unique.
-  func noOp() {}
-  noOp()
+  // opportunities elsewhere. Instead, this function performs a trivial
+  // function call, passing it a sufficiently unique value to avoid
+  // de-duplication.
+  func noOp(_: String) {}
+  noOp(#function)
 }

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -267,6 +267,9 @@ func failureBreakpoint() {
   // opportunities elsewhere. Instead, this function performs a trivial
   // function call, passing it a sufficiently unique value to avoid
   // de-duplication.
-  func noOp(_: String) {}
-  noOp(#function)
+  struct NoOp {
+    nonisolated(unsafe) static var ignored: Int = 0
+    static func perform(_: inout Int) {}
+  }
+  NoOp.perform(&NoOp.ignored)
 }


### PR DESCRIPTION
This fixes an issue where the setting a debugger breakpoint on the special `failureBreakpoint()` marker function (which is used to break on test failures) may cause the debugger to resolve to the incorrect symbol in release builds due to linker de-duplication. See code comment for additional details.

### Result:

Confirmed this resolved the issue in a manually built release build of the testing library.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Resolves rdar://129872111