### PR TITLE
Make `Test.xcTestCompatibleSelector` `nonisolated(unsafe)` so it can be used with Xcode 15 CLTools.

### DIFF
--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -66,7 +66,7 @@ public struct Test: Sendable {
   /// On platforms that do not support Objective-C interop, the value of this
   /// property is always `nil`.
   @_spi(ForToolsIntegrationOnly)
-  public var xcTestCompatibleSelector: __XCTestCompatibleSelector?
+  public nonisolated(unsafe) var xcTestCompatibleSelector: __XCTestCompatibleSelector?
 
   /// An enumeration describing the evaluation state of a test's cases.
   ///


### PR DESCRIPTION
When building Swift Testing using Xcode 15.3 or the Xcode 15.3 CLTools and a prerelease Swift 6 toolchain, the compiler produces an error:

> /Volumes/Dev/Source/swift-testing/Sources/Testing/Test.swift:69:14: error: stored property 'xcTestCompatibleSelector' of 'Sendable'-conforming struct 'Test' has non-sendable type '__XCTestCompatibleSelector?' (aka 'Optional<Selector>')
> 67 |   /// property is always `nil`.
> 68 |   @_spi(ForToolsIntegrationOnly)
> 69 |   public var xcTestCompatibleSelector: __XCTestCompatibleSelector?
>    |              `- error: stored property 'xcTestCompatibleSelector' of 'Sendable'-conforming struct 'Test' has non-sendable type '__XCTestCompatibleSelector?' (aka 'Optional<Selector>')

Although Xcode 15.3 is not formally supported, this is trivial to resolve by marking the offending property `nonisolated(unsafe)`. The property's type (`Selector?` on Darwin, `Never?` elsewhere) is `Sendable` but `Selector` was not marked as such until Xcode 16.

This change will unblock some workflows that still use Xcode 15.3.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
