### PR TITLE
Report a skipped event for parameterized tests with no cases

### DIFF
--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -264,7 +264,7 @@ extension Runner.Plan {
       }
 
       // If the test is parameterized but has no cases, mark it as skipped.
-      if case .run = action, test.isParameterized, test.testCases?.lazy.first(where: { _ in true }) == nil {
+      if case .run = action, test.isParameterized, test.testCases?.first(where: { _ in true }) == nil {
         action = .skip(SkipInfo(comment: "No test cases found."))
       }
 

--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -264,7 +264,7 @@ extension Runner.Plan {
       }
 
       // If the test is parameterized but has no cases, mark it as skipped.
-      if case .run = action, test.isParameterized, test.testCases?.first(where: { _ in true }) == nil {
+      if case .run = action, let testCases = test.testCases, testCases.first(where: { _ in true }) == nil {
         action = .skip(SkipInfo(comment: "No test cases found."))
       }
 

--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -263,6 +263,11 @@ extension Runner.Plan {
         }
       }
 
+      // If the test is parameterized but has no cases, mark it as skipped.
+      if case .run = action, test.isParameterized, test.testCases?.lazy.first(where: { _ in true }) == nil {
+        action = .skip(SkipInfo(comment: "No test cases found."))
+      }
+
       actionGraph.updateValue(action, at: keyPath)
 
       return test

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -201,6 +201,24 @@ final class RunnerTests: XCTestCase {
     await fulfillment(of: [testSkipped], timeout: 0.0)
   }
 
+  func testParameterizedTestWithNoCasesIsSkipped() async throws {
+    let testSkipped = expectation(description: "Test was skipped")
+    var configuration = Configuration()
+    configuration.eventHandler = { event, _ in
+      if case .testSkipped(_) = event.kind {
+        testSkipped.fulfill()
+      }
+      if case .testStarted = event.kind {
+        XCTFail("The test should not be reported as started.")
+      }
+    }
+    let runner = await Runner(testing: [
+      Test(arguments: Array<Int>(), parameters: [.init(index: 0, firstName: "i", type: Int.self)]) { _ in },
+    ], configuration: configuration)
+    await runner.run()
+    await fulfillment(of: [testSkipped], timeout: 0.0)
+  }
+
   func testTestIsSkippedWithBlockingEnabledIfTrait() async throws {
     let testSkipped = expectation(description: "Test was skipped")
     testSkipped.expectedFulfillmentCount = 4

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -205,7 +205,7 @@ final class RunnerTests: XCTestCase {
     let testSkipped = expectation(description: "Test was skipped")
     var configuration = Configuration()
     configuration.eventHandler = { event, _ in
-      if case .testSkipped(_) = event.kind {
+      if case .testSkipped = event.kind {
         testSkipped.fulfill()
       }
       if case .testStarted = event.kind {


### PR DESCRIPTION
When a parameterized test's argument list is empty, a "skip" event is a better reflection of the fact that the test function doesn't actually get executed.

With this change, a `.testSkipped` event will get posted for such tests, instead of a `.testStarted` + `.testEnded` event pair. 

This also means that the following tests will be reported very similarly (with just a different comment on the `SkipInfo`):

```
@Test(arguments: Array<Int>()) func t1(x: Int) {}
@Test(.disabled(), arguments: [1]) func t2(x: Int) {}
```

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
