### PR TITLE
Add support for `swift test list --verbose`.

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -355,6 +355,10 @@ func parseCommandLineArguments(from args: [String]) throws -> __CommandLineArgum
 
   if args.contains("--list-tests") {
     result.listTests = true
+  } else if args.first == "list" {
+    // Allow the "list" subcommand explicitly in place of "--list-tests". This
+    // makes invocation from e.g. Wasmtime a bit more intuitive/idiomatic.
+    result.listTests = true
   }
 
   // Parallelization (on by default)

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -309,13 +309,25 @@ struct SwiftPMTests {
 
   @Test("list subcommand")
   func list() async throws {
-    let testIDs = await listTestsForEntryPoint(Test.all)
-    let currentTestID = try #require(
-      Test.current
-        .flatMap(\.id.parent)
-        .map(String.init(describing:))
-    )
+    do {
+      let args = try parseCommandLineArguments(from: ["PATH", "--list-tests"])
+      #expect(args.listTests == true)
+    }
+    do {
+      let args = try parseCommandLineArguments(from: ["PATH", "list"])
+      #expect(args.listTests == true)
+    }
+    let testIDs = await listTestsForEntryPoint(Test.all, verbosity: 0)
+    let currentTestID = String(describing: try #require(Test.current?.id.parent))
     #expect(testIDs.contains(currentTestID))
+  }
+
+  @Test("list --verbose subcommand")
+  func listVerbose() async throws {
+    let testIDs = await listTestsForEntryPoint(Test.all, verbosity: 1)
+    let currentTestID = String(describing: try #require(Test.current?.id))
+    #expect(testIDs.contains(currentTestID))
+    #expect(testIDs.allSatisfy { $0.contains(".swift:") })
   }
 
   @Test(


### PR DESCRIPTION
When `--verbose` is passed to `swift test list`, it is intended that we handle it by emitting all test IDs including source location info, not just ambiguous test IDs. This change will be useful to the Swift VSCode plugin in ensuring that tests are properly identified.

This change also allows you to pass `list` directly to the test executable instead of `--list-tests`, which simplifies running tests in Wasm.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
