### PR TITLE
Simplify `failureBreakpoint()` and add a unit test.

### DIFF
--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -236,6 +236,9 @@ extension Issue {
 
 // MARK: - Debugging failures
 
+/// A unique value used by ``failureBreakpoint()``.
+@usableFromInline nonisolated(unsafe) var failureBreakpointValue = 0
+
 /// A function called by the testing library when a failure occurs.
 ///
 /// Whenever a test failure (specifically, a non-known ``Issue``) is recorded,
@@ -265,11 +268,7 @@ func failureBreakpoint() {
   // behavior can be disabled by passing the `-no_deduplicate` flag described in
   // ld(1), but that would disable it module-wide and sacrifice optimization
   // opportunities elsewhere. Instead, this function performs a trivial
-  // function call, passing it a sufficiently unique value to avoid
-  // de-duplication.
-  struct NoOp {
-    nonisolated(unsafe) static var ignored: Int = 0
-    static func perform(_: inout Int) {}
-  }
-  NoOp.perform(&NoOp.ignored)
+  // operation on a usable-from-inline value, which the compiler must assume
+  // cannot be optimized away.
+  failureBreakpointValue = 1
 }

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -525,4 +525,11 @@ struct MiscellaneousTests {
     #expect(mappedTests.count == tests.count)
     #expect(mappedTests.values.allSatisfy { tests.contains($0) })
   }
+
+  @Test("failureBreakpoint() call")
+  func failureBreakpointCall() {
+    failureBreakpointValue = 0
+    failureBreakpoint()
+    #expect(failureBreakpointValue == 1)
+  }
 }


### PR DESCRIPTION
This PR simplifies the "unique" action performed by `failureBreakpoint()` to avoid de-duplication and implements a unit test to confirm that action is actually occurring and not being optimized away (at least under the current compiler settings at the time of test.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
