### PR TITLE
Remove @_implementationOnly imports guarded by 'SWT_BUILDING_WITH_CMAKE'

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -8,11 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 /// The common implementation of the entry point functions in this package.
 ///

--- a/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
@@ -8,11 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 /// The exit code returned to Swift Package Manager by Swift Testing when no
 /// tests matched the inputs specified by the developer (or, for the case of

--- a/Sources/Testing/Events/Clock.swift
+++ b/Sources/Testing/Events/Clock.swift
@@ -8,11 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 @_spi(Experimental) @_spi(ForToolsIntegrationOnly)
 extension Test {

--- a/Sources/Testing/Events/TimeValue.swift
+++ b/Sources/Testing/Events/TimeValue.swift
@@ -10,11 +10,7 @@
 
 // `internal` because `TimeValue.init(_ timespec:)` below is internal and
 // references a type (`timespec`) which comes from this import.
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 internal import _TestingInternals
-#endif
 
 /// A container type representing a time value that is suitable for storage,
 /// conversion, encoding, and decoding.

--- a/Sources/Testing/ExitTests/ExitCondition.swift
+++ b/Sources/Testing/ExitTests/ExitCondition.swift
@@ -8,11 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 /// An enumeration describing possible conditions under which an exit test will
 /// succeed or fail.

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -8,11 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 #if !SWT_NO_EXIT_TESTS
 /// A type describing an exit test.

--- a/Sources/Testing/ExitTests/WaitFor.swift
+++ b/Sources/Testing/ExitTests/WaitFor.swift
@@ -10,11 +10,7 @@
 
 #if !SWT_NO_EXIT_TESTS
 
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 internal import _TestingInternals
-#endif
 
 #if SWT_TARGET_OS_APPLE || os(Linux)
 /// Block the calling thread, wait for the target process to exit, and return

--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -8,11 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 /// A type representing a backtrace or stack trace.
 @_spi(ForToolsIntegrationOnly)

--- a/Sources/Testing/Support/Additions/CommandLineAdditions.swift
+++ b/Sources/Testing/Support/Additions/CommandLineAdditions.swift
@@ -8,11 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 extension CommandLine {
   /// The path to the current process' executable.

--- a/Sources/Testing/Support/CError.swift
+++ b/Sources/Testing/Support/CError.swift
@@ -8,11 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 internal import _TestingInternals
-#endif
 
 /// A type representing an error from a C function such as `fopen()`.
 ///

--- a/Sources/Testing/Support/Environment.swift
+++ b/Sources/Testing/Support/Environment.swift
@@ -8,11 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 /// A type describing the environment of the current process.
 ///

--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -8,11 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 internal import _TestingInternals
-#endif
 
 #if !SWT_NO_FILE_IO
 /// A type representing a file handle.

--- a/Sources/Testing/Support/GetSymbol.swift
+++ b/Sources/Testing/Support/GetSymbol.swift
@@ -8,11 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 internal import _TestingInternals
-#endif
 
 #if !SWT_NO_DYNAMIC_LINKING
 

--- a/Sources/Testing/Support/Locked.swift
+++ b/Sources/Testing/Support/Locked.swift
@@ -8,11 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 internal import _TestingInternals
-#endif
 
 /// A type that wraps a value requiring access from a synchronous caller during
 /// concurrent execution.

--- a/Sources/Testing/Support/Versions.swift
+++ b/Sources/Testing/Support/Versions.swift
@@ -8,11 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 /// A human-readable string describing the current operating system's version.
 ///

--- a/Sources/Testing/Test+Discovery.swift
+++ b/Sources/Testing/Test+Discovery.swift
@@ -8,11 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 /// A protocol describing a type that contains tests.
 ///

--- a/Sources/Testing/Traits/Tags/Tag.Color+Loading.swift
+++ b/Sources/Testing/Traits/Tags/Tag.Color+Loading.swift
@@ -8,11 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 #if !SWT_NO_FILE_IO
 #if os(macOS) || (os(iOS) && targetEnvironment(macCatalyst)) || os(Linux)

--- a/Tests/TestingTests/ABIEntryPointTests.swift
+++ b/Tests/TestingTests/ABIEntryPointTests.swift
@@ -11,11 +11,7 @@
 #if canImport(Foundation) && !SWT_NO_ABI_ENTRY_POINT
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 @Suite("ABI entry point tests")
 struct ABIEntryPointTests {

--- a/Tests/TestingTests/ClockTests.swift
+++ b/Tests/TestingTests/ClockTests.swift
@@ -10,11 +10,7 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 @Suite("Clock API Tests")
 struct ClockTests {

--- a/Tests/TestingTests/DumpTests.swift
+++ b/Tests/TestingTests/DumpTests.swift
@@ -9,11 +9,7 @@
 //
 
 @testable @_spi(ForToolsIntegrationOnly) import Testing
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 // NOTE: The tests in this file are here to exercise Plan.dump(), but they are
 // not intended to actually test that the output is in a particular format since

--- a/Tests/TestingTests/EventTests.swift
+++ b/Tests/TestingTests/EventTests.swift
@@ -10,11 +10,7 @@
 
 #if !SWT_NO_SNAPSHOT_TYPES
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 @Suite("Event Tests")
 struct EventTests {

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -9,11 +9,7 @@
 //
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 #if !SWT_NO_EXIT_TESTS
 @Suite("Exit test tests") struct ExitTestTests {

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -9,11 +9,7 @@
 //
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 #if canImport(XCTest)
 import XCTest

--- a/Tests/TestingTests/Support/CErrorTests.swift
+++ b/Tests/TestingTests/Support/CErrorTests.swift
@@ -9,11 +9,7 @@
 //
 
 @testable import Testing
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 @Suite("CError Tests")
 struct CErrorTests {

--- a/Tests/TestingTests/Support/EnvironmentTests.swift
+++ b/Tests/TestingTests/Support/EnvironmentTests.swift
@@ -9,11 +9,7 @@
 //
 
 @testable @_spi(Experimental) import Testing
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 @Suite("Environment Tests", .serialized)
 struct EnvironmentTests {

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -9,11 +9,7 @@
 //
 
 @testable import Testing
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 #if !SWT_NO_FILE_IO
 // NOTE: we don't run these tests on iOS (etc.) because processes on those

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -9,11 +9,7 @@
 //
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 private func configurationForEntryPoint(withArguments args: [String]) throws -> Configuration {
   let args = try parseCommandLineArguments(from: args)

--- a/Tests/TestingTests/Traits/TagListTests.swift
+++ b/Tests/TestingTests/Traits/TagListTests.swift
@@ -9,11 +9,7 @@
 //
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 @Suite("Tag/Tag List Tests", .tags(.traitRelated))
 struct TagListTests {

--- a/Tests/TestingTests/TypeInfoTests.swift
+++ b/Tests/TestingTests/TypeInfoTests.swift
@@ -9,11 +9,7 @@
 //
 
 @testable @_spi(ForToolsIntegrationOnly) import Testing
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 @Suite("TypeInfo Tests")
 struct TypeInfoTests {

--- a/Tests/TestingTests/VariadicGenericTests.swift
+++ b/Tests/TestingTests/VariadicGenericTests.swift
@@ -9,11 +9,7 @@
 //
 
 import Testing
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 @Test func variadicCStringArguments() async throws {
   #expect(swt_pointersNotEqual2("abc", "123"))

--- a/cmake/modules/shared/CompilerSettings.cmake
+++ b/cmake/modules/shared/CompilerSettings.cmake
@@ -16,9 +16,6 @@ add_compile_options(
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend ExistentialAny>"
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend InternalImportsByDefault>")
 
-# Definitions applied unconditionally to files of all languages, in all targets.
-add_compile_definitions("SWT_BUILDING_WITH_CMAKE")
-
 # Platform-specific definitions.
 if(APPLE)
   add_compile_definitions("SWT_TARGET_OS_APPLE")


### PR DESCRIPTION
This removes the `SWT_BUILDING_WITH_CMAKE` compilation condition, and the `@_implementationOnly import _TestingInternals` declarations it guards.

### Motivation:

When support for building via CMake was first added (in #387), many source files in the `Testing` target were modified to avoid using `private`- or `internal`-level imports of the `_TestingInternals` module and instead use the older `@_implementationOnly import` style when building via CMake. As a result, many files have:

```swift
#if SWT_BUILDING_WITH_CMAKE
@_implementationOnly import _TestingInternals
#else
private import _TestingInternals
#endif
```

This has proven to be a maintenance problem for us, because as new files are added over time, it's not immediately obvious that they need to use this pattern for importing this module—leading to warnings when building with CMake such as the one fixed by #553.

I wasn't aware of the reasoning behind the above change at the time, but I investigated it recently and here's what I concluded: Early on, the changes in #387 did _not_ enable Library Evolution (LE) for the `Testing` module, meaning it was still a non-resilient module. [SE-0409](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md) states that all dependencies of non-resilient modules must be loaded by clients, so it would make sense that under those conditions, the build of a client who imports `Testing` would fail because clients do not have visibility to the `_TestingInternals` module. However, in a later PR commit LE was enabled, but nobody realized that those `import` code changes were no longer necessary and could be reverted.

I was able to reproduce this and confirm the theory: I added an example client target in the CMake build, then disabled LE in the `Testing` module, and attempted to build the client. It failed with the expected missing module error. Then, re-enabling LE and rebuilding everything, the error went away. Hopefully this is sufficient proof that reverting this is safe, but I'll check with the main contributor of that PR to check and see if there were any other issues before landing. 

But overall, the goal here is to simplify these imports to reduce maintenance burden and fully embrace SE-0409.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
