### PR TITLE
Remove 'Runner.Plan.independentlyRunnableSteps'

### DIFF
--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -303,52 +303,6 @@ extension Runner.Plan {
   }
 }
 
-// MARK: - Parallelization support
-
-extension Runner.Plan {
-  /// Get the steps in a test graph that can run independently of each other.
-  ///
-  /// - Parameters:
-  ///   - stepGraph: The step graph to recursively examine.
-  ///
-  /// - Returns: The steps in `stepGraph` that can run independently of each
-  ///   other.
-  ///
-  /// For more information, see ``independentlyRunnableSteps``.
-  private func _independentlyRunnableSteps(in stepGraph: Graph<String, Step?>) -> [Step] {
-    if let step = stepGraph.value {
-      return [step]
-    }
-    return stepGraph.children.reduce(into: []) { result, childStepGraph in
-      result += _independentlyRunnableSteps(in: childStepGraph.value)
-    }
-  }
-
-  /// The steps of the runner plan that can run independently of each other.
-  ///
-  /// If a test is a child of another test, then it is dependent on that test
-  /// to run. The value of this property is the set of steps that are _not_
-  /// dependent on each other. For example, given the following structure:
-  ///
-  /// ```swift
-  /// struct A {
-  ///   @Suite struct B {
-  ///     @Test func c() {}
-  ///     @Test func d() {}
-  ///   struct E {
-  ///     @Test func f() {}
-  ///   }
-  /// }
-  /// ```
-  ///
-  /// Only `B` and `E` are fully independent of any other tests. `c()` and
-  /// `d()` are independent of each other, but both are dependent on `B`, and
-  /// `f()` is dependent on `E`.
-  public var independentlyRunnableSteps: [Step] {
-    _independentlyRunnableSteps(in: stepGraph)
-  }
-}
-
 // MARK: - Snapshotting
 
 extension Runner.Plan {

--- a/Tests/TestingTests/PlanTests.swift
+++ b/Tests/TestingTests/PlanTests.swift
@@ -421,14 +421,6 @@ struct PlanTests {
     #expect(plan.stepGraph.subgraph(at: typeInfo.fullyQualifiedNameComponents + CollectionOfOne("reserved1(reserved2:)")) != nil)
   }
 
-  @Test("Runner.Plan.independentlyRunnableSteps property (all tests top-level)")
-  func independentlyRunnableTests() async throws {
-    let plan = await Runner.Plan(configuration: .init())
-    for step in plan.independentlyRunnableSteps {
-      #expect(step.test.id.nameComponents.count == 1, "Test is not top-level: \(step.test)")
-    }
-  }
-
   @Test("Test cases of a disabled test are not evaluated")
   func disabledTestCases() async throws {
     var configuration = Configuration()


### PR DESCRIPTION
This removes the `Runner.Plan.independentlyRunnableSteps` SPI and related code. This was initially needed for tools integration to support multi-process parallelization, but the approach has changed and this is no longer needed or used.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
