### PR TITLE
Update links for repositories moved to the swiftlang org on GitHub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 FROM swiftlang/swift:nightly-main-jammy
 
 # Set up the current build user in the same way done in the Swift.org CI system:
-# https://github.com/apple/swift-docker/blob/main/swift-ci/master/ubuntu/22.04/Dockerfile
+# https://github.com/swiftlang/swift-docker/blob/main/swift-ci/master/ubuntu/22.04/Dockerfile
 
 RUN groupadd -g 998 build-user && \
     useradd -m -r -u 998 -g build-user build-user

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -17,7 +17,7 @@ The detailed documentation for Swift Testing can be found on the
 There, you can delve into comprehensive guides, tutorials, and API references to
 make the most out of this package.
 
-This documentation is generated using [DocC](https://github.com/apple/swift-docc)
+This documentation is generated using [DocC](https://github.com/swiftlang/swift-docc)
 and is derived from symbol documentation in this project's source code as well
 as supplemental content located in the
 [`Sources/Testing/Testing.docc/`](https://github.com/apple/swift-testing/tree/main/Sources/Testing/Testing.docc)
@@ -25,7 +25,7 @@ directory.
 
 ## Vision document
 
-The [Vision document](https://github.com/apple/swift-evolution/blob/main/visions/swift-testing.md)
+The [Vision document](https://github.com/swiftlang/swift-evolution/blob/main/visions/swift-testing.md)
 for Swift Testing offers a comprehensive discussion of the project's design
 principles and goals. 
 

--- a/Documentation/StyleGuide.md
+++ b/Documentation/StyleGuide.md
@@ -140,12 +140,12 @@ Begin topic group headings inside types with a noun or noun phrase.
 
 The macro target of this package produces a number of different compile-time
 diagnostics. These diagnostics should be written according to the Swift style
-guide for compiler diagnostics [here](https://github.com/apple/swift/blob/main/docs/Diagnostics.md).
+guide for compiler diagnostics [here](https://github.com/swiftlang/swift/blob/main/docs/Diagnostics.md).
 
 ### Documentation
 
 Documentation for the testing library should follow the
-[Swift Book style guide](https://github.com/apple/swift-book/blob/main/Style.md)
+[Swift Book style guide](https://github.com/swiftlang/swift-book/blob/main/Style.md)
 and [Apple Style Guide](https://support.apple.com/guide/applestyleguide/) as
 contextually appropriate.
 

--- a/Documentation/Vision.md
+++ b/Documentation/Vision.md
@@ -7,7 +7,7 @@ automated testing to identify software defects. Better APIs and tools for
 testing can greatly improve a platform’s quality. Below, we propose a new API
 direction for testing in Swift.
 
-Click [here](https://github.com/apple/swift-evolution/blob/main/visions/swift-testing.md)
+Click [here](https://github.com/swiftlang/swift-evolution/blob/main/visions/swift-testing.md)
 to view the complete vision document for Swift Testing, which has been accepted
 by the Swift Language Steering Group and is now hosted in the
-[swift-evolution](https://github.com/apple/swift-evolution) repository.
+[swift-evolution](https://github.com/swiftlang/swift-evolution) repository.

--- a/Package.swift
+++ b/Package.swift
@@ -140,7 +140,7 @@ extension Array where Element == PackageDescription.SwiftSetting {
   ///
   /// These leverage a pseudo-experimental feature in the Swift compiler for
   /// setting availability definitions, which was added in
-  /// [apple/swift#65218](https://github.com/apple/swift/pull/65218).
+  /// [swiftlang/swift#65218](https://github.com/swiftlang/swift/pull/65218).
   private static var availabilityMacroSettings: Self {
     [
       .enableExperimentalFeature("AvailabilityMacro=_mangledTypeNameAPI:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0"),

--- a/Sources/Testing/Events/Clock.swift
+++ b/Sources/Testing/Events/Clock.swift
@@ -27,7 +27,7 @@ extension Test {
         // that of the Swift Clock API, so we don't use `SuspendingClock`
         // directly on them and instead derive a value from platform-specific
         // API. SuspendingClock corresponds to CLOCK_UPTIME_RAW on Darwin.
-        // SEE: https://github.com/apple/swift/blob/main/stdlib/public/Concurrency/Clock.cpp
+        // SEE: https://github.com/swiftlang/swift/blob/main/stdlib/public/Concurrency/Clock.cpp
         var uptime = timespec()
         _ = clock_gettime(CLOCK_UPTIME_RAW, &uptime)
         return TimeValue(uptime)

--- a/Sources/Testing/Events/TimeValue.swift
+++ b/Sources/Testing/Events/TimeValue.swift
@@ -76,7 +76,7 @@ extension TimeValue: Codable {}
 extension TimeValue: CustomStringConvertible {
   var description: String {
 #if os(WASI)
-    // BUG: https://github.com/apple/swift/issues/72398
+    // BUG: https://github.com/swiftlang/swift/issues/72398
     return String(describing: Duration(self))
 #else
     let (secondsFromAttoseconds, attosecondsRemaining) = attoseconds.quotientAndRemainder(dividingBy: 1_000_000_000_000_000_000)

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -137,7 +137,7 @@ private func _callBinaryOperator<T, U, R>(
   // nonescaping closure, but our use cases are safe (e.g. `true && false`) and
   // we cannot force one function or the other to be escaping. Use
   // withoutActuallyEscaping() to tell the compiler that what we're doing is
-  // okay. SEE: https://github.com/apple/swift-evolution/blob/main/proposals/0176-enforce-exclusive-access-to-memory.md#restrictions-on-recursive-uses-of-non-escaping-closures
+  // okay. SEE: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0176-enforce-exclusive-access-to-memory.md#restrictions-on-recursive-uses-of-non-escaping-closures
   var rhsValue: U?
   let result: R = withoutActuallyEscaping(rhs) { rhs in
     op(lhs, {

--- a/Sources/Testing/Parameterization/TypeInfo.swift
+++ b/Sources/Testing/Parameterization/TypeInfo.swift
@@ -184,19 +184,19 @@ extension TypeInfo {
 extension TypeInfo {
   /// Whether or not the described type is a Swift `enum` type.
   ///
-  /// Per the [Swift mangling ABI](https://github.com/apple/swift/blob/main/docs/ABI/Mangling.rst),
+  /// Per the [Swift mangling ABI](https://github.com/swiftlang/swift/blob/main/docs/ABI/Mangling.rst),
   /// enumeration types are mangled as `"O"`.
   ///
   /// - Bug: We use the internal Swift standard library function
   ///   `_mangledTypeName()` to derive this information. We should use supported
-  ///   API instead. ([swift-#69147](https://github.com/apple/swift/issues/69147))
+  ///   API instead. ([swift-#69147](https://github.com/swiftlang/swift/issues/69147))
   var isSwiftEnumeration: Bool {
     mangledName?.last == "O"
   }
 
   /// Whether or not the described type is imported from C, C++, or Objective-C.
   ///
-  /// Per the [Swift mangling ABI](https://github.com/apple/swift/blob/main/docs/ABI/Mangling.rst),
+  /// Per the [Swift mangling ABI](https://github.com/swiftlang/swift/blob/main/docs/ABI/Mangling.rst),
   /// types imported from C-family languages are placed in a single flat `__C`
   /// module. That module has a standardized mangling of `"So"`. The presence of
   /// those characters at the start of a type's mangled name indicates that it
@@ -204,7 +204,7 @@ extension TypeInfo {
   ///
   /// - Bug: We use the internal Swift standard library function
   ///   `_mangledTypeName()` to derive this information. We should use supported
-  ///   API instead. ([swift-#69146](https://github.com/apple/swift/issues/69146))
+  ///   API instead. ([swift-#69146](https://github.com/swiftlang/swift/issues/69146))
   var isImportedFromC: Bool {
     guard let mangledName, mangledName.count > 2 else {
       return false

--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -75,7 +75,7 @@ public struct Backtrace: Sendable {
         initializedCount = Int(RtlCaptureStackBackTrace(0, ULONG(addresses.count), addresses.baseAddress!, nil))
 #elseif os(WASI)
         // SEE: https://github.com/WebAssembly/WASI/issues/159
-        // SEE: https://github.com/apple/swift/pull/31693
+        // SEE: https://github.com/swiftlang/swift/pull/31693
         initializedCount = 0
 #else
 #warning("Platform-specific implementation missing: backtraces unavailable")
@@ -122,7 +122,7 @@ extension Backtrace {
     /// - Bug: On Windows, the weak reference to this object triggers a
     ///   crash. To avoid said crash, we'll keep a strong reference to the
     ///   object (abandoning memory until the process exits.)
-    ///   ([swift-#62985](https://github.com/apple/swift/issues/62985))
+    ///   ([swift-#62985](https://github.com/swiftlang/swift/issues/62985))
 #if os(Windows)
     var errorObject: (any AnyObject & Sendable)?
 #else

--- a/Sources/Testing/Testing.docc/BugIdentifiers.md
+++ b/Sources/Testing/Testing.docc/BugIdentifiers.md
@@ -46,7 +46,7 @@ convenience, you can also directly pass an integer as a bug's identifier using
 | `.bug(id: 12345)` | None |
 | `.bug(id: "12345")` | None |
 | `.bug("https://www.example.com?id=12345", id: "12345")` | None |
-| `.bug("https://github.com/apple/swift/pull/12345")` | [GitHub Issues for the Swift project](https://github.com/apple/swift/issues) |
+| `.bug("https://github.com/swiftlang/swift/pull/12345")` | [GitHub Issues for the Swift project](https://github.com/swiftlang/swift/issues) |
 | `.bug("https://bugs.webkit.org/show_bug.cgi?id=12345")` | [WebKit Bugzilla](https://bugs.webkit.org/) |
 | `.bug(id: "FB12345")` | Apple Feedback Assistant | <!-- SEE ALSO: rdar://104582015 -->
 <!--

--- a/Sources/Testing/Traits/Comment+Macro.swift
+++ b/Sources/Testing/Traits/Comment+Macro.swift
@@ -38,7 +38,7 @@ extension Trait where Self == Comment {
   }
 
   /// Construct a comment related to a test from a single-line
-  /// [Markup](https://github.com/apple/swift/blob/main/docs/DocumentationComments.md)
+  /// [Markup](https://github.com/swiftlang/swift/blob/main/docs/DocumentationComments.md)
   /// comment near it.
   ///
   /// - Parameters:
@@ -53,7 +53,7 @@ extension Trait where Self == Comment {
   }
 
   /// Construct a comment related to a test from a
-  /// [Markup](https://github.com/apple/swift/blob/main/docs/DocumentationComments.md)
+  /// [Markup](https://github.com/swiftlang/swift/blob/main/docs/DocumentationComments.md)
   /// block comment near it.
   ///
   /// - Parameters:

--- a/Sources/Testing/Traits/Comment.swift
+++ b/Sources/Testing/Traits/Comment.swift
@@ -42,11 +42,11 @@ public struct Comment: RawRepresentable, Sendable {
     /// starting with `/*` and ending with `*/`.
     case block
 
-    /// This comment came from a single-line [Markup](https://github.com/apple/swift/blob/main/docs/DocumentationComments.md)
+    /// This comment came from a single-line [Markup](https://github.com/swiftlang/swift/blob/main/docs/DocumentationComments.md)
     /// comment in the test's source code starting with `///`.
     case documentationLine
 
-    /// This comment came from a block [Markup](https://github.com/apple/swift/blob/main/docs/DocumentationComments.md)
+    /// This comment came from a block [Markup](https://github.com/swiftlang/swift/blob/main/docs/DocumentationComments.md)
     /// comment in the test's source code starting with `/**` and ending with
     /// `*/`.
     case documentationBlock

--- a/Sources/TestingMacros/Support/CRC32.swift
+++ b/Sources/TestingMacros/Support/CRC32.swift
@@ -11,7 +11,7 @@
 /// The precomputed CRC-32 lookup table.
 ///
 /// This table is used by the ``crc32(_:)`` function below. It is borrowed from
-/// the [Swift standard library](https://github.com/apple/swift/blob/main/stdlib/public/Backtracing/Elf.swift).
+/// the [Swift standard library](https://github.com/swiftlang/swift/blob/main/stdlib/public/Backtracing/Elf.swift).
 private let _crc32Table: [UInt32] = [
   0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f,
   0xe963a535, 0x9e6495a3, 0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988,
@@ -66,7 +66,7 @@ private let _crc32Table: [UInt32] = [
 /// - Returns: The CRC-32 code computed for `bytes`.
 ///
 /// A starting value of `0` is assumed. This function is adapted from the
-/// [Swift standard library](https://github.com/apple/swift/blob/main/stdlib/public/Backtracing/Elf.swift).
+/// [Swift standard library](https://github.com/swiftlang/swift/blob/main/stdlib/public/Backtracing/Elf.swift).
 func crc32(_ bytes: some Sequence<UInt8>) -> UInt32 {
   ~bytes.reduce(~0) { crcValue, byte in
     _crc32Table[Int(UInt8(truncatingIfNeeded: crcValue) ^ byte)] ^ (crcValue >> 8)

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -74,7 +74,7 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
   /// - Returns: The name of the macro as understood by a developer, such as
   ///   `"'@Test'"`. Include single quotes.
   private static func _macroName(_ attribute: AttributeSyntax) -> String {
-    // SEE: https://github.com/apple/swift/blob/main/docs/Diagnostics.md?plain=1#L44
+    // SEE: https://github.com/swiftlang/swift/blob/main/docs/Diagnostics.md?plain=1#L44
     "'\(attribute.attributeNameText)'"
   }
 

--- a/Sources/_TestingInternals/Discovery.cpp
+++ b/Sources/_TestingInternals/Discovery.cpp
@@ -164,7 +164,7 @@ public:
 
 // This environment does not have a dynamic linker/loader. Therefore, there is
 // only one image (this one) with Swift code in it.
-// SEE: https://github.com/apple/swift/tree/main/stdlib/public/runtime/ImageInspectionStatic.cpp
+// SEE: https://github.com/swiftlang/swift/tree/main/stdlib/public/runtime/ImageInspectionStatic.cpp
 
 extern "C" const char sectionBegin __asm("section$start$__TEXT$__swift5_types");
 extern "C" const char sectionEnd __asm("section$end$__TEXT$__swift5_types");

--- a/Sources/_TestingInternals/include/Defines.h
+++ b/Sources/_TestingInternals/include/Defines.h
@@ -36,7 +36,7 @@
 ///
 /// - Bug: The value provided to the compiler (`_SWT_TESTING_LIBRARY_VERSION`)
 ///   is not visible in Swift, so this second macro is needed.
-///   ((#43521)[https://github.com/apple/swift/issues/43521])
+///   ((#43521)[https://github.com/swiftlang/swift/issues/43521])
 #if defined(_SWT_TESTING_LIBRARY_VERSION)
 #define SWT_TESTING_LIBRARY_VERSION _SWT_TESTING_LIBRARY_VERSION
 #else


### PR DESCRIPTION
### Motivation:

Update links for repositories moved to the swiftlang org on GitHub

### Modifications:

Update the link:
+ https://github.com/apple/swift/ => https://github.com/swiftlang/swift/
+ https://github.com/apple/swift-docc/ => https://github.com/swiftlang/swift-docc/
+ https://github.com/apple/swift-docker/ => https://github.com/swiftlang/swift-docker/
+ https://github.com/apple/swift-book/ => https://github.com/swiftlang/swift-book/
+ https://github.com/apple/swift-evolution/ => https://github.com/swiftlang/swift-evolution/

### Result:

Correct the links that moved to the new responsible for Swift organization.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
