### PR TITLE
Missing newline on error in `entryPoint()`.

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -116,7 +116,7 @@ func entryPoint(passing args: __CommandLineArguments_v0?, eventHandler: Event.Ha
     }
   } catch {
 #if !SWT_NO_FILE_IO
-    try? FileHandle.stderr.write(String(describing: error))
+    try? FileHandle.stderr.write("\(error)\n")
 #endif
 
     exitCode.withLock { exitCode in


### PR DESCRIPTION
There's a missing newline when logging an error in `entryPoint()` which results in the command prompt appearing on the wrong line after the test process terminates (when using `swift test`).

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
