### PR TITLE
Avoid calling `malloc()` while holding a lock that may block dyld or libobjc.

### DIFF
--- a/Sources/_TestingInternals/Discovery.cpp
+++ b/Sources/_TestingInternals/Discovery.cpp
@@ -260,6 +260,7 @@ static SWTMachHeaderList getMachHeaders(void) {
   // After the first call sets up the loader hook, all calls take the lock and
   // make a copy of whatever has been loaded so far.
   SWTMachHeaderList result;
+  result.reserve(_dyld_image_count());
   os_unfair_lock_lock(&lock); {
     result = *machHeaders;
   } os_unfair_lock_unlock(&lock);


### PR DESCRIPTION
This PR pre-sizes the vector result of `getMachHeaders()` on Darwin (used during test discovery) so that it is very unlikely that it will need to be reallocated while holding the function's lock. If `malloc()` is called while this lock is held, there is a theoretical possibility of deadlock with the Objective-C runtime or dyld itself if `malloc()` ends up calling into either.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
