### PR TITLE
Remove "unconditional" messaging from Issue kind `.unconditional`.

### DIFF
--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -171,7 +171,10 @@ extension Issue.Kind: CustomStringConvertible {
   public var description: String {
     switch self {
     case .unconditional:
-      "Unconditionally failed"
+      // Although the failure is unconditional at the point it is recorded, the
+      // code that recorded the issue may not be unconditionally executing, so
+      // we shouldn't describe it as unconditional (we just don't know!)
+      "Issue recorded"
     case let .expectationFailed(expectation):
       if let mismatchedErrorDescription = expectation.mismatchedErrorDescription {
         "Expectation failed: \(mismatchedErrorDescription)"
@@ -457,7 +460,7 @@ extension Issue.Kind.Snapshot: CustomStringConvertible {
   public var description: String {
     switch self {
     case .unconditional:
-      "Unconditionally failed"
+      "Issue recorded"
     case let .expectationFailed(expectation):
       if let mismatchedErrorDescription = expectation.mismatchedErrorDescription {
         "Expectation failed: \(mismatchedErrorDescription)"


### PR DESCRIPTION
This PR changes the default message for an issue of kind `.unconditional` from `"Unconditionally failed"` to `"Issue recorded"`.

Although the failure is unconditional at the point it is recorded, the code that recorded the issue may not be unconditionally executing, so we shouldn't describe it as unconditional (we just don't know!)

For example, given the following code:

```swift
if case .empty = potatoSack.contents {
  Issue.record("No potatoes left.")
}
```

We would previously log:

> Unconditionally failed: No potatoes left.

Now we'll log:

> Issue recorded: No potatoes left.

Resolves #574.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
