### PR TITLE
`Graph.count` is computed incorrectly.

### DIFF
--- a/Sources/Testing/Support/Graph.swift
+++ b/Sources/Testing/Support/Graph.swift
@@ -376,7 +376,7 @@ extension Graph {
   /// - Complexity: O(*n*), where *n* is the number of nodes in the graph.
   var count: Int {
     1 + children.reduce(into: 0) { count, child in
-      count += child.value.underestimatedCount
+      count += child.value.count
     }
   }
 }

--- a/Tests/TestingTests/Support/GraphTests.swift
+++ b/Tests/TestingTests/Support/GraphTests.swift
@@ -223,11 +223,15 @@ struct GraphTests {
         "C2": Graph(value: 13579),
       ]),
       "C3": Graph(value: 789, children: [
-        "C4": Graph(value: nil),
+        "C4": Graph(value: nil, children: [
+          "C5": Graph(value: nil, children: [
+            "C6": Graph(value: nil)
+          ])
+        ]),
       ]),
     ])
     #expect(graph.underestimatedCount == 3)
-    #expect(graph.count == 5)
+    #expect(graph.count == 7)
   }
 
   @Test("forEach(_:) function")


### PR DESCRIPTION
`Graph.count` is computed with the `underestimatedCount` of its children, not the `count` of them, which results in a shallow sum. Oops.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
