### PR TITLE
Disable a couple of tests on older OSes that are reliant on `Regex`.

### DIFF
--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -81,6 +81,7 @@ struct SwiftPMTests {
   }
 
   @Test("--filter or --skip argument with bad regex")
+  @available(_regexAPI, *)
   func badArguments() throws {
     #expect(throws: (any Error).self) {
       _ = try configurationForEntryPoint(withArguments: ["PATH", "--filter", "("])
@@ -91,6 +92,7 @@ struct SwiftPMTests {
   }
 
   @Test("--filter with no matches")
+  @available(_regexAPI, *)
   func filterWithNoMatches() async {
     var args = __CommandLineArguments_v0()
     args.filter = ["NOTHING_MATCHES_THIS_TEST_NAME_HOPEFULLY"]


### PR DESCRIPTION
The tests in question use `Regex`, so they won't run on older Darwin versions.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
