### PR TITLE
Work around a bug in the older Swift compiler used to build swift-syntax in the toolchain, which affected certain result builder APIs

### DIFF
--- a/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
@@ -142,11 +142,12 @@ extension FunctionParameterSyntax {
     // Enclose the base type declaration reference in a 1-element tuple, e.g.
     // `(<baseType>)`. It will be used in a member access expression below, and
     // some types (such as function types) require this.
-    let metatypeMemberAccessBase = TupleExprSyntax {
-      LabeledExprListSyntax {
-        LabeledExprSyntax(expression: baseTypeDeclReferenceExpr)
-      }
-    }
+    //
+    // Intentionally avoid using the result builder variant of these APIs due to
+    // a bug which affected a range of Swift compilers (including the one
+    // currently used to build swift-syntax in the toolchain) and caused one of
+    // these APIs to have an incorrect representation in the module interface.
+    let metatypeMemberAccessBase = TupleExprSyntax(elements: [LabeledExprSyntax(expression: baseTypeDeclReferenceExpr)])
 
     return MemberAccessExprSyntax(base: metatypeMemberAccessBase, name: .identifier("self"))
   }


### PR DESCRIPTION
This works around a bug which was identified while working towards adding swift-testing to Swift toolchains. See the code comment for a more detailed explanation.

### Modifications:

Use a different variant of this swift-syntax API in our macro plugin to avoid the bug.

### Result:

Building in the toolchain avoids the failure this was causing.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
