### PR TITLE
Remove an obsolete workaround for Result.get()

### DIFF
--- a/Sources/Testing/Support/Additions/ResultAdditions.swift
+++ b/Sources/Testing/Support/Additions/ResultAdditions.swift
@@ -19,7 +19,7 @@ extension Result {
   ///
   /// - Warning: This function is used to implement the `#expect()` and
   ///   `#require()` macros. Do not call it directly.
-  @inlinable public func __required() throws(Failure) -> Success {
+  @inlinable public func __required() throws -> Success {
     try get()
   }
 }

--- a/Sources/Testing/Support/Additions/ResultAdditions.swift
+++ b/Sources/Testing/Support/Additions/ResultAdditions.swift
@@ -13,20 +13,13 @@ extension Result {
   ///
   /// - Warning: This function is used to implement the `#expect()` and
   ///   `#require()` macros. Do not call it directly.
-  public func __expected() {}
+  @inlinable public func __expected() {}
 
   /// Handle this instance as if it were returned from a call to `#require()`.
   ///
   /// - Warning: This function is used to implement the `#expect()` and
   ///   `#require()` macros. Do not call it directly.
-  public func __required() throws -> Success {
-    /// `get()` is current broken in the Swift standard library, so switch
-    /// manually to work around the problem. ([122797397](rdar://122797397))
-    switch self {
-    case let .success(result):
-      return result
-    case let .failure(error):
-      throw error
-    }
+  @inlinable public func __required() throws(Failure) -> Success {
+    try get()
   }
 }


### PR DESCRIPTION
This removes a workaround for `Result.get()` which was briefly necessary (added in #215) due to a compiler issue but has since been resolved.

I took the opportunity to also make these two helper methods `@inlinable` since they are included in many macro expansions and in certain situations that optimization opportunity could be helpful.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
