### PR TITLE
Lower `Backtrace` and `SourceContext` to SPI.

### DIFF
--- a/Sources/Testing/ABI/v0/Encoded/ABIv0.EncodedIssue.swift
+++ b/Sources/Testing/ABI/v0/Encoded/ABIv0.EncodedIssue.swift
@@ -22,9 +22,13 @@ extension ABIv0 {
     /// The location in source where this issue occurred, if available.
     var sourceLocation: SourceLocation?
 
+    /// The backtrace where this issue occurred, if available.
+    var _backtrace: [Backtrace.Address]?
+
     init(encoding issue: borrowing Issue) {
       isKnown = issue.isKnown
       sourceLocation = issue.sourceLocation
+      _backtrace = issue.sourceContext.backtrace.map(\.addresses)
     }
   }
 }

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -94,6 +94,7 @@ public struct Issue: Sendable {
   public var comments: [Comment]
 
   /// A ``SourceContext`` indicating where and how this issue occurred.
+  @_spi(ForToolsIntegrationOnly)
   public var sourceContext: SourceContext
 
   /// Whether or not this issue is known to occur.

--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -15,6 +15,7 @@ private import _TestingInternals
 #endif
 
 /// A type representing a backtrace or stack trace.
+@_spi(ForToolsIntegrationOnly)
 public struct Backtrace: Sendable {
   /// A type describing an address in a backtrace.
   ///

--- a/Sources/Testing/SourceAttribution/SourceContext.swift
+++ b/Sources/Testing/SourceAttribution/SourceContext.swift
@@ -14,6 +14,7 @@
 /// Most commonly used when recording a failure, in order to indicate the source
 /// location where the failure occurred as well as the backtrace of the failing
 /// call, since the latter may be useful to understand how it was invoked.
+@_spi(ForToolsIntegrationOnly)
 public struct SourceContext: Sendable {
   /// The backtrace associated with this instance, if available.
   public var backtrace: Backtrace?

--- a/Sources/Testing/Testing.docc/Expectations.md
+++ b/Sources/Testing/Testing.docc/Expectations.md
@@ -90,5 +90,5 @@ the test when the code doesn't satisfy a requirement, use
 
 - ``SourceLocation``
 <!-- - ``_sourceLocation()`` -->
-- ``SourceContext``
-- ``Backtrace``
+<!-- - ``SourceContext`` -->
+<!-- - ``Backtrace`` -->


### PR DESCRIPTION
`Backtrace` is our implementation of a stack trace type. Xcode 16 uses it to provide richer information about test failures than can be provided by _just_ an instance of `SourceLocation`.

The standard library has its own type, `_Backtracing.Backtrace`, but due to our deployment requirements on Apple platforms, we can't use it yet. It would make sense for us to adopt the `Backtrace` type in the standard library as soon as possible. To avoid staging issues in the future, and because our type has not undergone any sort of formal review, I'm lowering it to tools-only SPI.

I'm also lowering `SourceContext` because it consists of an instance of `Backtrace` and an instance of `SourceLocation`—but if `Backtrace` is SPI, then the public interface of `SourceContext` is simply a wrapper around `SourceLocation`. This does not eliminate the internal need for the type, but it does make it redundant from an API perspective. If and when we regain `Backtrace` as a public interface, we can look at raising `SourceContext` too.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
