### PR TITLE
Simplify `swiftTestingDirectoryPath`.

### DIFF
--- a/Sources/Testing/Traits/Tags/Tag.Color+Loading.swift
+++ b/Sources/Testing/Traits/Tags/Tag.Color+Loading.swift
@@ -61,6 +61,10 @@ var swiftTestingDirectoryPath: String? {
   if let homeDirectoryPath = _homeDirectoryPath {
     return appendPathComponent(swiftTestingDirectoryName, to: homeDirectoryPath)
   }
+#elseif SWT_TARGET_OS_APPLE
+  // Other Apple/Darwin platforms do not support the concept of a home
+  // directory. One exists for the current user, but it's not something that
+  // actually contains user-configurable data like a .swift-testing directory.
 #elseif os(Windows)
   if let appDataDirectoryPath = _appDataDirectoryPath {
     return appendPathComponent(swiftTestingDirectoryName, to: appDataDirectoryPath)

--- a/Sources/Testing/Traits/Tags/Tag.Color+Loading.swift
+++ b/Sources/Testing/Traits/Tags/Tag.Color+Loading.swift
@@ -49,6 +49,7 @@ private var _appDataDirectoryPath: String? {
 /// On Apple platforms and on Linux, this path is equivalent to
 /// `"~/.swift-testing"`. On Windows, it is equivalent to
 /// `"%HOMEPATH%\AppData\Local\.swift-testing"`.
+///
 /// The value of this property is `nil` if the platform does not support the
 /// concept of a home directory, or if the home directory could not be
 /// determined.
@@ -60,18 +61,16 @@ var swiftTestingDirectoryPath: String? {
   if let homeDirectoryPath = _homeDirectoryPath {
     return appendPathComponent(swiftTestingDirectoryName, to: homeDirectoryPath)
   }
-  return nil
 #elseif os(Windows)
   if let appDataDirectoryPath = _appDataDirectoryPath {
     return appendPathComponent(swiftTestingDirectoryName, to: appDataDirectoryPath)
   }
-  return nil
 #elseif os(WASI)
-  return nil
+  // WASI does not support the concept of a home directory.
 #else
 #warning("Platform-specific implementation missing: .swift-testing directory location unavailable")
-  return nil
 #endif
+  return nil
 }
 
 /// Read tag colors out of the file `"tag-colors.json"` in a given directory.
@@ -96,6 +95,7 @@ func loadTagColors(fromFileInDirectoryAtPath swiftTestingDirectoryPath: String? 
     // tag colors.
     return [:]
   }
+
   // Find the path to the tag-colors.json file and try to load its contents.
   let tagColorsPath = appendPathComponent("tag-colors.json", to: swiftTestingDirectoryPath)
   let fileHandle = try FileHandle(forReadingAtPath: tagColorsPath)


### PR DESCRIPTION
Since all platform-specific paths in this function end in `return nil`, we can simplify a bit.

Also a couple of drive-by newline changes.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
