### PR TITLE
Change the default JSON schema version to v0.

### DIFF
--- a/Sources/Testing/EntryPoints/ABIv0/ABIv0.Record+Streaming.swift
+++ b/Sources/Testing/EntryPoints/ABIv0/ABIv0.Record+Streaming.swift
@@ -57,8 +57,8 @@ extension ABIv0.Record {
 /// External adopters are not necessarily written in Swift and are expected to
 /// decode the JSON produced for this type in implementation-specific ways.
 ///
-/// - Warning: This type will be removed when the ABI version 0 JSON schema is
-///   finalized.
+/// - Warning: This type supports early Xcode 16 betas and will be removed in a
+///   future update.
 struct EventAndContextSnapshot {
   /// A snapshot of the event.
   var event: Event.Snapshot
@@ -86,8 +86,8 @@ extension EventAndContextSnapshot: Codable {}
 /// performs additional postprocessing before writing JSON data to ensure it
 /// does not contain any newline characters.
 ///
-/// - Warning: This function will be removed when the ABI version 0 JSON schema
-///   is finalized.
+/// - Warning: This function supports early Xcode 16 betas and will be removed
+///   in a future update.
 func eventHandlerForStreamingEventSnapshots(
   to eventHandler: @escaping @Sendable (_ eventAndContextJSON: UnsafeRawBufferPointer) -> Void
 ) -> Event.Handler {

--- a/Sources/Testing/EntryPoints/ABIv0/Encoded/ABIv0.EncodedTest.swift
+++ b/Sources/Testing/EntryPoints/ABIv0/Encoded/ABIv0.EncodedTest.swift
@@ -81,7 +81,7 @@ extension ABIv0 {
         let testIsParameterized = test.isParameterized
         isParameterized = testIsParameterized
         if testIsParameterized {
-          _testCases = test.testCases?.map(EncodedTestCase.init(encoding:))
+          _testCases = test.uncheckedTestCases?.map(EncodedTestCase.init(encoding:))
         }
       }
       name = test.name

--- a/Sources/Testing/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/EntryPoints/EntryPoint.swift
@@ -220,12 +220,12 @@ public struct __CommandLineArguments_v0: Sendable {
   /// The version of the event stream schema to use when writing events to
   /// ``experimentalEventStreamOutput``.
   ///
-  /// If the value of this property is `nil`, events are encoded verbatim (using
-  /// ``Event/Snapshot``.) Otherwise, the corresponding stable schema is used
-  /// (e.g. ``ABIv0/Record`` for `0`.)
+  /// The corresponding stable schema is used to encode events to the event
+  /// stream (for example, ``ABIv0/Record`` is used if the value of this
+  /// property is `0`.)
   ///
-  /// - Warning: The behavior of this property will change when the ABI version
-  ///   0 JSON schema is finalized.
+  /// If the value of this property is `nil`, the testing library assumes a
+  /// value of `0` instead.
   public var experimentalEventStreamVersion: Int?
 
   /// The value(s) of the `--filter` argument.
@@ -482,9 +482,11 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
 /// - Throws: If `version` is not a supported ABI version.
 func eventHandlerForStreamingEvents(version: Int?, forwardingTo eventHandler: @escaping @Sendable (UnsafeRawBufferPointer) -> Void) throws -> Event.Handler {
   switch version {
-  case nil:
+  case -1:
+    // Legacy support for Xcode 16 betas. Support for this undocumented version
+    // will be removed in a future update. Do not use it.
     eventHandlerForStreamingEventSnapshots(to: eventHandler)
-  case 0:
+  case nil, 0:
     ABIv0.Record.eventHandler(forwardingTo: eventHandler)
   case let .some(unsupportedVersion):
     throw _EntryPointError.invalidArgument("--experimental-event-stream-version", value: "\(unsupportedVersion)")

--- a/Sources/Testing/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/EntryPoints/EntryPoint.swift
@@ -224,8 +224,8 @@ public struct __CommandLineArguments_v0: Sendable {
   /// stream (for example, ``ABIv0/Record`` is used if the value of this
   /// property is `0`.)
   ///
-  /// If the value of this property is `nil`, the testing library assumes a
-  /// value of `0` instead.
+  /// If the value of this property is `nil`, the testing library assumes that
+  /// the newest available schema should be used.
   public var experimentalEventStreamVersion: Int?
 
   /// The value(s) of the `--filter` argument.

--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -128,6 +128,23 @@ public struct Test: Sendable {
     }
   }
 
+  /// Equivalent to ``testCases``, but without requiring that the test cases be
+  /// evaluated first.
+  ///
+  /// Most callers should not use this property and should prefer ``testCases``
+  /// since it will help catch logic errors in the testing library. Use this
+  /// property if you are interested in the test's test cases, but the test has
+  /// not been evaluated by an instance of ``Runner/Plan`` (e.g. if you are
+  /// implementing `swift test list`.)
+  var uncheckedTestCases: (some Sequence<Test.Case>)? {
+    testCasesState.flatMap { testCasesState in
+      if case let .evaluated(testCases) = testCasesState {
+        return testCases
+      }
+      return nil
+    }
+  }
+
   /// Evaluate this test's cases if they have not been evaluated yet.
   ///
   /// The arguments of a test are captured into a closure so they can be lazily


### PR DESCRIPTION
This PR changes the default JSON schema version for event stream output to version 0 (the version documented in #479.) Previously, if a caller did not specify a version number for the event stream, it would default to encoding "snapshots" of various values from the testing library.

Xcode 16 Beta 1 uses this legacy format, so to continue supporting newer betas of Xcode 16 transitionally, this PR temporarily enables a "-1" JSON schema version that continues to emit snapshot encodings. This JSON schema version will be removed (along with the snapshots code in general) in a future update once Xcode has migrated.

Resolves #527.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
