### PR TITLE
Ensure that a `CustomExecutionTrait`'s teardown logic occurs _after_ nested tests run.

### DIFF
--- a/Tests/TestingTests/Traits/CustomExecutionTraitTests.swift
+++ b/Tests/TestingTests/Traits/CustomExecutionTraitTests.swift
@@ -10,26 +10,6 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
-private struct CustomTrait: CustomExecutionTrait, TestTrait {
-  var before: Confirmation
-  var after: Confirmation
-  func execute(_ function: @escaping @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws {
-    before()
-    defer {
-      after()
-    }
-    try await function()
-  }
-}
-
-private struct CustomThrowingErrorTrait: CustomExecutionTrait, TestTrait {
-  fileprivate struct CustomTraitError: Error {}
-
-  func execute(_ function: @escaping @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws {
-    throw CustomTraitError()
-  }
-}
-
 @Suite("CustomExecutionTrait Tests")
 struct CustomExecutionTraitTests {
   @Test("Execute code before and after a non-parameterized test.")
@@ -75,5 +55,54 @@ struct CustomExecutionTraitTests {
         Issue.record("Expected trait to fail the test. Should not have reached test body.")
       }.run(configuration: configuration)
     }
+  }
+
+  @Test("Teardown occurs after child tests run")
+  func teardownOccursAtEnd() async throws {
+    var configuration = Configuration()
+    configuration.eventHandler = { event, _ in
+      print(event)
+    }
+    await runTest(for: TestsWithCustomTrait.self, configuration: configuration)
+  }
+}
+
+// MARK: - Fixtures
+
+private struct CustomTrait: CustomExecutionTrait, TestTrait {
+  var before: Confirmation
+  var after: Confirmation
+  func execute(_ function: @escaping @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws {
+    before()
+    defer {
+      after()
+    }
+    try await function()
+  }
+}
+
+private struct CustomThrowingErrorTrait: CustomExecutionTrait, TestTrait {
+  fileprivate struct CustomTraitError: Error {}
+
+  func execute(_ function: @escaping @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws {
+    throw CustomTraitError()
+  }
+}
+
+struct DoSomethingBeforeAndAfterTrait: CustomExecutionTrait, SuiteTrait, TestTrait {
+  static let state = Locked(rawValue: 0)
+
+  func execute(_ function: @escaping @Sendable () async throws -> Void, for test: Testing.Test, testCase: Testing.Test.Case?) async throws {
+    #expect(Self.state.increment() == 1)
+
+    try await function()
+    #expect(Self.state.increment() == 3)
+  }
+}
+
+@Suite(.hidden, DoSomethingBeforeAndAfterTrait())
+struct TestsWithCustomTrait { // Trait should only excecute once for each test since it is a suite trait, if we want to execute trait logic for each test set isRecursive to true
+  @Test(.hidden) func f() async {
+    #expect(DoSomethingBeforeAndAfterTrait.state.increment() == 2)
   }
 }

--- a/Tests/TestingTests/Traits/CustomExecutionTraitTests.swift
+++ b/Tests/TestingTests/Traits/CustomExecutionTraitTests.swift
@@ -59,7 +59,7 @@ struct CustomExecutionTraitTests {
 
   @Test("Teardown occurs after child tests run")
   func teardownOccursAtEnd() async throws {
-    await runTest(for: TestsWithCustomTrait.self, configuration: .init())
+    await runTest(for: TestsWithCustomTraitWithStrongOrdering.self, configuration: .init())
   }
 }
 

--- a/Tests/TestingTests/Traits/CustomExecutionTraitTests.swift
+++ b/Tests/TestingTests/Traits/CustomExecutionTraitTests.swift
@@ -97,7 +97,7 @@ struct DoSomethingBeforeAndAfterTrait: CustomExecutionTrait, SuiteTrait, TestTra
 }
 
 @Suite(.hidden, DoSomethingBeforeAndAfterTrait())
-struct TestsWithCustomTrait { // Trait should only excecute once for each test since it is a suite trait, if we want to execute trait logic for each test set isRecursive to true
+struct TestsWithCustomTraitWithStrongOrdering {
   @Test(.hidden) func f() async {
     #expect(DoSomethingBeforeAndAfterTrait.state.increment() == 2)
   }

--- a/Tests/TestingTests/Traits/CustomExecutionTraitTests.swift
+++ b/Tests/TestingTests/Traits/CustomExecutionTraitTests.swift
@@ -59,11 +59,7 @@ struct CustomExecutionTraitTests {
 
   @Test("Teardown occurs after child tests run")
   func teardownOccursAtEnd() async throws {
-    var configuration = Configuration()
-    configuration.eventHandler = { event, _ in
-      print(event)
-    }
-    await runTest(for: TestsWithCustomTrait.self, configuration: configuration)
+    await runTest(for: TestsWithCustomTrait.self, configuration: .init())
   }
 }
 


### PR DESCRIPTION
This PR reorders operations in `Runner` such that a test with a custom execution trait will execute operations in this order:

1. Custom execution trait "before" logic;
1. Test logic;
1. Child test logic; and finally
1. Custom execution trait "after" logic.

There is currently a bug here where child test logic runs _after_ the custom execution trait runs its "after" logic, which is not intentional.

Resolves rdar://125115497.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
