### PR TITLE
Ensure `stdout` is line-buffered when testing starts.

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -60,6 +60,13 @@ func entryPoint(passing args: __CommandLineArguments_v0?, eventHandler: Event.Ha
       eventRecorder.record(event, in: context)
       oldEventHandler(event, context)
     }
+
+    // Ensure that stdout is line- rather than block-buffered. Swift Package
+    // Manager reroutes standard I/O through pipes, so we tend to end up with
+    // block-buffered streams.
+    FileHandle.stdout.withUnsafeCFILEHandle { stdout in
+      _ = setvbuf(stdout, nil, _IOLBF, Int(BUFSIZ))
+    }
 #endif
 
     // If the caller specified an alternate event handler, hook it up too.

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -60,13 +60,6 @@ func entryPoint(passing args: __CommandLineArguments_v0?, eventHandler: Event.Ha
       eventRecorder.record(event, in: context)
       oldEventHandler(event, context)
     }
-
-    // Ensure that stdout is line- rather than block-buffered. Swift Package
-    // Manager reroutes standard I/O through pipes, so we tend to end up with
-    // block-buffered streams.
-    FileHandle.stdout.withUnsafeCFILEHandle { stdout in
-      _ = setvbuf(stdout, nil, _IOLBF, Int(BUFSIZ))
-    }
 #endif
 
     // If the caller specified an alternate event handler, hook it up too.

--- a/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
@@ -69,6 +69,15 @@ public func __swiftPMEntryPoint(passing args: __CommandLineArguments_v0? = nil) 
 /// - Warning: This function is used by Swift Package Manager. Do not call it
 ///   directly.
 public func __swiftPMEntryPoint(passing args: __CommandLineArguments_v0? = nil) async -> Never {
+#if !SWT_NO_FILE_IO
+  // Ensure that stdout is line- rather than block-buffered. Swift Package
+  // Manager reroutes standard I/O through pipes, so we tend to end up with
+  // block-buffered streams.
+  FileHandle.stdout.withUnsafeCFILEHandle { stdout in
+    _ = setvbuf(stdout, nil, _IOLBF, Int(BUFSIZ))
+  }
+#endif
+
   let exitCode: CInt = await __swiftPMEntryPoint(passing: args)
   exit(exitCode)
 }


### PR DESCRIPTION
Swift Package Manager reroutes test output through pipes which are block-buffered by default, but convention in C is that `stdout` is line-buffered. This results (when using `swift test`) in output to `stdout` (e.g. from `print()`) not being displayed until after most test events have been displayed.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
