### PR TITLE
Update Swift GitHub repo URL

### DIFF
--- a/Sources/Testing/Testing.docc/BugIdentifiers.md
+++ b/Sources/Testing/Testing.docc/BugIdentifiers.md
@@ -46,7 +46,7 @@ convenience, you can also directly pass an integer as a bug's identifier using
 | `.bug(id: 12345)` | None |
 | `.bug(id: "12345")` | None |
 | `.bug("https://www.example.com?id=12345", id: "12345")` | None |
-| `.bug("https://github.com/apple/swift/pull/12345")` | [GitHub Issues for the Swift project](https://github.com/apple/swift/issues) |
+| `.bug("https://github.com/swiftlang/swift/pull/12345")` | [GitHub Issues for the Swift project](https://github.com/swiftlang/swift/issues) |
 | `.bug("https://bugs.webkit.org/show_bug.cgi?id=12345")` | [WebKit Bugzilla](https://bugs.webkit.org/) |
 | `.bug(id: "FB12345")` | Apple Feedback Assistant | <!-- SEE ALSO: rdar://104582015 -->
 <!--


### PR DESCRIPTION
Update Swift Testing documentation to refer to the new Swift repo location. This is a purely cosmetic change.

### Checklist:

- [X] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
