### PR TITLE
Silence a noisy test

### DIFF
--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -98,6 +98,7 @@ struct SwiftPMTests {
   func filterWithNoMatches() async {
     var args = __CommandLineArguments_v0()
     args.filter = ["NOTHING_MATCHES_THIS_TEST_NAME_HOPEFULLY"]
+    args.verbosity = .min
     let exitCode = await __swiftPMEntryPoint(passing: args) as CInt
     #expect(exitCode == EXIT_NO_TESTS_FOUND)
   }


### PR DESCRIPTION
`SwiftPMTests.filterWithNoMatches()` emits an extra run log to `stderr` by mistake. Shh.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
