### PR TITLE
Add some WASI-specific branches.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -133,6 +133,7 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .define("SWT_NO_FILE_IO", .when(platforms: [.wasi])),
       .define("SWT_NO_EXIT_TESTS", .when(platforms: [.iOS, .watchOS, .tvOS, .visionOS, .wasi])),
       .define("SWT_NO_SNAPSHOT_TYPES", .when(platforms: [.linux, .windows, .wasi])),
+      .define("SWT_NO_DYNAMIC_LINKING", .when(platforms: [.wasi])),
     ]
   }
 

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -644,6 +644,10 @@ extension Event.ConsoleOutputRecorder.Options {
     // Windows does not set the "TERM" variable, so assume it supports 256-color
     // ANSI escape codes.
     true
+#elseif os(WASI)
+    // The "Terminal" under WASI can be assumed to be the browser's JavaScript
+    // console, which we don't expect supports color escape codes.
+    false
 #else
 #warning("Platform-specific implementation missing: terminal colors unavailable")
     return false
@@ -662,6 +666,10 @@ extension Event.ConsoleOutputRecorder.Options {
     // Windows does not set the "COLORTERM" variable, so assume it supports
     // true-color ANSI escape codes. SEE: https://github.com/microsoft/terminal/issues/11057
     true
+#elseif os(WASI)
+    // The "Terminal" under WASI can be assumed to be the browser's JavaScript
+    // console, which we don't expect supports color escape codes.
+    false
 #else
 #warning("Platform-specific implementation missing: terminal colors unavailable")
     return false

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -585,6 +585,8 @@ extension Event.ConsoleOutputRecorder.Options {
         result.ansiColorBitDepth = 24
       } else if _terminalSupports256ColorANSIEscapeCodes {
         result.ansiColorBitDepth = 8
+      } else if _terminalSupports16ColorANSIEscapeCodes {
+        result.ansiColorBitDepth = 4
       }
     }
 
@@ -630,6 +632,28 @@ extension Event.ConsoleOutputRecorder.Options {
     }
 
     return false
+  }
+
+  /// Whether or not the system terminal claims to support 16-color ANSI escape
+  /// codes.
+  private static var _terminalSupports16ColorANSIEscapeCodes: Bool {
+#if SWT_TARGET_OS_APPLE || os(Linux)
+    if let termVariable = Environment.variable(named: "TERM") {
+      return termVariable != "dumb"
+    }
+    return false
+#elseif os(Windows)
+    // Windows does not set the "TERM" variable, so assume it supports 16-color
+    // ANSI escape codes.
+    true
+#elseif os(WASI)
+    // The "Terminal" under WASI can be assumed to be the browser's JavaScript
+    // console, which we don't expect supports color escape codes.
+    false
+#else
+#warning("Platform-specific implementation missing: terminal colors unavailable")
+    return false
+#endif
   }
 
   /// Whether or not the system terminal claims to support 256-color ANSI escape

--- a/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
@@ -24,7 +24,7 @@ private import _TestingInternals
 ///
 /// This constant is not part of the public interface of the testing library.
 var EXIT_NO_TESTS_FOUND: CInt {
-#if SWT_TARGET_OS_APPLE || os(Linux)
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(WASI)
   EX_UNAVAILABLE
 #elseif os(Windows)
   ERROR_NOT_FOUND

--- a/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
@@ -39,11 +39,13 @@ extension Event {
       ///
       /// Allowed values are `1` (no color support), `4` (16-color), `8`
       /// (256-color), and `24` (true color.) The default value of this property
-      /// is `4` (16-color.)
+      /// is `1` (no color support.) When using Swift Testing from the command
+      /// line with `swift test`, the environment is automatically inspected to
+      /// determine what color support is available.
       ///
       /// The value of this property is ignored unless the value of
       /// ``useANSIEscapeCodes`` is `true`.
-      public var ansiColorBitDepth: Int8 = 4
+      public var ansiColorBitDepth: Int8 = 1
 
 #if os(macOS) || (os(iOS) && targetEnvironment(macCatalyst))
       /// Whether or not to use [SF&nbsp;Symbols](https://developer.apple.com/sf-symbols/)

--- a/Sources/Testing/Support/Additions/CommandLineAdditions.swift
+++ b/Sources/Testing/Support/Additions/CommandLineAdditions.swift
@@ -48,6 +48,11 @@ extension CommandLine {
         }
         return path
       }
+#elseif os(WASI)
+      // WASI does not really have the concept of a file system path to the main
+      // executable, so simply return the first argument--presumably the program
+      // name, but as you know this is not guaranteed by the C standard!
+      return String(cString: arguments[0])
 #else
 #warning("Platform-specific implementation missing: executable path unavailable")
       return ""

--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -374,7 +374,7 @@ extension FileHandle {
 #if SWT_TARGET_OS_APPLE || os(Linux)
     // If stderr is a TTY and TERM is set, that's good enough for us.
     withUnsafePOSIXFileDescriptor { fd in
-      if let fd, 0 != isatty(fd), let term = Environment.variable(named: "TERM"), !term.isEmpty && term != "dumb" {
+      if let fd, 0 != isatty(fd), let term = Environment.variable(named: "TERM"), !term.isEmpty {
         return true
       }
       return false

--- a/Sources/Testing/Support/Versions.swift
+++ b/Sources/Testing/Support/Versions.swift
@@ -83,6 +83,10 @@ let operatingSystemVersion: String = {
       return result
     }
   }
+#elseif os(WASI)
+  if let libcVersion = swt_getWASIVersion().flatMap(String.init(validatingCString:)), !libcVersion.isEmpty {
+    return "WASI with libc \(libcVersion)"
+  }
 #else
 #warning("Platform-specific implementation missing: OS version unavailable")
 #endif

--- a/Sources/_TestingInternals/include/Stubs.h
+++ b/Sources/_TestingInternals/include/Stubs.h
@@ -121,6 +121,24 @@ static int swt_siginfo_t_si_status(const siginfo_t *siginfo) {
 }
 #endif
 
+//#if defined(__wasi__)
+/// Get the version of the C standard library and runtime used by WASI, if
+/// available.
+///
+/// This function is provided because `WASI_LIBC_VERSION` may or may not be
+/// defined and may or may not be a complex macro.
+///
+/// For more information about the `WASI_LIBC_VERSION` macro, see
+/// [wasi-libc-#490](https://github.com/WebAssembly/wasi-libc/issues/490).
+static const char *_Nullable swt_getWASIVersion(void) {
+#if defined(WASI_LIBC_VERSION)
+  return WASI_LIBC_VERSION;
+#else
+  return 0;
+#endif
+}
+//#endif
+
 SWT_ASSUME_NONNULL_END
 
 #endif


### PR DESCRIPTION
Adds some WASI-specific branches to platform-specific code (instead of falling back to the "unknown" case with warnings.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
