### PR TITLE
Allow non-`final` classes to act as suites.

### DIFF
--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -87,8 +87,6 @@ concurrency safety:
   }
 }
 
-If you use a class as a test suite, it must be declared `final`.
-
 For more information about suites and how to declare and customize them, see
 <doc:OrganizingTests>.
 
@@ -128,8 +126,8 @@ family of functions. When writing tests using the testing library, implement
 }
 
 The use of `async` and `throws` is optional. If teardown is needed, declare your
-test suite as a `final` class or as an actor rather than as a structure and
-implement `deinit`:
+test suite as a class or as an actor rather than as a structure and implement
+`deinit`:
 
 @Row {
   @Column {

--- a/Sources/Testing/Testing.docc/OrganizingTests.md
+++ b/Sources/Testing/Testing.docc/OrganizingTests.md
@@ -145,15 +145,3 @@ _not_ be annotated with the `@available` attribute:
 
 The compiler emits an error when presented with a test suite that doesn't
 meet this requirement.
-
-#### Classes must be final
-
-The testing library doesn't support inheritance between test suite
-types. When using a class as a test suite type, it may inherit from another
-class, but it must be declared `final`:
-
-```swift
-@Suite final class FoodTruckTests { ... } // ✅ OK: The class is final.
-actor CashRegisterTests: NSObject { ... } // ✅ OK: The actors are implicitly final.
-class MenuItemTests { ... } // ❌ ERROR: This class isn't final.
-```

--- a/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
@@ -197,17 +197,6 @@ func diagnoseIssuesWithLexicalContext(
     diagnostics.append(.genericDeclarationNotSupported(decl, whenUsing: attribute, becauseOf: lexicalContext.type, on: lexicalContext))
   }
 
-  // Suites that are classes must be final.
-  if let classDecl = lexicalContext.as(ClassDeclSyntax.self) {
-    if !classDecl.modifiers.lazy.map(\.name.tokenKind).contains(.keyword(.final)) {
-      if Syntax(classDecl) == Syntax(decl) {
-        diagnostics.append(.nonFinalClassNotSupported(classDecl, whenUsing: attribute))
-      } else {
-        diagnostics.append(.containingNodeUnsupported(classDecl, whenUsing: attribute, on: decl))
-      }
-    }
-  }
-
   // Suites cannot be protocols (there's nowhere to put most of the
   // declarations we generate.)
   if let protocolDecl = lexicalContext.as(ProtocolDeclSyntax.self) {

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -349,17 +349,10 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
         severity: .error
       )
     } else if let namedDecl = node.asProtocol((any NamedDeclSyntax).self) {
-      // Special-case class declarations as implicitly non-final (since we would
-      // only diagnose a class here if it were non-final.)
-      let nonFinal = if node.is(ClassDeclSyntax.self) {
-        " non-final"
-      } else {
-        ""
-      }
       let declName = namedDecl.name.textWithoutBackticks
       return Self(
         syntax: syntax,
-        message: "Attribute \(_macroName(attribute)) cannot be applied to \(_kindString(for: decl, includeA: true)) within\(generic)\(nonFinal) \(_kindString(for: node)) '\(declName)'",
+        message: "Attribute \(_macroName(attribute)) cannot be applied to \(_kindString(for: decl, includeA: true)) within\(generic) \(_kindString(for: node)) '\(declName)'",
         severity: .error
       )
     } else if let extensionDecl = node.as(ExtensionDeclSyntax.self) {
@@ -550,22 +543,6 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
     Self(
       syntax: Syntax(decl),
       message: "Attribute \(_macroName(attribute)) cannot be applied to a subclass of 'XCTestCase'",
-      severity: .error
-    )
-  }
-
-  /// Create a diagnostic message stating that `@Test` or `@Suite` is
-  /// incompatible with a non-`final` class declaration.
-  ///
-  /// - Parameters:
-  ///   - decl: The unsupported class declaration.
-  ///   - attribute: The `@Test` or `@Suite` attribute.
-  ///
-  /// - Returns: A diagnostic message.
-  static func nonFinalClassNotSupported(_ decl: ClassDeclSyntax, whenUsing attribute: AttributeSyntax) -> Self {
-    Self(
-      syntax: Syntax(decl),
-      message: "Attribute \(_macroName(attribute)) cannot be applied to non-final class '\(decl.name.textWithoutBackticks)'",
       severity: .error
     )
   }

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -84,8 +84,6 @@ struct TestDeclarationMacroTests {
         "Attribute 'Suite' cannot be applied to a subclass of 'XCTestCase'",
 
       // Unsupported inheritance
-      "@Suite class C {}":
-        "Attribute 'Suite' cannot be applied to non-final class 'C'",
       "@Suite protocol P {}":
         "Attribute 'Suite' cannot be applied to a protocol",
 
@@ -110,10 +108,6 @@ struct TestDeclarationMacroTests {
         "Attribute 'Test' cannot be applied to a function within generic structure 'S'",
       "struct S<T> { @Suite struct S {} }":
         "Attribute 'Suite' cannot be applied to a structure within generic structure 'S'",
-      "class C { @Test func f() {} }":
-        "Attribute 'Test' cannot be applied to a function within non-final class 'C'",
-      "class C { @Suite struct S {} }":
-        "Attribute 'Suite' cannot be applied to a structure within non-final class 'C'",
       "protocol P { @Test func f() {} }":
         "Attribute 'Test' cannot be applied to a function within protocol 'P'",
       "protocol P { @Suite struct S {} }":

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -151,6 +151,10 @@ actor ActorTests {
   nonisolated func parameterizedNonisolated(i: Int) async throws {}
 }
 
+@Suite(.hidden) class NonFinalClassTests {
+  @Test(.hidden) func f() {}
+}
+
 @Suite(.hidden)
 struct TestsWithStaticMemberAccessBySelfKeyword {
   static let x = 0 ..< 100


### PR DESCRIPTION
Now that we require Swift 6, we can see the names of classes during `@Test` macro expansion. This was the primary blocker preventing us from allowing non-`final` classes, because we had to substitute `Self` for the class name and this was invalid if the suite type could be covariant. We can drop the constraint now.

Note that test functions are _not_ heritable.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
