### PR TITLE
Support building macro plugin as a library instead of executable via CMake

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -68,6 +68,10 @@ let package = Package(
       ],
       exclude: ["CMakeLists.txt"],
       swiftSettings: .packageSettings + [
+        // When building as a package, the macro plugin always builds as an
+        // executable rather than a library.
+        .define("SWT_NO_LIBRARY_MACRO_PLUGINS"),
+
         // The only target which needs the ability to import this macro
         // implementation target's module is its unit test target. Users of the
         // macros this target implements use them via their declarations in the

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -14,9 +14,9 @@ endif()
 
 find_package(SwiftSyntax CONFIG GLOBAL)
 if(SwiftSyntax_FOUND)
-  set(SwiftTesting_BuildMacrosAsExecutables OFF)
+  set(SwiftTesting_BuildMacrosAsExecutables NO)
 else()
-  set(SwiftTesting_BuildMacrosAsExecutables ON)
+  set(SwiftTesting_BuildMacrosAsExecutables YES)
 endif()
 
 ExternalProject_Add(TestingMacros

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -12,17 +12,32 @@ if(NOT SwiftTesting_MACRO_MAKE_PROGRAM)
   set(SwiftTesting_MACRO_MAKE_PROGRAM ${CMAKE_MAKE_PROGRAM})
 endif()
 
+find_package(SwiftSyntax CONFIG GLOBAL)
+if(SwiftSyntax_FOUND)
+  set(SwiftTesting_BuildMacrosAsExecutables OFF)
+else()
+  set(SwiftTesting_BuildMacrosAsExecutables ON)
+endif()
+
 ExternalProject_Add(TestingMacros
   PREFIX "tm"
   SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/TestingMacros"
   CMAKE_ARGS
     -DCMAKE_MAKE_PROGRAM=${SwiftTesting_MACRO_MAKE_PROGRAM}
+    -DSwiftTesting_BuildMacrosAsExecutables=${SwiftTesting_BuildMacrosAsExecutables}
+    -DSwiftSyntax_DIR=${SwiftSyntax_DIR}
   INSTALL_COMMAND "")
 ExternalProject_Get_Property(TestingMacros BINARY_DIR)
-if(CMAKE_HOST_WIN32)
-  set(TestingMacrosPath "${BINARY_DIR}/TestingMacros.exe#TestingMacros")
+
+if(SwiftTesting_BuildMacrosAsExecutables)
+  set(_TestingMacros_ExecutableSuffix "")
+  if(CMAKE_HOST_WIN32)
+    set(_TestingMacros_ExecutableSuffix ".exe")
+  endif()
+
+  set(SwiftTesting_MacroPluginFlags -load-plugin-executable "${BINARY_DIR}/TestingMacros${_TestingMacros_ExecutableSuffix}#TestingMacros")
 else()
-  set(TestingMacrosPath "${BINARY_DIR}/TestingMacros#TestingMacros")
+  set(SwiftTesting_MacroPluginFlags -plugin-path "${CMAKE_BINARY_DIR}/lib")
 endif()
 
 include(AvailabilityDefinitions)

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -29,17 +29,6 @@ ExternalProject_Add(TestingMacros
   INSTALL_COMMAND "")
 ExternalProject_Get_Property(TestingMacros BINARY_DIR)
 
-if(SwiftTesting_BuildMacrosAsExecutables)
-  set(_TestingMacros_ExecutableSuffix "")
-  if(CMAKE_HOST_WIN32)
-    set(_TestingMacros_ExecutableSuffix ".exe")
-  endif()
-
-  set(SwiftTesting_MacroPluginFlags -load-plugin-executable "${BINARY_DIR}/TestingMacros${_TestingMacros_ExecutableSuffix}#TestingMacros")
-else()
-  set(SwiftTesting_MacroPluginFlags -plugin-path "${BINARY_DIR}")
-endif()
-
 include(AvailabilityDefinitions)
 include(CompilerSettings)
 add_subdirectory(_TestingInternals)

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -37,7 +37,7 @@ if(SwiftTesting_BuildMacrosAsExecutables)
 
   set(SwiftTesting_MacroPluginFlags -load-plugin-executable "${BINARY_DIR}/TestingMacros${_TestingMacros_ExecutableSuffix}#TestingMacros")
 else()
-  set(SwiftTesting_MacroPluginFlags -plugin-path "${CMAKE_BINARY_DIR}/lib")
+  set(SwiftTesting_MacroPluginFlags -plugin-path "${BINARY_DIR}")
 endif()
 
 include(AvailabilityDefinitions)

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -96,9 +96,7 @@ target_link_libraries(Testing PRIVATE
   _TestingInternals)
 add_dependencies(Testing
   TestingMacros)
-target_compile_definitions(Testing PRIVATE
-  SWT_BUILDING_WITH_CMAKE)
 target_compile_options(Testing PUBLIC
-  -load-plugin-executable "${TestingMacrosPath}")
+  ${SwiftTesting_MacroPluginFlags})
 target_compile_options(Testing PRIVATE
   -enable-library-evolution)

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -96,7 +96,17 @@ target_link_libraries(Testing PRIVATE
   _TestingInternals)
 add_dependencies(Testing
   TestingMacros)
-target_compile_options(Testing PUBLIC
-  ${SwiftTesting_MacroPluginFlags})
 target_compile_options(Testing PRIVATE
   -enable-library-evolution)
+
+if(SwiftTesting_BuildMacrosAsExecutables)
+  if(CMAKE_HOST_WIN32)
+    set(_TestingMacros_ExecutableSuffix ".exe")
+  endif()
+
+  target_compile_options(Testing PUBLIC
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-load-plugin-executable ${BINARY_DIR}/TestingMacros${_TestingMacros_ExecutableSuffix}#TestingMacros>")
+else()
+  target_compile_options(Testing PUBLIC
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-plugin-path ${BINARY_DIR}>")
+endif()

--- a/Sources/TestingMacros/CMakeLists.txt
+++ b/Sources/TestingMacros/CMakeLists.txt
@@ -22,20 +22,7 @@ if(WIN32)
   add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 endif()
 
-include(FetchContent)
-find_package(SwiftSyntax CONFIG GLOBAL)
-if(NOT SwiftSyntax_FOUND)
-  set(FETCHCONTENT_BASE_DIR ${CMAKE_BINARY_DIR}/_d)
-  # TODO: Update GIT_TAG to the 6.0 release tag once it is available.
-  FetchContent_Declare(SwiftSyntax
-    GIT_REPOSITORY https://github.com/swiftlang/swift-syntax
-    GIT_TAG 27b74edd5de625d0e399869a5af08f1501af8837)
-  FetchContent_MakeAvailable(SwiftSyntax)
-endif()
-
-include(AvailabilityDefinitions)
-include(CompilerSettings)
-add_executable(TestingMacros
+set(_TestingMacros_SourceFiles
   ConditionMacro.swift
   SourceLocationMacro.swift
   SuiteDeclarationMacro.swift
@@ -61,14 +48,53 @@ add_executable(TestingMacros
   TagMacro.swift
   TestDeclarationMacro.swift
   TestingMacrosMain.swift)
-set_target_properties(TestingMacros PROPERTIES
-  ENABLE_EXPORTS TRUE)
-target_compile_options(TestingMacros PRIVATE -parse-as-library)
-target_link_libraries(TestingMacros PRIVATE
-  SwiftSyntax::SwiftCompilerPlugin
+
+find_package(SwiftSyntax CONFIG GLOBAL)
+
+if(SwiftTesting_BuildMacrosAsExecutables)
+  # When building the macro plugin as an executable, clone and build
+  # swift-syntax.
+  include(FetchContent)
+  set(FETCHCONTENT_BASE_DIR ${CMAKE_BINARY_DIR}/_d)
+  # TODO: Update GIT_TAG to the 6.0 release tag once it is available.
+  FetchContent_Declare(SwiftSyntax
+    GIT_REPOSITORY https://github.com/swiftlang/swift-syntax
+    GIT_TAG 27b74edd5de625d0e399869a5af08f1501af8837)
+  FetchContent_MakeAvailable(SwiftSyntax)
+endif()
+
+# Include these modules _after_ swift-syntax is declared above, but _before_ the
+# macro plugin target is declared below, so that its settings are not applied to
+# the former but are applied to the latter.
+include(AvailabilityDefinitions)
+include(CompilerSettings)
+
+set(_TestingMacros_LinkedLibraries_PRIVATE
   SwiftSyntax::SwiftSyntax
   SwiftSyntax::SwiftSyntaxMacroExpansion
-  SwiftSyntax::SwiftSyntaxMacros
-  SwiftSyntax509
-  SwiftSyntax510
-  SwiftSyntax600)
+  SwiftSyntax::SwiftSyntaxMacros)
+
+if(SwiftTesting_BuildMacrosAsExecutables)
+  # When swift-syntax is built locally, the macro plugin must be built as an
+  # executable.
+  add_executable(TestingMacros ${_TestingMacros_SourceFiles})
+
+  set_target_properties(TestingMacros PROPERTIES
+    ENABLE_EXPORTS TRUE)
+
+  # Parse the module as a library, even though it's an executable, because it
+  # uses an `@main` type to define its entry point.
+  target_compile_options(TestingMacros PRIVATE -parse-as-library)
+
+  # Include the .swift file which contains its `@main` entry point type.
+  target_compile_definitions(TestingMacros PRIVATE SWT_NO_LIBRARY_MACRO_PLUGINS)
+
+  # Link the 'SwiftCompilerPlugin' target, but only when built as an executable.
+  list(APPEND _TestingMacros_LinkedLibraries_PRIVATE
+    SwiftSyntax::SwiftCompilerPlugin)
+else()
+  add_library(TestingMacros SHARED ${_TestingMacros_SourceFiles})
+endif()
+
+target_link_libraries(TestingMacros PRIVATE
+  ${_TestingMacros_LinkedLibraries_PRIVATE})

--- a/Sources/TestingMacros/CMakeLists.txt
+++ b/Sources/TestingMacros/CMakeLists.txt
@@ -22,7 +22,45 @@ if(WIN32)
   add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 endif()
 
-set(_TestingMacros_SourceFiles
+find_package(SwiftSyntax CONFIG GLOBAL)
+
+if(SwiftTesting_BuildMacrosAsExecutables)
+  # When building the macro plugin as an executable, clone and build
+  # swift-syntax.
+  include(FetchContent)
+  set(FETCHCONTENT_BASE_DIR ${CMAKE_BINARY_DIR}/_d)
+  # TODO: Update GIT_TAG to the 6.0 release tag once it is available.
+  FetchContent_Declare(SwiftSyntax
+    GIT_REPOSITORY https://github.com/swiftlang/swift-syntax
+    GIT_TAG 27b74edd5de625d0e399869a5af08f1501af8837)
+  FetchContent_MakeAvailable(SwiftSyntax)
+endif()
+
+# Include these modules _after_ swift-syntax is declared above, but _before_ the
+# macro plugin target is declared below, so that its settings are not applied to
+# the former but are applied to the latter.
+include(AvailabilityDefinitions)
+include(CompilerSettings)
+
+if(SwiftTesting_BuildMacrosAsExecutables)
+  # When swift-syntax is built locally, the macro plugin must be built as an
+  # executable.
+  add_executable(TestingMacros)
+
+  set_target_properties(TestingMacros PROPERTIES
+    ENABLE_EXPORTS TRUE)
+
+  # Parse the module as a library, even though it's an executable, because it
+  # uses an `@main` type to define its entry point.
+  target_compile_options(TestingMacros PRIVATE -parse-as-library)
+
+  # Include the .swift file which contains its `@main` entry point type.
+  target_compile_definitions(TestingMacros PRIVATE SWT_NO_LIBRARY_MACRO_PLUGINS)
+else()
+  add_library(TestingMacros SHARED)
+endif()
+
+target_sources(TestingMacros PRIVATE
   ConditionMacro.swift
   SourceLocationMacro.swift
   SuiteDeclarationMacro.swift
@@ -49,52 +87,12 @@ set(_TestingMacros_SourceFiles
   TestDeclarationMacro.swift
   TestingMacrosMain.swift)
 
-find_package(SwiftSyntax CONFIG GLOBAL)
-
-if(SwiftTesting_BuildMacrosAsExecutables)
-  # When building the macro plugin as an executable, clone and build
-  # swift-syntax.
-  include(FetchContent)
-  set(FETCHCONTENT_BASE_DIR ${CMAKE_BINARY_DIR}/_d)
-  # TODO: Update GIT_TAG to the 6.0 release tag once it is available.
-  FetchContent_Declare(SwiftSyntax
-    GIT_REPOSITORY https://github.com/swiftlang/swift-syntax
-    GIT_TAG 27b74edd5de625d0e399869a5af08f1501af8837)
-  FetchContent_MakeAvailable(SwiftSyntax)
-endif()
-
-# Include these modules _after_ swift-syntax is declared above, but _before_ the
-# macro plugin target is declared below, so that its settings are not applied to
-# the former but are applied to the latter.
-include(AvailabilityDefinitions)
-include(CompilerSettings)
-
-set(_TestingMacros_LinkedLibraries_PRIVATE
+target_link_libraries(TestingMacros PRIVATE
   SwiftSyntax::SwiftSyntax
   SwiftSyntax::SwiftSyntaxMacroExpansion
   SwiftSyntax::SwiftSyntaxMacros)
-
 if(SwiftTesting_BuildMacrosAsExecutables)
-  # When swift-syntax is built locally, the macro plugin must be built as an
-  # executable.
-  add_executable(TestingMacros ${_TestingMacros_SourceFiles})
-
-  set_target_properties(TestingMacros PROPERTIES
-    ENABLE_EXPORTS TRUE)
-
-  # Parse the module as a library, even though it's an executable, because it
-  # uses an `@main` type to define its entry point.
-  target_compile_options(TestingMacros PRIVATE -parse-as-library)
-
-  # Include the .swift file which contains its `@main` entry point type.
-  target_compile_definitions(TestingMacros PRIVATE SWT_NO_LIBRARY_MACRO_PLUGINS)
-
   # Link the 'SwiftCompilerPlugin' target, but only when built as an executable.
-  list(APPEND _TestingMacros_LinkedLibraries_PRIVATE
+  target_link_libraries(TestingMacros PRIVATE
     SwiftSyntax::SwiftCompilerPlugin)
-else()
-  add_library(TestingMacros SHARED ${_TestingMacros_SourceFiles})
 endif()
-
-target_link_libraries(TestingMacros PRIVATE
-  ${_TestingMacros_LinkedLibraries_PRIVATE})

--- a/Sources/TestingMacros/TestingMacrosMain.swift
+++ b/Sources/TestingMacros/TestingMacrosMain.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(SwiftCompilerPlugin)
+#if SWT_NO_LIBRARY_MACRO_PLUGINS
 import SwiftCompilerPlugin
 import SwiftSyntaxMacros
 

--- a/cmake/modules/shared/CompilerSettings.cmake
+++ b/cmake/modules/shared/CompilerSettings.cmake
@@ -6,7 +6,7 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-# Settings intended to be applied to every Swift target in this package.
+# Settings intended to be applied to every Swift target in this project.
 # Analogous to project-level build settings in an Xcode project.
 add_compile_options(
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -require-explicit-sendable>")
@@ -16,7 +16,9 @@ add_compile_options(
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend ExistentialAny>"
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend InternalImportsByDefault>")
 
-# Platform specific defines.
+add_compile_definitions("SWT_BUILDING_WITH_CMAKE")
+
+# Platform-specific definitions.
 if(APPLE)
   add_compile_definitions("SWT_TARGET_OS_APPLE")
 endif()

--- a/cmake/modules/shared/CompilerSettings.cmake
+++ b/cmake/modules/shared/CompilerSettings.cmake
@@ -16,6 +16,7 @@ add_compile_options(
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend ExistentialAny>"
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend InternalImportsByDefault>")
 
+# Definitions applied unconditionally to files of all languages, in all targets.
 add_compile_definitions("SWT_BUILDING_WITH_CMAKE")
 
 # Platform-specific definitions.


### PR DESCRIPTION
This adds support in the CMake rules for building the `TestingMacros` macro plugin target as a library instead of an executable.

### Motivation:

In preparation for adding Swift Testing to Swift.org toolchains (as [mentioned](https://github.com/swiftlang/swift-evolution/blob/main/visions/swift-testing.md#distribution) in the vision document), this modifies the project's CMake rules to allow building its macro plugin in a way that is consistent with others in the toolchain — as a shared library rather than an executable. Macros in the toolchain can be libraries which are directly loaded by the compiler and avoid the IPC overhead of being a separate executable.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
