### PR TITLE
@Test applied to function with newline before its name causes error in expanded code

### DIFF
--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -299,13 +299,13 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
       thunkBody = ""
     } else if let typeName {
       if functionDecl.isStaticOrClass {
-        thunkBody = "_ = \(forwardCall("\(typeName).\(functionDecl.name)\(forwardedParamsExpr)"))"
+        thunkBody = "_ = \(forwardCall("\(typeName).\(functionDecl.name.trimmed)\(forwardedParamsExpr)"))"
       } else {
         let instanceName = context.makeUniqueName(thunking: functionDecl)
         let varOrLet = functionDecl.isMutating ? "var" : "let"
         thunkBody = """
         \(raw: varOrLet) \(raw: instanceName) = \(forwardInit("\(typeName)()"))
-        _ = \(forwardCall("\(raw: instanceName).\(functionDecl.name)\(forwardedParamsExpr)"))
+        _ = \(forwardCall("\(raw: instanceName).\(functionDecl.name.trimmed)\(forwardedParamsExpr)"))
         """
 
         // If there could be an Objective-C selector associated with this test,
@@ -327,7 +327,7 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
         }
       }
     } else {
-      thunkBody = "_ = \(forwardCall("\(functionDecl.name)\(forwardedParamsExpr)"))"
+      thunkBody = "_ = \(forwardCall("\(functionDecl.name.trimmed)\(forwardedParamsExpr)"))"
     }
 
     // If this function is synchronous and is not explicitly isolated to the

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -206,6 +206,18 @@ struct TestsWithAsyncArguments {
 )
 func parameterizedTestWithTrailingComment(value: Int) {}
 
+@Test(.hidden) func // Meaningful trivia: intentional newline before name
+globalMultiLineTestDecl() async {}
+
+@Suite(.hidden)
+struct MultiLineSuite {
+  @Test(.hidden) func // Meaningful trivia: intentional newline before name
+  multiLineTestDecl() async {}
+
+  @Test(.hidden) static func // Meaningful trivia: intentional newline before name
+  staticMultiLineTestDecl() async {}
+}
+
 @Suite("Miscellaneous tests")
 struct MiscellaneousTests {
   @Test("Free function's name")


### PR DESCRIPTION
This fixes an issue where certain trivia, such as a newline (`\n`) placed in between the `func` keyword and a function's name on a function with the `@Test` attribute causes an error in the macro expansion code. For example:

```swift
@Test func
nameOnSecondLine() { ... }
```

### Modifications:

Trim trivia from function name in macro expansion code.

### Result:

These examples now build without errors.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Resolves rdar://130797660
