### PR TITLE
Remove @_spi annotations from ParallelizationTrait and .serialized

### DIFF
--- a/Sources/Testing/Testing.docc/Parallelization.md
+++ b/Sources/Testing/Testing.docc/Parallelization.md
@@ -19,9 +19,6 @@ accomplished by the testing library using task groups, and tests generally all
 run in the same process. The number of tests that run concurrently is controlled
 by the Swift runtime.
 
-<!--
-HIDDEN: .serialized is experimental SPI pending feature review.
-
 ## Disabling parallelization
 
 Parallelization can be disabled on a per-function or per-suite basis using the
@@ -56,12 +53,6 @@ This trait is recursively applied: if it is applied to a suite, any
 parameterized tests or test suites contained in that suite are also serialized
 (as are any tests contained in those suites, and so on.)
 
-This trait does not affect the execution of a test relative to its peers or to
+This trait doesn't affect the execution of a test relative to its peers or to
 unrelated tests. This trait has no effect if test parallelization is globally
 disabled (by, for example, passing `--no-parallel` to the `swift test` command.)
-
-## Topics
-
-- ``Trait/serialized``
-- ``ParallelizationTrait``
--->

--- a/Sources/Testing/Testing.docc/Traits.md
+++ b/Sources/Testing/Testing.docc/Traits.md
@@ -25,7 +25,6 @@ behavior of test functions.
 
 - <doc:EnablingAndDisabling>
 - <doc:LimitingExecutionTime>
-- <doc:Parallelization>
 - ``Trait/enabled(if:_:sourceLocation:)``
 - ``Trait/enabled(_:sourceLocation:_:)``
 - ``Trait/disabled(_:sourceLocation:)``
@@ -33,11 +32,10 @@ behavior of test functions.
 - ``Trait/disabled(_:sourceLocation:_:)``
 - ``Trait/timeLimit(_:)``
 
-<!--
-HIDDEN: .serialized is experimental SPI pending feature review.
 ### Running tests serially or in parallel
-- ``ParallelizationTrait``
- -->
+
+- <doc:Parallelization>
+- ``Trait/serialized``
 
 ### Annotating tests
 
@@ -61,6 +59,7 @@ HIDDEN: .serialized is experimental SPI pending feature review.
 - ``Bug``
 - ``Comment``
 - ``ConditionTrait``
+- ``ParallelizationTrait``
 - ``Tag``
 - ``Tag/List``
 - ``TimeLimitTrait``

--- a/Sources/Testing/Testing.docc/Traits/Trait.md
+++ b/Sources/Testing/Testing.docc/Traits/Trait.md
@@ -24,6 +24,10 @@ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 - ``Trait/timeLimit(_:)``
  
+### Running tests serially or in parallel
+
+- ``Trait/serialized``
+
 ### Categorizing tests
 
 - ``Trait/tags(_:)``

--- a/Sources/Testing/Traits/ParallelizationTrait.swift
+++ b/Sources/Testing/Traits/ParallelizationTrait.swift
@@ -26,7 +26,6 @@
 /// `swift test` command.)
 ///
 /// To add this trait to a test, use ``Trait/serialized``.
-@_spi(Experimental)
 public struct ParallelizationTrait: TestTrait, SuiteTrait {
   public var isRecursive: Bool {
     true
@@ -47,7 +46,6 @@ extension ParallelizationTrait: SPIAwareTrait {
 
 // MARK: -
 
-@_spi(Experimental)
 extension Trait where Self == ParallelizationTrait {
   /// A trait that serializes the test to which it is applied.
   ///


### PR DESCRIPTION
Following up on https://github.com/apple/swift-testing/pull/535, apply the changes described in SWT-0003, along with a few documentation tweaks to reflect the API status.

### Result:

The `.serialized` test trait can be used as stable API without any `@_spi` import modifiers.