### PR TITLE
Do not write to `stderr` when testing `swift test list`.

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -76,13 +76,15 @@ func entryPoint(passing args: __CommandLineArguments_v0?, eventHandler: Event.Ha
 
     if args.listTests ?? false {
       let tests = await Test.all
-      for testID in listTestsForEntryPoint(tests) {
-        // Print the test ID to stdout (classical CLI behavior.)
+      if args.verbosity > .min {
+        for testID in listTestsForEntryPoint(tests) {
+          // Print the test ID to stdout (classical CLI behavior.)
 #if SWT_TARGET_OS_APPLE && !SWT_NO_FILE_IO
-        try? FileHandle.stdout.write("\(testID)\n")
+          try? FileHandle.stdout.write("\(testID)\n")
 #else
-        print(testID)
+          print(testID)
 #endif
+        }
       }
 
       // Post an event for every discovered test. These events are turned into


### PR DESCRIPTION
When testing the JSON ABI _vis-à-vis_ `swift test list`, we're writing to `stderr`. For the purposes of our tests, this is just noise, so block output to `stderr` from the `list` subcommand if verbosity is set to `.min` (as it is in the tests.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
