### PR TITLE
Remove `"(unknown context at $xxxxxxxx)"` from fully-qualified type names.

### DIFF
--- a/Sources/Testing/Parameterization/TypeInfo.swift
+++ b/Sources/Testing/Parameterization/TypeInfo.swift
@@ -104,6 +104,11 @@ extension TypeInfo {
         result[0] = String(firstComponent.split(separator: ":", maxSplits: 1).last!)
       }
 
+      // If a type is private or embedded in a function, its fully qualified
+      // name may include "(unknown context at $xxxxxxxx)" as a component. Strip
+      // those out as they're uninteresting to us.
+      result = result.filter { !$0.starts(with: "(unknown context at") }
+
       return result
     case let .nameOnly(fullyQualifiedNameComponents, _, _):
       return fullyQualifiedNameComponents


### PR DESCRIPTION
This PR ensures that the aforementioned gunk doesn't show up in our string representations of suites and type IDs. These substrings indicate that a type is `private`, nested in a function, or otherwise might have a non-unique Swift name. We don't care: Swift Testing will treat two private types with the same (otherwise qualified) name in the same module as the same type and will ultimately disambiguate tests in them by source location if needed.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
