### PR TITLE
Use `access()` instead of `stat()` to determine if the SF Pro font is installed.

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -598,8 +598,7 @@ extension Event.ConsoleOutputRecorder.Options {
     if let environmentVariable = Environment.flag(named: "SWT_SF_SYMBOLS_ENABLED") {
       result.useSFSymbols = environmentVariable
     } else {
-      var statStruct = stat()
-      result.useSFSymbols = (0 == stat("/Library/Fonts/SF-Pro.ttf", &statStruct))
+      result.useSFSymbols = (0 == access("/Library/Fonts/SF-Pro.ttf", F_OK))
     }
 #endif
 


### PR DESCRIPTION
This PR uses the slightly more efficient `access()` syscall to determine if SF Pro is installed on macOS.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
