### PR TITLE
Fix a crash when an issue is recorded on a detached task.

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -262,15 +262,16 @@ extension Event.HumanReadableOutputRecorder {
         }
 
       case let .issueRecorded(issue):
-        let test = test!
-        let id = test.id.keyPathRepresentation
-        var testData = context.testData[id] ?? .init(startInstant: instant)
-        if issue.isKnown {
-          testData.knownIssueCount += 1
-        } else {
-          testData.issueCount += 1
+        if let test {
+          let id = test.id.keyPathRepresentation
+          var testData = context.testData[id] ?? .init(startInstant: instant)
+          if issue.isKnown {
+            testData.knownIssueCount += 1
+          } else {
+            testData.issueCount += 1
+          }
+          context.testData[id] = testData
         }
-        context.testData[id] = testData
 
       default:
         // These events do not manipulate the context structure.

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -359,6 +359,16 @@ struct EventRecorderTests {
     }
   }
 #endif
+
+  @Test("Recorded issues may not have associated tests")
+  func issueWithoutTest() {
+    let issue = Issue(kind: .unconditional, comments: [], sourceContext: .init())
+    let event = Event(.issueRecorded(issue), testID: nil, testCaseID: nil)
+    let context = Event.Context(test: nil, testCase: nil)
+
+    let recorder = Event.HumanReadableOutputRecorder()
+    _ = recorder.record(event, in: context)
+  }
 }
 
 // MARK: - Fixtures


### PR DESCRIPTION
Given the following code:

```swift
@Test func f() async {
  await Task.detached {
    #expect(1 == 2)
  }.value
}
```

An issue is recorded on a detached task, but Swift Testing is unable to determine at runtime which test it corresponds to. This should simply result in the issue being attributed to an arbitrary test, or to the aether, but #421 caused a regression that triggers an optional unwrap crash instead.

This PR fixes the crash. :)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
