### PR TITLE
Fix Wasm-specific warnings.

### DIFF
--- a/Sources/Testing/Support/Additions/CommandLineAdditions.swift
+++ b/Sources/Testing/Support/Additions/CommandLineAdditions.swift
@@ -52,7 +52,7 @@ extension CommandLine {
       // WASI does not really have the concept of a file system path to the main
       // executable, so simply return the first argument--presumably the program
       // name, but as you know this is not guaranteed by the C standard!
-      return String(cString: arguments[0])
+      return arguments[0]
 #else
 #warning("Platform-specific implementation missing: executable path unavailable")
       return ""

--- a/Sources/_TestingInternals/include/Includes.h
+++ b/Sources/_TestingInternals/include/Includes.h
@@ -47,7 +47,9 @@
 #include <unistd.h>
 #endif
 
-#if __has_include(<sys/fcntl.h>)
+#if __has_include(<fcntl.h>)
+#include <fcntl.h>
+#elif __has_include(<sys/fcntl.h>)
 #include <sys/fcntl.h>
 #endif
 


### PR DESCRIPTION
This PR fixes a couple of (harmless) warnings when building for Wasm.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
