### PR TITLE
Explicitly import Foundation in IssueTests.swift.

### DIFF
--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -1415,7 +1415,9 @@ final class IssueTests: XCTestCase {
 }
 #endif
 
-#if !SWT_NO_SNAPSHOT_TYPES
+#if canImport(Foundation) && !SWT_NO_SNAPSHOT_TYPES
+import Foundation
+
 @Suite("Issue Codable Conformance Tests")
 struct IssueCodingTests {
 


### PR DESCRIPTION
If XCTest is unavailable, IssueTests.swift fails to compile due to a Foundation dependency (that was transitively satisfied by importing XCTest which reexports Foundation). Add an explicit import of Foundation in this file to resolve the issue.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
