### PR TITLE
Ensure `&` is escaped in XML output.

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.JUnitXMLRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.JUnitXMLRecorder.swift
@@ -216,6 +216,8 @@ extension Event.JUnitXMLRecorder {
       "&lt;"
     case ">":
       "&gt;"
+    case "&":
+      "&amp;"
     case _ where !character.isASCII:
       character.unicodeScalars.lazy
         .map(\.value)


### PR DESCRIPTION
Ensure `&` is escaped in XML output as `&amp;`. Thanks for the reminder, @jakepetroules.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
