### PR TITLE
Improve diagnostic output when an exit test fails.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -149,21 +149,11 @@ func callExitTest(
     )
   }
 
-  lazy var actualValue: CInt? = switch actualExitCondition {
-  case .failure:
-    nil
-  case let .exitCode(exitCode):
-    exitCode
-#if !os(Windows)
-  case let .signal(signal):
-    signal
-#endif
-  }
-
   return __checkValue(
     expectedExitCondition.matches(actualExitCondition),
     expression: expression,
-    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(actualValue),
+    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(actualExitCondition),
+    mismatchedExitConditionDescription: String(describingForTest: expectedExitCondition),
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation

--- a/Sources/Testing/Expectations/Expectation.swift
+++ b/Sources/Testing/Expectations/Expectation.swift
@@ -18,7 +18,7 @@ public struct Expectation: Sendable {
   ///
   /// If this expectation passed, the value of this property is `nil` because no
   /// error mismatch occurred.
-  @_spi(ForToolsIntegrationOnly)
+  @_spi(Experimental) @_spi(ForToolsIntegrationOnly)
   public var mismatchedErrorDescription: String?
 
   /// A description of the difference between the operands in the expression
@@ -27,8 +27,15 @@ public struct Expectation: Sendable {
   /// If this expectation passed, the value of this property is `nil` because
   /// the difference is only computed when necessary to assist with diagnosing
   /// test failures.
-  @_spi(ForToolsIntegrationOnly)
+  @_spi(Experimental) @_spi(ForToolsIntegrationOnly)
   public var differenceDescription: String?
+
+  /// A description of the exit condition that was expected to be matched.
+  ///
+  /// If this expectation passed, the value of this property is `nil` because no
+  /// exit test failed.
+  @_spi(Experimental) @_spi(ForToolsIntegrationOnly)
+  public var mismatchedExitConditionDescription: String?
 
   /// Whether the expectation passed or failed.
   ///
@@ -93,7 +100,7 @@ extension Expectation {
     /// - Parameter expectation: The real expectation.
     public init(snapshotting expectation: borrowing Expectation) {
       self.evaluatedExpression = expectation.evaluatedExpression
-      self.mismatchedErrorDescription = expectation.mismatchedErrorDescription
+      self.mismatchedErrorDescription = expectation.mismatchedErrorDescription ?? expectation.mismatchedExitConditionDescription
       self.differenceDescription = expectation.differenceDescription
       self.isPassing = expectation.isPassing
       self.isRequired = expectation.isRequired

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -64,6 +64,7 @@ public func __checkValue(
   expressionWithCapturedRuntimeValues: @autoclosure () -> __Expression? = nil,
   mismatchedErrorDescription: @autoclosure () -> String? = nil,
   difference: @autoclosure () -> String? = nil,
+  mismatchedExitConditionDescription: @autoclosure () -> String? = nil,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -106,6 +107,7 @@ public func __checkValue(
   // only evaluated and included lazily upon failure.
   expectation.mismatchedErrorDescription = mismatchedErrorDescription()
   expectation.differenceDescription = difference()
+  expectation.mismatchedExitConditionDescription = mismatchedExitConditionDescription()
 
   // Ensure the backtrace is captured here so it has fewer extraneous frames
   // from the testing framework which aren't relevant to the user.

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -178,6 +178,8 @@ extension Issue.Kind: CustomStringConvertible {
     case let .expectationFailed(expectation):
       if let mismatchedErrorDescription = expectation.mismatchedErrorDescription {
         "Expectation failed: \(mismatchedErrorDescription)"
+      } else if let mismatchedExitConditionDescription = expectation.mismatchedExitConditionDescription {
+        "Expectation failed: \(mismatchedExitConditionDescription)"
       } else {
         "Expectation failed: \(expectation.evaluatedExpression.expandedDescription())"
       }

--- a/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
+++ b/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
@@ -230,13 +230,8 @@ private func _parseCondition(from expr: AsExprSyntax, for macro: some Freestandi
 /// - Returns: An instance of ``Condition`` describing `expr`.
 private func _parseCondition(from expr: ClosureExprSyntax, for macro: some FreestandingMacroExpansionSyntax, in context: some MacroExpansionContext) -> Condition {
   if expr.signature == nil && expr.statements.count == 1, let item = expr.statements.first?.item {
-    if case let .expr(bodyExpr) = item {
-      return Condition(
-        "__checkValue",
-        arguments: [Argument(expression: expr)],
-        expression: _parseCondition(from: bodyExpr, for: macro, in: context).expression
-      )
-    }
+    // TODO: capture closures as a different kind of Testing.Expression with a
+    // separate subexpression per code item.
 
     // If a closure contains a single statement or declaration, we can't
     // meaningfully break it down as an expression, but we can still capture its

--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -45,7 +45,7 @@ struct ConditionMacroTests {
       ##"#expect(1 is Int)"##:
         ##"Testing.__checkCast(1, is: (Int).self, expression: .__fromBinaryOperation(.__fromSyntaxNode("1"), "is", .__fromSyntaxNode("Int")), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation.__here()).__expected()"##,
       ##"#expect("123") { 1 == 2 } then: { foo() }"##:
-        ##"Testing.__checkClosureCall(performing: { 1 == 2 }, then: { foo() }, expression: .__fromBinaryOperation(.__fromSyntaxNode("1"), "==", .__fromSyntaxNode("2")), comments: ["123"], isRequired: false, sourceLocation: Testing.SourceLocation.__here()).__expected()"##,
+        ##"Testing.__checkClosureCall(performing: { 1 == 2 }, then: { foo() }, expression: .__fromSyntaxNode("1 == 2"), comments: ["123"], isRequired: false, sourceLocation: Testing.SourceLocation.__here()).__expected()"##,
       ##"#expect("123") { let x = 0 }"##:
         ##"Testing.__checkClosureCall(performing: { let x = 0 }, expression: .__fromSyntaxNode("let x = 0"), comments: ["123"], isRequired: false, sourceLocation: Testing.SourceLocation.__here()).__expected()"##,
       ##"#expect("123") { let x = 0; return x == 0 }"##:
@@ -121,7 +121,7 @@ struct ConditionMacroTests {
       ##"#require(1 is Int)"##:
         ##"Testing.__checkCast(1, is: (Int).self, expression: .__fromBinaryOperation(.__fromSyntaxNode("1"), "is", .__fromSyntaxNode("Int")), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation.__here()).__required()"##,
       ##"#require("123") { 1 == 2 } then: { foo() }"##:
-        ##"Testing.__checkClosureCall(performing: { 1 == 2 }, then: { foo() }, expression: .__fromBinaryOperation(.__fromSyntaxNode("1"), "==", .__fromSyntaxNode("2")), comments: ["123"], isRequired: true, sourceLocation: Testing.SourceLocation.__here()).__required()"##,
+        ##"Testing.__checkClosureCall(performing: { 1 == 2 }, then: { foo() }, expression: .__fromSyntaxNode("1 == 2"), comments: ["123"], isRequired: true, sourceLocation: Testing.SourceLocation.__here()).__required()"##,
       ##"#require("123") { let x = 0 }"##:
         ##"Testing.__checkClosureCall(performing: { let x = 0 }, expression: .__fromSyntaxNode("let x = 0"), comments: ["123"], isRequired: true, sourceLocation: Testing.SourceLocation.__here()).__required()"##,
       ##"#require("123") { let x = 0; return x == 0 }"##:


### PR DESCRIPTION
This PR ensures that the expected and actual exit conditions are included in diagnostic output when an exit test fails. I haven't yet given `ExitCondition` a custom test description, but for now this allows you to see at a glance what went wrong.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
