### PR TITLE
Add instructions for running tests for WebAssembly

### DIFF
--- a/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
+++ b/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
@@ -148,7 +148,7 @@ section of
 #### Running tests for WebAssembly
 
 To run tests for WebAssembly, install a Swift SDK for WebAssembly by following
-[the instructions](https://book.swiftwasm.org/getting-started/setup-snapshot.html).
+[these instructions](https://book.swiftwasm.org/getting-started/setup-snapshot.html).
 
 Because `swift test` doesn't know what WebAssembly environment you'd like to use
 to run your tests, building tests and running them are two separate steps. To
@@ -159,11 +159,20 @@ swift build --swift-sdk wasm32-unknown-wasi --build-tests
 ```
 
 After building tests, you can run them using a [WASI](https://wasi.dev/)-compliant
-WebAssembly runtime, such as [Wasmtime](https://wasmtime.dev/) or
+WebAssembly runtime such as [Wasmtime](https://wasmtime.dev/) or
 [WasmKit](https://github.com/swiftwasm/WasmKit). For example, to run tests using
 Wasmtime, use the following command (replace `{YOURPACKAGE}` with your package's
 name):
 
 ```sh
 wasmtime .build/debug/{YOURPACKAGE}PackageTests.wasm
+```
+
+Most WebAssembly runtimes forward trailing arguments to the WebAssembly program,
+so you can pass command-line options of the testing library. For example, to list
+all tests and filter them by name, use the following commands:
+
+```sh
+wasmtime .build/debug/{YOURPACKAGE}PackageTests.wasm --list-tests
+wasmtime .build/debug/{YOURPACKAGE}PackageTests.wasm --filter "FoodTruckTests.foodTruckExists"
 ```

--- a/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
+++ b/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
@@ -165,7 +165,7 @@ Wasmtime, use the following command (replace `{YOURPACKAGE}` with your package's
 name):
 
 ```sh
-wasmtime .build/debug/{YOURPACKAGE}PackageTests.wasm
+wasmtime .build/debug/{YOURPACKAGE}PackageTests.wasm --testing-library swift-testing
 ```
 
 Most WebAssembly runtimes forward trailing arguments to the WebAssembly program,
@@ -173,6 +173,6 @@ so you can pass command-line options of the testing library. For example, to lis
 all tests and filter them by name, use the following commands:
 
 ```sh
-wasmtime .build/debug/{YOURPACKAGE}PackageTests.wasm --list-tests
-wasmtime .build/debug/{YOURPACKAGE}PackageTests.wasm --filter "FoodTruckTests.foodTruckExists"
+wasmtime .build/debug/{YOURPACKAGE}PackageTests.wasm list --testing-library swift-testing
+wasmtime .build/debug/{YOURPACKAGE}PackageTests.wasm --testing-library swift-testing --filter "FoodTruckTests.foodTruckExists"
 ```

--- a/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
+++ b/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
@@ -144,3 +144,26 @@ using Xcode 16 Beta.
 See the [Test Explorer](https://www.swift.org/documentation/articles/getting-started-with-vscode-swift.html#test-explorer)
 section of
 [Getting Started with Swift in VS Code](https://www.swift.org/documentation/articles/getting-started-with-vscode-swift.html).
+
+#### Running tests for WebAssembly
+
+To run tests for WebAssembly, install a Swift SDK for WebAssembly by following
+[the instructions](https://book.swiftwasm.org/getting-started/setup-snapshot.html).
+
+Because `swift test` doesn't know what WebAssembly environment you'd like to use
+to run your tests, building tests and running them are two separate steps. To
+build tests for WebAssembly, use the following command:
+
+```sh
+swift build --swift-sdk wasm32-unknown-wasi --build-tests
+```
+
+After building tests, you can run them using a [WASI](https://wasi.dev/)-compliant
+WebAssembly runtime, such as [Wasmtime](https://wasmtime.dev/) or
+[WasmKit](https://github.com/swiftwasm/WasmKit). For example, to run tests using
+Wasmtime, use the following command (replace `{YOURPACKAGE}` with your package's
+name):
+
+```sh
+wasmtime .build/debug/{YOURPACKAGE}PackageTests.wasm
+```


### PR DESCRIPTION
Close https://github.com/apple/swift-testing/issues/585

Please feel free to correct and rephrase my wording :pray: 

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
