### PR TITLE
Apply `@_spi(ForToolsIntegrationOnly)` attribute to the right `isKnown` property.

### DIFF
--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -98,6 +98,7 @@ public struct Issue: Sendable {
   public var sourceContext: SourceContext
 
   /// Whether or not this issue is known to occur.
+  @_spi(ForToolsIntegrationOnly)
   public var isKnown = false
 
   /// Initialize an issue instance with the specified details.
@@ -215,7 +216,6 @@ extension Issue {
     public var sourceContext: SourceContext
 
     /// Whether or not this issue is known to occur.
-    @_spi(ForToolsIntegrationOnly)
     public var isKnown = false
 
     /// Initialize an issue instance with the specified details.


### PR DESCRIPTION
Accidentally applied it to `Issue.Snapshot`, not `Issue`.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
