### PR TITLE
Add out-of-range confirmation issue

### DIFF
--- a/Sources/Testing/Issues/Confirmation.swift
+++ b/Sources/Testing/Issues/Confirmation.swift
@@ -172,13 +172,8 @@ public func confirmation<R>(
          expectedCount.lowerBound == expectedCount.upperBound {
         issueKind = .confirmationMiscounted(actual: actualCount, expected: expectedCount.lowerBound)
       } else {
-        // TODO: define an issue kind for out-of-range confirmation failures
-        issueKind = .unconditional
-        comment = if let comment {
-          "\(comment) - expected \(expectedCount) confirmations"
-        } else {
-          "expected \(expectedCount) confirmations"
-        }
+        issueKind = .confirmationMiscountedRange(actual: actualCount, expected: expectedCount)
+        comment = "\(comment?.description ?? "") - expected \(expectedCount) confirmations"
       }
       Issue.record(
         issueKind,

--- a/Tests/TestingTests/ConfirmationTests.swift
+++ b/Tests/TestingTests/ConfirmationTests.swift
@@ -29,16 +29,16 @@ struct ConfirmationTests {
 
   @Test("Unsuccessful confirmations")
   func unsuccessfulConfirmations() async {
-    await confirmation("Miscount recorded", expectedCount: 3) { miscountRecorded in
-      await confirmation("Unconditional issue recorded") { unconditionalRecorded in
+    await confirmation("Miscount issue recorded", expectedCount: 3) { miscountRecorded in
+      await confirmation("Miscount Range issue recorded", expectedCount: 1) { miscountRangeRecorded in
         var configuration = Configuration()
         configuration.eventHandler = { event, _ in
           if case let .issueRecorded(issue) = event.kind {
             switch issue.kind {
-            case .confirmationMiscounted:
+            case let .confirmationMiscounted(actual: actual, expected: expected):
               miscountRecorded()
-            case .unconditional:
-              unconditionalRecorded()
+            case let .confirmationMiscountedRange(actual: actual, expected: expected):
+              miscountRangeRecorded()
             default:
               break
             }


### PR DESCRIPTION
### Motivation:

Add out-of-range confirmation issue

### Modifications:

Add confirmationMiscountedRange case

### Result:

Complete the missing part in #512

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
