### PR TITLE
Emit a specific exit code when no tests match inputs to `swift test`.

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
@@ -118,6 +118,11 @@ private func entryPoint(
 
   let eventHandler = try eventHandlerForStreamingEvents(version: args?.eventStreamVersion, forwardingTo: recordHandler)
   let exitCode = await entryPoint(passing: args, eventHandler: eventHandler)
+
+  // To maintain compatibility with Xcode 16 Beta 1, suppress custom exit codes.
+  if exitCode == EXIT_NO_TESTS_FOUND {
+    return EXIT_SUCCESS
+  }
   return exitCode
 }
 #endif

--- a/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
@@ -31,7 +31,7 @@ var EXIT_NO_TESTS_FOUND: CInt {
 #if SWT_TARGET_OS_APPLE || os(Linux)
   EX_UNAVAILABLE
 #elseif os(Windows)
-  CInt(bitPattern: ERROR_NOT_FOUND)
+  ERROR_NOT_FOUND
 #else
 #warning("Platform-specific implementation missing: value for EXIT_NO_TESTS_FOUND unavailable")
 #endif

--- a/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
@@ -34,7 +34,7 @@ var EXIT_NO_TESTS_FOUND: CInt {
   ERROR_NOT_FOUND
 #else
 #warning("Platform-specific implementation missing: value for EXIT_NO_TESTS_FOUND unavailable")
-  2 // We're assuming that EXIT_SUCCESS = 0 and EXIT_FAILURE = 1.
+  return 2 // We're assuming that EXIT_SUCCESS = 0 and EXIT_FAILURE = 1.
 #endif
 }
 

--- a/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
@@ -14,9 +14,9 @@
 private import _TestingInternals
 #endif
 
-/// The exit code returned to Swift Package Manager when no tests matched the
-/// inputs specified by the developer (or, for the case of `swift test list`,
-/// when no tests were found.)
+/// The exit code returned to Swift Package Manager by Swift Testing when no
+/// tests matched the inputs specified by the developer (or, for the case of
+/// `swift test list`, when no tests were found.)
 ///
 /// Because Swift Package Manager does not directly link to the testing library,
 /// it duplicates the definition of this constant in its own source. Any changes

--- a/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
@@ -34,6 +34,7 @@ var EXIT_NO_TESTS_FOUND: CInt {
   ERROR_NOT_FOUND
 #else
 #warning("Platform-specific implementation missing: value for EXIT_NO_TESTS_FOUND unavailable")
+  2 // We're assuming that EXIT_SUCCESS = 0 and EXIT_FAILURE = 1.
 #endif
 }
 

--- a/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
@@ -14,6 +14,29 @@
 private import _TestingInternals
 #endif
 
+/// The exit code returned to Swift Package Manager when no tests matched the
+/// inputs specified by the developer (or, for the case of `swift test list`,
+/// when no tests were found.)
+///
+/// Because Swift Package Manager does not directly link to the testing library,
+/// it duplicates the definition of this constant in its own source. Any changes
+/// to this constant in either package must be mirrored in the other.
+///
+/// Tools authors using the ABI entry point function can determine if no tests
+/// matched the developer's inputs by counting the number of test records passed
+/// to the event handler or written to the event stream output path.
+///
+/// This constant is not part of the public interface of the testing library.
+var EXIT_NO_TESTS_FOUND: CInt {
+#if SWT_TARGET_OS_APPLE || os(Linux)
+  EX_UNAVAILABLE
+#elseif os(Windows)
+  CInt(bitPattern: ERROR_NOT_FOUND)
+#else
+#warning("Platform-specific implementation missing: value for EXIT_NO_TESTS_FOUND unavailable")
+#endif
+}
+
 /// The entry point to the testing library used by Swift Package Manager.
 ///
 /// - Parameters:

--- a/Sources/_TestingInternals/include/Includes.h
+++ b/Sources/_TestingInternals/include/Includes.h
@@ -103,6 +103,10 @@
 #include <dlfcn.h>
 #endif
 
+#if __has_include(<sysexits.h>)
+#include <sysexits.h>
+#endif
+
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -88,6 +88,14 @@ struct SwiftPMTests {
     }
   }
 
+  @Test("--filter with no matches")
+  func filterWithNoMatches() async {
+    var args = __CommandLineArguments_v0()
+    args.filter = ["NOTHING_MATCHES_THIS_TEST_NAME_HOPEFULLY"]
+    let exitCode = await __swiftPMEntryPoint(passing: args) as CInt
+    #expect(exitCode == EXIT_NO_TESTS_FOUND)
+  }
+
   @Test("--skip argument")
   @available(_regexAPI, *)
   func skip() async throws {

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -29,6 +29,12 @@ struct SwiftPMTests {
     #expect(!CommandLine.arguments.isEmpty)
   }
 
+  @Test("EXIT_NO_TESTS_FOUND is unique")
+  func valueOfEXIT_NO_TESTS_FOUND() {
+    #expect(EXIT_NO_TESTS_FOUND != EXIT_SUCCESS)
+    #expect(EXIT_NO_TESTS_FOUND != EXIT_FAILURE)
+  }
+
   @Test("--parallel/--no-parallel argument")
   func parallel() throws {
     var configuration = try configurationForEntryPoint(withArguments: ["PATH"])


### PR DESCRIPTION
This PR modifies the entry point function used by Swift Package Manager so that when no tests match the inputs (or, in the case of `swift test list`, when there are no Swift Testing tests in the test target), Swift Package Manager can detect it and respond appropriately.

Because exit codes exist in a flat namespace, and because on POSIX-y systems only the low 8 bits of an exit code are reliable, our options here are limited. I have selected the `EX_UNAVAILABLE` code from sysexits.h to represent this state. On Windows, all 32 bits of the exit code are propagated, but there is no `EX_UNAVAILABLE` value, so I've used the Win32 `ERROR_NOT_FOUND` error code instead. My assumption is that neither of these codes is likely to _actually_ be passed to `exit()` by test code (because why would they be?)

A separate PR is required in Swift Package Manager to correctly handle this exit code and emit the `noMatchingTests` diagnostic that's currently emitted only for XCTest.

Resolves rdar://131704539.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
