### PR TITLE
Fix incorrect implementation-only import for CMake build

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
@@ -9,7 +9,11 @@
 //
 
 #if canImport(Foundation) && !SWT_NO_ABI_ENTRY_POINT
+#if SWT_BUILDING_WITH_CMAKE
+@_implementationOnly import _TestingInternals
+#else
 private import _TestingInternals
+#endif
 
 extension ABIv0 {
   /// The type of the entry point to the testing library used by tools that want


### PR DESCRIPTION
This resolves a warning seen when building the project with CMake, since that style currently still requires `@_implementationOnly import` instead of `private import` or other access levels.

```
ABIEntryPoint.swift:12:16: warning: '_TestingInternals' inconsistently imported as implementation-only
```

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
