### PR TITLE
Remove `Test.Case`'s conformance to `Identifiable`.

### DIFF
--- a/Sources/Testing/Parameterization/Test.Case.ID.swift
+++ b/Sources/Testing/Parameterization/Test.Case.ID.swift
@@ -8,27 +8,27 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-extension Test.Case: Identifiable {
+extension Test.Case {
   /// The ID of a test case.
   ///
   /// Instances of this type are considered unique within the scope of a given
   /// parameterized test function. They are not necessarily unique across two
   /// different ``Test`` instances.
+  @_spi(ForToolsIntegrationOnly)
   public struct ID: Sendable, Equatable, Hashable {
     /// The IDs of the arguments of this instance's associated ``Test/Case``, in
     /// the order they appear in ``Test/Case/arguments``.
     ///
     /// The value of this property is `nil` if _any_ of the associated test
     /// case's arguments has a `nil` ID.
-    @_spi(ForToolsIntegrationOnly)
     public var argumentIDs: [Argument.ID]?
 
-    @_spi(ForToolsIntegrationOnly)
     public init(argumentIDs: [Argument.ID]?) {
       self.argumentIDs = argumentIDs
     }
   }
 
+  @_spi(ForToolsIntegrationOnly)
   public var id: ID {
     let argumentIDs = arguments.compactMap(\.id)
     guard argumentIDs.count == arguments.count else {


### PR DESCRIPTION
With further consideration after #548, we've decided to remove conformance to `Identifiable` from `Test.Case` rather than promoting it to API. The identity of a test case is fuzzy because it depends on the arguments to a test, not all of which may be uniquely identifiable. We need more time to consider the design of this part of the interface before making it a permanent part of our API.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
