### PR TITLE
Skip evaluating parameterized test arguments for disabled tests

### DIFF
--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -253,12 +253,14 @@ extension Runner.Plan {
       // can be evaluated lazily only once it is determined that the test will
       // run, to avoid unnecessary work. But now is the appropriate time to
       // evaluate them.
-      do {
-        try await test.evaluateTestCases()
-      } catch {
-        let sourceContext = SourceContext(backtrace: Backtrace(forFirstThrowOf: error))
-        let issue = Issue(kind: .errorCaught(error), comments: [], sourceContext: sourceContext)
-        action = .recordIssue(issue)
+      if case .run = action {
+        do {
+          try await test.evaluateTestCases()
+        } catch {
+          let sourceContext = SourceContext(backtrace: Backtrace(forFirstThrowOf: error))
+          let issue = Issue(kind: .errorCaught(error), comments: [], sourceContext: sourceContext)
+          action = .recordIssue(issue)
+        }
       }
 
       actionGraph.updateValue(action, at: keyPath)

--- a/Tests/TestingTests/PlanTests.swift
+++ b/Tests/TestingTests/PlanTests.swift
@@ -428,6 +428,20 @@ struct PlanTests {
       #expect(step.test.id.nameComponents.count == 1, "Test is not top-level: \(step.test)")
     }
   }
+
+  @Test("Test cases of a disabled test are not evaluated")
+  func disabledTestCases() async throws {
+    var configuration = Configuration()
+    configuration.setEventHandler { event, context in
+      guard case .testSkipped = event.kind else {
+        return
+      }
+      let testSnapshot = try #require(context.test.map({ Test.Snapshot(snapshotting: $0 )}))
+      #expect(testSnapshot.testCases?.isEmpty ?? false)
+    }
+
+    await runTestFunction(named: "disabled(x:)", in: ParameterizedTests.self, configuration: configuration)
+  }
 }
 
 // MARK: - Fixtures

--- a/Tests/TestingTests/Test.Case.ArgumentTests.swift
+++ b/Tests/TestingTests/Test.Case.ArgumentTests.swift
@@ -152,7 +152,7 @@ struct Test_Case_ArgumentTests {
 // MARK: - Fixture tests
 
 @Suite(.hidden)
-private struct ParameterizedTests {
+struct ParameterizedTests {
   @Test(.hidden, arguments: ["value"])
   func oneParameter(x: String) {}
 
@@ -170,4 +170,6 @@ private struct ParameterizedTests {
 
   @Test(.hidden, arguments: ["value": 123])
   func oneDictionaryElementTupleParameter(x: (key: String, value: Int)) {}
+
+  @Test(.disabled(), arguments: [1, 2, 3]) func disabled(x: Int) {}
 }


### PR DESCRIPTION
Similar to how parameterized test arguments are left unevaluated for tests that aren't included in a `Plan`, also leave them unevaluated for tests in a `Plan` that won't run, e.g. because of having the `.disabled()` trait attached.

### Motivation:

Since the changes in #366, parameterized test arguments are evaluated lazily, only for tests which are included in the `Runner.Plan` that is being prepared for execution. A code comment included in that change further suggested that arguments are only evaluated for tests which will actually run as part of the plan, as opposed to being skipped. However the actual code didn't reflect that behavior, by mistake. That means wasted work is being performed when setting up a `Runner.Plan`, evaluating the arguments of tests which won't end up actually running.

### Modifications:

Only perform the step of evaluating test arguments/cases for tests which are marked with a `.run` action in the `Runner.Plan`.

### Result:

Less throwaway work is performed when setting up a `Runner.Plan` for greater efficiency.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
